### PR TITLE
Update account ID for mastodon icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ The license does not include the HedgeDoc logo, whose terms of usage can be foun
 [hedgedoc-community]: https://community.hedgedoc.org
 [hedgedoc-community-calls]: https://community.hedgedoc.org/t/codimd-community-call/19
 [social-mastodon]: https://social.hedgedoc.org/mastodon
-[social-mastodon-image]: https://img.shields.io/mastodon/follow/18547?domain=https%3A%2F%2Fsocial.snopyta.org&style=social
+[social-mastodon-image]: https://img.shields.io/mastodon/follow/49593?domain=https%3A%2F%2Fsocial.snopyta.org&style=social


### PR DESCRIPTION
Currently the mastodon button still points to the old account. This
patch fixes this problem by using the new account id.