### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,10 @@
     "group:socketio",
     "group:linters",
     "group:test",
-    "group:nextjsMonorepo",
-    ":disableMajorUpdates",
-    ":gitSignOff"
+    ":gitSignOff",
+    ":prHourlyLimitNone",
+    ":dependencyDashboard",
+    ":rebaseStalePrs"
   ],
   "labels": [
     "type: maintenance"


### PR DESCRIPTION
### Component/Part
Renovate Config

### Description
This PR
- removes `group:nextjsMonorepo` as that is already included in `config:base` via `group:monorepos`
- disables the hourly PR creation limit
- enables the dependency dashboard
- enables automatic rebasing when the base branch updates

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
<!-- e.g #123 -->
