### PR TITLE
Fix broken PDF embed in features page & explain embedding problems 

### DIFF
--- a/public/docs/features.md
+++ b/public/docs/features.md
@@ -246,7 +246,8 @@ When you’re a carpenter making a beautiful chest of drawers, you’re not goin
 #### PDF
 
 **Caution: this might be blocked by your browser if not using an `https` URL.**
-{%pdf https://papers.nips.cc/paper/5346-sequence-to-sequence-learning-with-neural-networks.pdf %}
+Note that not all servers allow embedding their content. See [our FAQ](https://hedgedoc.org/faq/#why-cant-i-embed-some-pdfs) for details.
+{%pdf https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf %}
 
 ### MathJax
 


### PR DESCRIPTION
## Component/Part
features page

### Description
This PR replaces the example PDF with one not having an `X-Frame-Options` header and adds a hint to our FAQ page which explains the embedding problems.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
#631
