### PR TITLE
Document reverse proxy config for Apache

### DIFF
--- a/docs/setup/reverse-proxy.md
+++ b/docs/setup/reverse-proxy.md
@@ -67,3 +67,29 @@ server {
     ssl_dhparam ssl-dhparams.pem;
 }
 ```
+### Apache
+You will need these modules enabled: `proxy`, `proxy_http` and `proxy_wstunnel`.  
+Here is an example config snippet:
+```
+<VirtualHost *:443>
+  ServerName hedgedoc.example.com
+
+  RewriteEngine on
+  RewriteCond %{REQUEST_URI} ^/socket.io             [NC]
+  RewriteCond %{HTTP:Upgrade} =websocket [NC]
+  RewriteRule /(.*)  ws://127.0.0.1:3000/$1          [P,L]
+
+  ProxyPass / http://127.0.0.1:3000/
+  ProxyPassReverse / http://127.0.0.1:3000/
+
+  RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
+        
+  ErrorLog ${APACHE_LOG_DIR}/error.log
+  CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+  SSLCertificateFile /etc/letsencrypt/live/hedgedoc.example.com/fullchain.pem
+  SSLCertificateKeyFile /etc/letsencrypt/live/hedgedoc.example.com/privkey.pem
+  Include /etc/letsencrypt/options-ssl-apache.conf
+</VirtualHost>
+```
+

--- a/docs/setup/reverse-proxy.md
+++ b/docs/setup/reverse-proxy.md
@@ -7,7 +7,7 @@ This documentation will cover HTTPS setup, with comments for HTTP setup.
 
 ## HedgeDoc config
 
-[Full explaination of the configuration options](../configuration.md)
+[Full explanation of the configuration options](../configuration.md)
 
 | `config.json` parameter | Environment variable | Value | Example |
 |-------------------------|----------------------|-------|---------|


### PR DESCRIPTION
### Component/Part
docs

### Description
As we found out in #616, Apache does not set the `X-Forwarded-Proto` header, which is now required because we switched to secure cookies in 383d791a50919bb9890a3f3f797ecc95125ab8bf.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
#616
