### PR TITLE
Fix image width on mobile view for front page

### DIFF
--- a/public/css/cover.css
+++ b/public/css/cover.css
@@ -372,3 +372,7 @@ select {
         max-width: 100%;
     }
 }
+
+.cover-heading img {
+    max-width: 100%;
+}


### PR DESCRIPTION
This PR fixes the width of the hedgedoc logo on the front page.