### PR TITLE
Change label used by renovate to "type: maintenance"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,6 @@
     ":gitSignOff"
   ],
   "labels": [
-    "dependencies"
+    "type: maintenance"
   ]
 }


### PR DESCRIPTION
### Component/Part
Renovate config

### Description
This PR changes the label that is used by renovate.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
#589 
