### PR TITLE
E2E tests: Increase timeout & set concurrency to 1

### DIFF
--- a/jest-e2e.json
+++ b/jest-e2e.json
@@ -12,5 +12,7 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "coverageDirectory": "./coverage-e2e"
+  "coverageDirectory": "./coverage-e2e",
+  "testTimeout": 10000,
+  "maxConcurrency": 1
 }


### PR DESCRIPTION
### Component/Part
CI

### Description
For some reason Jest sometimes times out when running in GitHub Actions.
This tries to mitigate that error.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
<!-- e.g #123 -->
