### PR TITLE
Generate CSS filenames with contenthash

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -177,7 +177,10 @@ module.exports = {
         }
       ]
     }),
-    new MiniCssExtractPlugin()
+    new MiniCssExtractPlugin({
+      filename: '[name].[contenthash].css',
+      chunkFilename: '[id].[contenthash].css'
+    })
   ],
 
   entry: {


### PR DESCRIPTION
### Component/Part
Webpack config

### Description
Previously, .css files always had the same name, which can lead to caching problems.
In our case, the new CSS for the HedgeDoc logo was not loaded when Chrome had the 1.6.0 CSS in the cache, leading the HedgeDoc logo filling the whole screen.
This PR adds the contenthash to the .css files generated by webpack, which ensures that changed files are always loaded.

References:
https://github.com/webpack-contrib/mini-css-extract-plugin#filename
https://webpack.js.org/configuration/output/#outputfilename

### Steps
- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

