### PR TITLE
[Migrations] Add variant of error message to catch block

### DIFF
--- a/lib/migrations/20150702001020-update-to-0_3_1.js
+++ b/lib/migrations/20150702001020-update-to-0_3_1.js
@@ -21,9 +21,8 @@ module.exports = {
         defaultValue: 0
       })
     }).catch(function (error) {
-      if (error.message === 'SQLITE_ERROR: duplicate column name: shortid' ||
-        error.message === 'column "shortid" of relation "Notes" already exists' ||
-        error.message.toLowerCase().includes("duplicate column name 'shortid'")) {
+      if (error.message === 'column "shortid" of relation "Notes" already exists' ||
+        error.message.toLowerCase().includes('duplicate column name')) {
         // eslint-disable-next-line no-console
         console.log('Migration has already run… ignoring.')
       } else {

--- a/lib/migrations/20150702001020-update-to-0_3_1.js
+++ b/lib/migrations/20150702001020-update-to-0_3_1.js
@@ -21,7 +21,10 @@ module.exports = {
         defaultValue: 0
       })
     }).catch(function (error) {
-      if (error.message === 'SQLITE_ERROR: duplicate column name: shortid' || error.message === "ER_DUP_FIELDNAME: Duplicate column name 'shortid'" || error.message === 'column "shortid" of relation "Notes" already exists') {
+      if (error.message === 'SQLITE_ERROR: duplicate column name: shortid' ||
+        error.message === "ER_DUP_FIELDNAME: Duplicate column name 'shortid'" ||
+        error.message === 'column "shortid" of relation "Notes" already exists' ||
+        error.message === 'ERROR: Duplicate column name \'shortid\'') {
         // eslint-disable-next-line no-console
         console.log('Migration has already run… ignoring.')
       } else {

--- a/lib/migrations/20150702001020-update-to-0_3_1.js
+++ b/lib/migrations/20150702001020-update-to-0_3_1.js
@@ -22,9 +22,8 @@ module.exports = {
       })
     }).catch(function (error) {
       if (error.message === 'SQLITE_ERROR: duplicate column name: shortid' ||
-        error.message === "ER_DUP_FIELDNAME: Duplicate column name 'shortid'" ||
         error.message === 'column "shortid" of relation "Notes" already exists' ||
-        error.message === 'ERROR: Duplicate column name \'shortid\'') {
+        error.message.toLowerCase().includes("duplicate column name 'shortid'")) {
         // eslint-disable-next-line no-console
         console.log('Migration has already run… ignoring.')
       } else {

--- a/lib/migrations/20160112220142-note-add-lastchange.js
+++ b/lib/migrations/20160112220142-note-add-lastchange.js
@@ -8,7 +8,8 @@ module.exports = {
         type: Sequelize.DATE
       })
     }).catch(function (error) {
-      if (error.message === 'SQLITE_ERROR: duplicate column name: lastchangeuserId' || error.message === "ER_DUP_FIELDNAME: Duplicate column name 'lastchangeuserId'" || error.message === 'column "lastchangeuserId" of relation "Notes" already exists') {
+      if (error.message === 'column "lastchangeuserId" of relation "Notes" already exists' ||
+        error.message.toLowerCase().includes('duplicate column name')) {
         // eslint-disable-next-line no-console
         console.log('Migration has already run… ignoring.')
       } else {

--- a/lib/migrations/20160420180355-note-add-alias.js
+++ b/lib/migrations/20160420180355-note-add-alias.js
@@ -8,7 +8,8 @@ module.exports = {
         indicesType: 'UNIQUE'
       })
     }).catch(function (error) {
-      if (error.message === 'SQLITE_ERROR: duplicate column name: alias' || error.message === "ER_DUP_FIELDNAME: Duplicate column name 'alias'" || error.message === 'column "alias" of relation "Notes" already exists') {
+      if (error.message.toLowerCase().includes('duplicate column name') ||
+        error.message === 'column "alias" of relation "Notes" already exists') {
         // eslint-disable-next-line no-console
         console.log('Migration has already run… ignoring.')
       } else {

--- a/lib/migrations/20160515114000-user-add-tokens.js
+++ b/lib/migrations/20160515114000-user-add-tokens.js
@@ -4,7 +4,8 @@ module.exports = {
     return queryInterface.addColumn('Users', 'accessToken', Sequelize.STRING).then(function () {
       return queryInterface.addColumn('Users', 'refreshToken', Sequelize.STRING)
     }).catch(function (error) {
-      if (error.message === 'SQLITE_ERROR: duplicate column name: accessToken' || error.message === "ER_DUP_FIELDNAME: Duplicate column name 'accessToken'" || error.message === 'column "accessToken" of relation "Users" already exists') {
+      if (error.message.toLowerCase().includes('duplicate column name') ||
+        error.message === 'column "accessToken" of relation "Users" already exists') {
         // eslint-disable-next-line no-console
         console.log('Migration has already run… ignoring.')
       } else {

--- a/lib/migrations/20160607060246-support-revision.js
+++ b/lib/migrations/20160607060246-support-revision.js
@@ -16,7 +16,8 @@ module.exports = {
         updatedAt: Sequelize.DATE
       })
     }).catch(function (error) {
-      if (error.message === 'SQLITE_ERROR: duplicate column name: savedAt' | error.message === "ER_DUP_FIELDNAME: Duplicate column name 'savedAt'" || error.message === 'column "savedAt" of relation "Notes" already exists') {
+      if (error.message.toLowerCase().includes('duplicate column name') ||
+        error.message === 'column "savedAt" of relation "Notes" already exists') {
         // eslint-disable-next-line no-console
         console.log('Migration has already run… ignoring.')
       } else {

--- a/lib/migrations/20160703062241-support-authorship.js
+++ b/lib/migrations/20160703062241-support-authorship.js
@@ -17,7 +17,8 @@ module.exports = {
         updatedAt: Sequelize.DATE
       })
     }).catch(function (error) {
-      if (error.message === 'SQLITE_ERROR: duplicate column name: authorship' || error.message === "ER_DUP_FIELDNAME: Duplicate column name 'authorship'" || error.message === 'column "authorship" of relation "Notes" already exists') {
+      if (error.message.toLowerCase().includes('duplicate column name') ||
+        error.message === 'column "authorship" of relation "Notes" already exists') {
         // eslint-disable-next-line no-console
         console.log('Migration has already run… ignoring.')
       } else {

--- a/lib/migrations/20161009040430-support-delete-note.js
+++ b/lib/migrations/20161009040430-support-delete-note.js
@@ -2,7 +2,8 @@
 module.exports = {
   up: function (queryInterface, Sequelize) {
     return queryInterface.addColumn('Notes', 'deletedAt', Sequelize.DATE).catch(function (error) {
-      if (error.message === 'SQLITE_ERROR: duplicate column name: deletedAt' || error.message === "ER_DUP_FIELDNAME: Duplicate column name 'deletedAt'" || error.message === 'column "deletedAt" of relation "Notes" already exists') {
+      if (error.message.toLowerCase().includes('duplicate column name') ||
+        error.message === 'column "deletedAt" of relation "Notes" already exists') {
         // eslint-disable-next-line no-console
         console.log('Migration has already run… ignoring.')
       } else {

--- a/lib/migrations/20161201050312-support-email-signin.js
+++ b/lib/migrations/20161201050312-support-email-signin.js
@@ -3,7 +3,8 @@ module.exports = {
   up: function (queryInterface, Sequelize) {
     return queryInterface.addColumn('Users', 'email', Sequelize.TEXT).then(function () {
       return queryInterface.addColumn('Users', 'password', Sequelize.TEXT).catch(function (error) {
-        if (error.message === "ER_DUP_FIELDNAME: Duplicate column name 'password'" || error.message === 'column "password" of relation "Users" already exists') {
+        if (error.message.toLowerCase().includes('duplicate column name') ||
+          error.message === 'column "password" of relation "Users" already exists') {
           // eslint-disable-next-line no-console
           console.log('Migration has already run… ignoring.')
         } else {
@@ -11,7 +12,8 @@ module.exports = {
         }
       })
     }).catch(function (error) {
-      if (error.message === 'SQLITE_ERROR: duplicate column name: email' || error.message === "ER_DUP_FIELDNAME: Duplicate column name 'email'" || error.message === 'column "email" of relation "Users" already exists') {
+      if (error.message.toLowerCase().includes('duplicate column name') ||
+        error.message === 'column "email" of relation "Users" already exists') {
         // eslint-disable-next-line no-console
         console.log('Migration has already run… ignoring.')
       } else {

--- a/lib/migrations/20180525153000-user-add-delete-token.js
+++ b/lib/migrations/20180525153000-user-add-delete-token.js
@@ -4,6 +4,14 @@ module.exports = {
     return queryInterface.addColumn('Users', 'deleteToken', {
       type: Sequelize.UUID,
       defaultValue: Sequelize.UUIDV4
+    }).catch(function (error) {
+      if (error.message.toLowerCase().includes('duplicate column name') ||
+        error.message === 'column "deleteToken" of relation "Users" already exists') {
+        // eslint-disable-next-line no-console
+        console.log('Migration has already run… ignoring.')
+      } else {
+        throw error
+      }
     })
   },
 

--- a/lib/migrations/20200321153000-fix-account-deletion.js
+++ b/lib/migrations/20200321153000-fix-account-deletion.js
@@ -45,6 +45,13 @@ module.exports = {
         },
         onDelete: 'cascade'
       })
+    }).catch(function (error) {
+      if (error.message.toLowerCase().includes('duplicate key on write or update')) {
+        // eslint-disable-next-line no-console
+        console.log('Migration has already run… ignoring.')
+      } else {
+        throw error
+      }
     })
   },
 


### PR DESCRIPTION
### Component/Part
Migration `20150702001020-update-to-0_3_1`

### Description
This PR adds a new variant of the "duplicate column name" error to the catch block. The solution is as hacky as the rest of the catch block, but I don't think that we need a more complex solution. 1.7 is the last 1.x version and 2.0 gets a new database layout.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Closes #607 