### PR TITLE
Limit CI runs to pushes to master and pull requests against master

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,10 @@
 name: Node.js CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   static-tests:


### PR DESCRIPTION
## Component/Part
Github Actions CI

### Description
As you can see in some PRs(e.g. #596), the CI executes every check twice. This is because the current CI config runs for every push to every branch and every pull request. 
 
This PR limits the CI runs to pushes to the master branch and pull requests against master.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
