### PR TITLE
Added zipping and uploading of production builds

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -78,5 +78,9 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: yarn --frozen-lockfile --prefer-offline
       - run: yarn run build
-
-
+      - run: yarn install --production --ignore-scripts --frozen-lockfile --prefer-offline
+      - run: zip -5 -r prebuild-node${{ matrix.node-version }}.zip ./ -x '*.git*'
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Prebuild with node ${{ matrix.node-version }}
+          path: ./prebuild-node${{ matrix.node-version }}.zip


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR adds zipping and uploading of the production builds so that one can just download, extract, configure and run them without the need to build the code. This is especially useful for low-end devices that suffer from too less available memory for building.

The workflow is extended by the following jobs:
- install production dependencies => dev-deps get removed
- zip everything together except the .git directory
- Upload the zip file as artifact

### Related Issue(s)
#96 
