### PR TITLE
Add some version checks to setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -2,6 +2,8 @@
 
 set -e
 
+version_lt() { test "$(printf '%s\n' "$@" | { [ "$(uname)" = "Linux" ] && sort -V || sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n; } | tail -n 1)" != "$1"; }
+
 # run command at repo root
 CURRENT_PATH=$PWD
 if [ -d .git ]; then
@@ -16,7 +18,23 @@ Read more on Node.js official website: https://nodejs.org
 And for yarn package manager at: https://yarnpkg.com/en/
 Setup will not be run
 EOF
-  exit 0
+  exit 1
+fi
+
+if version_lt "$(yarn --version)" '1.3.2'; then
+  cat <<EOF
+Your yarn version is outdated. Please upgrade to a version
+newer than 1.3.2.
+EOF
+  exit 1
+fi
+
+if version_lt "$(node --version)" 'v6.0.0'; then
+  cat <<EOF
+Your node version is outdated. Please upgrade to version 6
+or higher. (Version 8 or higher is recommended)
+EOF
+  exit 1
 fi
 
 echo "copy config files"

--- a/bin/setup
+++ b/bin/setup
@@ -21,18 +21,22 @@ EOF
   exit 1
 fi
 
-if version_lt "$(yarn --version)" '1.3.2'; then
+if version_lt "$(yarn --version)" '1.22.0'; then
   cat <<EOF
-Your yarn version is outdated. Please upgrade to a version
-newer than 1.3.2.
+FATAL: Your Yarn version is outdated.
+
+Please upgrade to a version newer than 1.22.0.
+See https://classic.yarnpkg.com/en/docs/install for instructions.
 EOF
   exit 1
 fi
 
-if version_lt "$(node --version)" 'v6.0.0'; then
+if version_lt "$(node --version)" 'v10.13.0'; then
   cat <<EOF
-Your node version is outdated. Please upgrade to version 6
-or higher. (Version 8 or higher is recommended)
+FATAL: Your Node.js version is outdated.
+
+Please upgrade to version 10.13 or higher.
+We recommend running the latest LTS release.
 EOF
   exit 1
 fi

--- a/bin/setup
+++ b/bin/setup
@@ -10,8 +10,7 @@ if [ -d .git ]; then
   cd "$(git rev-parse --show-toplevel)"
 fi
 
-if ! type yarn > /dev/null
-then
+if ! type yarn > /dev/null; then
   cat << EOF
 FATAL: Yarn could not be found.
 
@@ -23,7 +22,7 @@ EOF
 fi
 
 if version_lt "$(yarn --version)" '1.22.0'; then
-  cat <<EOF
+  cat << EOF
 FATAL: Your Yarn version is outdated.
 
 Please upgrade to version 1.22.0 or higher and try again.
@@ -33,7 +32,7 @@ EOF
 fi
 
 if version_lt "$(node --version)" 'v10.13.0'; then
-  cat <<EOF
+  cat << EOF
 FATAL: Your Node.js version is outdated.
 
 Please upgrade to version 10.13 or higher and try again.
@@ -63,7 +62,6 @@ Read more info at https://github.com/hedgedoc/hedgedoc#configuration-files
 
 * config.json           -- HedgeDoc config
 * .sequelizerc          -- db config
-
 EOF
 
 # change directory back

--- a/bin/setup
+++ b/bin/setup
@@ -26,7 +26,7 @@ if version_lt "$(yarn --version)" '1.22.0'; then
   cat <<EOF
 FATAL: Your Yarn version is outdated.
 
-Please upgrade to a version newer than 1.22.0 and try again.
+Please upgrade to version 1.22.0 or higher and try again.
 See https://classic.yarnpkg.com/en/docs/install for instructions.
 EOF
   exit 1

--- a/bin/setup
+++ b/bin/setup
@@ -13,10 +13,11 @@ fi
 if ! type yarn > /dev/null
 then
   cat << EOF
-yarn is not installed, please install Node.js, npm and yarn.
-Read more on Node.js official website: https://nodejs.org
-And for yarn package manager at: https://yarnpkg.com/en/
-Setup will not be run
+FATAL: Yarn could not be found.
+
+Please follow the official installation instructions at
+https://classic.yarnpkg.com/en/docs/install
+and try again.
 EOF
   exit 1
 fi
@@ -25,7 +26,7 @@ if version_lt "$(yarn --version)" '1.22.0'; then
   cat <<EOF
 FATAL: Your Yarn version is outdated.
 
-Please upgrade to a version newer than 1.22.0.
+Please upgrade to a version newer than 1.22.0 and try again.
 See https://classic.yarnpkg.com/en/docs/install for instructions.
 EOF
   exit 1
@@ -35,13 +36,13 @@ if version_lt "$(node --version)" 'v10.13.0'; then
   cat <<EOF
 FATAL: Your Node.js version is outdated.
 
-Please upgrade to version 10.13 or higher.
-We recommend running the latest LTS release.
+Please upgrade to version 10.13 or higher and try again.
+We recommend running the latest LTS release, see https://nodejs.org/en/about/releases/ for details.
 EOF
   exit 1
 fi
 
-echo "copy config files"
+echo "Copying config files..."
 if [ ! -f config.json ]; then
   cp config.json.example config.json
 fi
@@ -50,7 +51,7 @@ if [ ! -f .sequelizerc ]; then
   cp .sequelizerc.example .sequelizerc
 fi
 
-echo "install packages"
+echo "Installing packages..."
 yarn install --pure-lockfile
 yarn install --production=false --pure-lockfile
 

--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,7 @@
 
 set -e
 
-version_lt() { test "$(printf '%s\n' "$@" | { [ "$(uname)" = "Linux" ] && sort -V || sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n; } | tail -n 1)" != "$1"; }
+version_lt() { test "$(printf '%s\n' "$@" | { [ "$(uname)" = "Linux" ] && (sort -V || sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n;) } | tail -n 1)" != "$1"; }
 
 # run command at repo root
 CURRENT_PATH=$PWD


### PR DESCRIPTION
There are some distros out there, shipping quite outdated packages with
them, which results in weird issues. Let's check that we have a more or
less up to date version of node and yarn installed.

This patch adds those checks and this way should provide some helpful
error messages to people who try to install CodiMD.

Previously: https://github.com/hackmdio/codimd/pull/1075