### PR TITLE
Remove IE11 support from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ To use HedgeDoc, your browser should match or exceed these versions:
 - ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/chrome/chrome_24x24.png) Chrome >= 47, ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/chrome/chrome_24x24.png) Chrome for Android >= 47
 - ![Safari](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/safari/safari_24x24.png) Safari >= 9, ![iOS Safarai](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/safari-ios/safari-ios_24x24.png) iOS Safari >= 8.4
 - ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/firefox/firefox_24x24.png) Firefox >= 44
-- ![IE](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/archive/internet-explorer_9-11/internet-explorer_9-11_24x24.png) IE >= 9, ![Edge](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/edge/edge_24x24.png) Edge >= 12
-- ![Opera](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/opera/opera_24x24.png) Opera >= 34, ![Opera Mini](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/opera-mini/opera-mini_24x24.png) Opera Mini not supported
+- ![Edge](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/edge/edge_24x24.png) Edge >= 12
+- ![Opera](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/opera/opera_24x24.png) Opera >=
+  34, ![Opera Mini](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/opera-mini/opera-mini_24x24.png)
+  Opera Mini not supported
 - ![Android Browser](https://raw.githubusercontent.com/alrra/browser-logos/HEAD/src/android-webview-beta/android-webview-beta_24x24.png) Android Browser >= 4.4
 
 ## Backup/restore your instance


### PR DESCRIPTION
### Component/Part
docs

### Description
Apparently we have stopped supporting IE11. It shows a syntax error for our JS. I have spent half an hour trying to add IE11 to our Babel config, but that did not resolve the issue. It seems bigger changes to our Webpack config might be necessary to support IE11 again, which I don't think is worthwhile. It's probably reasonable to just remove IE from the list of supported browsers.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Closes #645 
