### PR TITLE
Fix shortcut icon urls pointing to old (nonexistent) files

### DIFF
--- a/public/views/hedgedoc/head.ejs
+++ b/public/views/hedgedoc/head.ejs
@@ -9,14 +9,12 @@
 <% if (opengraph.hasOwnProperty(og) && opengraph[og].trim() !== '') { %>
 <meta property="og:<%- og %>" content="<%- opengraph[og] %>">
 <% }} if (!opengraph.hasOwnProperty('image')) { %>
-<meta property="og:image" content="<%- serverURL %>/icons/android-chrome-512x512">
+<meta property="og:image" content="<%- serverURL %>/icons/android-chrome-512x512.png">
 <meta property="og:image:alt" content="HedgeDoc logo">
 <meta property="og:image:type" content="image/png">
 <% } %>
 <base href="<%- serverURL %>/">
 <title><%= title %></title>
-<link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
-<link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">
 <% if(useCDN) { %>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.0/css/bootstrap.min.css" integrity="sha256-H0KfTigpUV+0/5tn2HXC0CPwhhDhWgSawJdnFd0CGCo=" crossorigin="anonymous" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fork-awesome/1.1.3/css/fork-awesome.min.css" integrity="sha256-ZhApazu+kejqTYhMF+1DzNKjIzP7KXu6AzyXcC1gMus=" crossorigin="anonymous" />

--- a/public/views/html.hbs
+++ b/public/views/html.hbs
@@ -12,8 +12,12 @@
     <title>
         {{title}}
     </title>
-    <link rel="icon" type="image/png" href="{{{url}}}/favicon.png">
-    <link rel="apple-touch-icon" href="{{{url}}}/apple-touch-icon.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{{url}}}/icons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{{url}}}/icons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{{url}}}/icons/favicon-16x16.png">
+    <link rel="manifest" href="{{{url}}}/icons/site.webmanifest">
+    <link rel="mask-icon" href="{{{url}}}/icons/safari-pinned-tab.svg" color="#b51f08">
+    <link rel="shortcut icon" href="{{{url}}}/icons/favicon.ico">
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.0/css/bootstrap.min.css" integrity="sha256-H0KfTigpUV+0/5tn2HXC0CPwhhDhWgSawJdnFd0CGCo=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fork-awesome/1.1.3/css/fork-awesome.min.css" integrity="sha256-ZhApazu+kejqTYhMF+1DzNKjIzP7KXu6AzyXcC1gMus=" crossorigin="anonymous" />

--- a/public/views/index/head.ejs
+++ b/public/views/index/head.ejs
@@ -11,7 +11,7 @@
 <meta property="og:description" content="<%= __('Best way to write and share your knowledge in markdown.') %>">
 <meta property="og:type" content="website">
 <meta property="og:url" content="<%- serverURL %>">
-<meta property="og:image" content="<%- serverURL %>/icons/android-chrome-512x512">
+<meta property="og:image" content="<%- serverURL %>/icons/android-chrome-512x512.png">
 <meta property="og:image:alt" content="HedgeDoc logo">
 <meta property="og:image:type" content="image/png">
 <base href="<%- serverURL %>/">

--- a/public/views/pretty.ejs
+++ b/public/views/pretty.ejs
@@ -18,14 +18,13 @@
     <% if (opengraph.hasOwnProperty(og) && opengraph[og].trim() !== '') { %>
     <meta property="og:<%= og %>" content="<%= opengraph[og] %>">
     <% }} if (!opengraph.hasOwnProperty('image')) { %>
-    <meta property="og:image" content="<%- serverURL %>/icons/android-chrome-512x512">
+    <meta property="og:image" content="<%- serverURL %>/icons/android-chrome-512x512.png">
     <meta property="og:image:alt" content="HedgeDoc logo">
     <meta property="og:image:type" content="image/png">
     <% } %>
     <base href="<%- serverURL %>/">
     <title><%= title %></title>
-    <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
-    <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">
+    <%- include includes/favicon.ejs %>
   <% if(useCDN) { %>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.0/css/bootstrap.min.css" integrity="sha256-H0KfTigpUV+0/5tn2HXC0CPwhhDhWgSawJdnFd0CGCo=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fork-awesome/1.1.3/css/fork-awesome.min.css" integrity="sha256-ZhApazu+kejqTYhMF+1DzNKjIzP7KXu6AzyXcC1gMus=" crossorigin="anonymous" />

--- a/public/views/slide.ejs
+++ b/public/views/slide.ejs
@@ -13,8 +13,7 @@
         <% } %>
         <base href="<%- serverURL %>/">
         <title><%= title %></title>
-        <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
-        <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">
+        <%- include includes/favicon.ejs %>
 
         <% if(useCDN) { %>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fork-awesome/1.1.3/css/fork-awesome.min.css" integrity="sha256-ZhApazu+kejqTYhMF+1DzNKjIzP7KXu6AzyXcC1gMus=" crossorigin="anonymous" />


### PR DESCRIPTION
### Component/Part
HTML-templates

### Description
This PR fixes the URLs of the shortcut icons ("favicons") in the HTML templates. Especially the read-only-view ("published") and the slide-view didn't had any correct icons, the editor itself at least had both old and new icons. Now they all include the favicon-partial if possible.

Thanks to @omia for reporting this issue.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
