### PR TITLE
Add a hotkey to hard-wrap the current paragraph or the selection

### DIFF
--- a/public/js/lib/editor/index.js
+++ b/public/js/lib/editor/index.js
@@ -121,6 +121,30 @@ export default class Editor {
       },
       'Shift-Ctrl-Backspace': cm => {
         utils.wrapTextWith(this.editor, cm, 'Backspace')
+      },
+      'Ctrl-\\': cm => {
+        var wrapOptions = {
+          wrapOn: /\s\S/,
+          column: 80
+        }
+
+        if (cm.somethingSelected()) {
+          var sels = cm.listSelections()
+          for (var i = 0; i < sels.length; ++sels) {
+            var head = sels[i].head
+            var anchor = sels[i].anchor
+
+            if (head.line < anchor.line) {
+              var temp = head
+              head = anchor
+              anchor = temp
+            }
+
+            cm.wrapRange(anchor, head, wrapOptions)
+          }
+        } else {
+          cm.wrapParagraph(cm.getCursor(), wrapOptions)
+        }
       }
     }
     this.eventListeners = {}

--- a/public/js/lib/editor/statusbar.html
+++ b/public/js/lib/editor/statusbar.html
@@ -14,6 +14,7 @@
             </a>
             <ul class="dropdown-menu" aria-labelledby="preferencesLabel">
                 <li class="ui-preferences-override-browser-keymap"><a><label>Allow override browser keymap&nbsp;&nbsp;<input type="checkbox"></label></a></li>
+                <li class="ui-preferences-hard-wrap"><a><label>Hard Wrap&nbsp;&nbsp;<input type="checkbox"></label></a></li>
             </ul>
         </div>
         <div class="status-keymap dropup pull-right">

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -211,6 +211,7 @@ module.exports = {
       'script-loader!Idle.Js',
       'expose-loader?LZString!lz-string',
       'script-loader!codemirror',
+      'script-loader!codemirrorWrap',
       'script-loader!inlineAttachment',
       'script-loader!jqueryTextcomplete',
       'script-loader!codemirrorSpellChecker',
@@ -360,6 +361,7 @@ module.exports = {
     extensions: ['.js'],
     alias: {
       codemirror: path.join(__dirname, 'node_modules/codemirror/codemirror.min.js'),
+      codemirrorWrap: path.join(__dirname, 'node_modules/codemirror/addon/wrap/hardwrap.js'),
       inlineAttachment: path.join(__dirname, 'public/vendor/inlineAttachment/inline-attachment.js'),
       jqueryTextcomplete: path.join(__dirname, 'public/vendor/jquery-textcomplete/jquery.textcomplete.js'),
       codemirrorSpellChecker: path.join(__dirname, 'public/vendor/codemirror-spell-checker/spell-checker.min.js'),


### PR DESCRIPTION
This makes use of the `wrap` add-on that already comes with CodeMirror.