### PR TITLE
chore: bump AWS SDK from 2.345.0 to 2.521.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "Idle.Js": "git+https://github.com/shawnmclean/Idle.js",
     "archiver": "^5.0.2",
     "async": "^2.1.4",
-    "aws-sdk": "^2.345.0",
+    "aws-sdk": "^2.521.0",
     "azure-storage": "^2.7.0",
     "base64url": "^3.0.0",
     "body-parser": "^1.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,10 +908,10 @@ autolinker@^3.11.0:
   dependencies:
     tslib "^1.9.3"
 
-aws-sdk@^2.345.0:
-  version "2.792.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.792.0.tgz#d124a6074244a4675e0416887734e8f6934bdd30"
-  integrity sha512-h7oSlrCDtZkW5qNw/idKmMjjNJaaPlXFY+NbqtaTjejpCyVuIonUmFvm8GW16V58Avj/hujJfhpX9q0BMCg+VQ==
+aws-sdk@^2.521.0:
+  version "2.799.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.799.0.tgz#8b1a64c1a9f8ccf5794eb07bdd8051e4cb6adcfd"
+  integrity sha512-NYAoiNU+bJXhlJsC0rFqrmD5t5ho7/VxldmziP6HLPYHfOCI9Uvk6UVjfPmhLWPm0mHnIxhsHqmsNGyjhHNYmw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
### Component/Part
Package AWS SDK

### Description
It bumps AWS SDK from 2.345.0 to 2.521.0

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

Tested locally executed an insert image.
Executed as:
```
CMD_S3_BUCKET="my-bucket" CMD_S3_REGION="eu-west-1" CMD_IMAGE_UPLOAD_TYPE="s3" CMD_S3_BUCKET="my-bucket" CMD_S3_REGION="eu-west-1" node app.js
```
### Related Issue(s)
#600 