### PR TITLE
Change year in copyright to 2021

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
-/* SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
-* 
+/* SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+*
 *  SPDX-License-Identifier: CC0-1.0
 */
 module.exports = {

--- a/.github/workflows/nest.js.yml
+++ b/.github/workflows/nest.js.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.mailmap.license
+++ b/.mailmap.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/.prettierrc.license
+++ b/.prettierrc.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,47 +4,47 @@ Upstream-Contact: The HedgeDoc developers <license@hedgedoc.org>
 Source: https://github.com/hedgedoc/hedgedoc
 
 Files: .idea/**
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: .github/ISSUE_TEMPLATE/*.md
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 Files: .github/pull_request_template.md
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 Files: docs/**/*.md
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 Files: docs/mkdocs.yml
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: docs/requirements.txt
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: docs/**/*.png
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 Files: docs/content/dev/db-schema.plantuml
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 Files: docs/content/dev/*api.yml
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 Files: docs/content/images/logo.svg
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: LicenseRef-HedgeDoc-Icon-Usgae-Guidelines
 
 Files: docs/content/images/hedgedoc_logo_horizontal.svg
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: LicenseRef-HedgeDoc-Icon-Usgae-Guidelines
 
 Files: docs/content/legal/developer-certificate-of-origin.txt

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/config.json.example.license
+++ b/config.json.example.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/docs/content/theme/styles/hedgedoc-custom.css
+++ b/docs/content/theme/styles/hedgedoc-custom.css
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/docs/content/theme/styles/roboto.css
+++ b/docs/content/theme/styles/roboto.css
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/jest-e2e.json.license
+++ b/jest-e2e.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/nest-cli.json.license
+++ b/nest-cli.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/package.json.license
+++ b/package.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/renovate.json.license
+++ b/renovate.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/api/public/me/me.controller.spec.ts
+++ b/src/api/public/me/me.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/public/me/me.controller.ts
+++ b/src/api/public/me/me.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/public/media/media.controller.spec.ts
+++ b/src/api/public/media/media.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/public/media/media.controller.ts
+++ b/src/api/public/media/media.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/public/monitoring/monitoring.controller.spec.ts
+++ b/src/api/public/monitoring/monitoring.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/public/monitoring/monitoring.controller.ts
+++ b/src/api/public/monitoring/monitoring.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/public/notes/notes.controller.spec.ts
+++ b/src/api/public/notes/notes.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/public/notes/notes.controller.ts
+++ b/src/api/public/notes/notes.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/public/public-api.module.ts
+++ b/src/api/public/public-api.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/utils/markdownbody-decorator.ts
+++ b/src/api/utils/markdownbody-decorator.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/authors/author.entity.ts
+++ b/src/authors/author.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/authors/authors.module.ts
+++ b/src/authors/authors.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/groups/group.entity.ts
+++ b/src/groups/group.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/history/history-entry-update.dto.ts
+++ b/src/history/history-entry-update.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/history/history-entry.dto.ts
+++ b/src/history/history-entry.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/history/history.module.ts
+++ b/src/history/history.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/history/history.service.spec.ts
+++ b/src/history/history.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/logger/console-logger.service.ts
+++ b/src/logger/console-logger.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/logger/logger.module.ts
+++ b/src/logger/logger.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/logger/nest-console-logger.service.ts
+++ b/src/logger/nest-console-logger.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/media/backends/backend-type.enum.ts
+++ b/src/media/backends/backend-type.enum.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/media/backends/filesystem-backend.ts
+++ b/src/media/backends/filesystem-backend.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/media/media-backend.interface.ts
+++ b/src/media/media-backend.interface.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/media/media-upload.entity.ts
+++ b/src/media/media-upload.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/media/media.module.ts
+++ b/src/media/media.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/media/media.service.spec.ts
+++ b/src/media/media.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/media/multer-file.interface.ts
+++ b/src/media/multer-file.interface.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/monitoring/monitoring.module.ts
+++ b/src/monitoring/monitoring.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/monitoring/monitoring.service.spec.ts
+++ b/src/monitoring/monitoring.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/monitoring/monitoring.service.ts
+++ b/src/monitoring/monitoring.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/monitoring/server-status.dto.ts
+++ b/src/monitoring/server-status.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/notes/author-color.entity.ts
+++ b/src/notes/author-color.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/notes/note-authorship.dto.ts
+++ b/src/notes/note-authorship.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/notes/note-metadata.dto.ts
+++ b/src/notes/note-metadata.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/notes/note-permissions.dto.ts
+++ b/src/notes/note-permissions.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/notes/note.dto.ts
+++ b/src/notes/note.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/notes/note.entity.ts
+++ b/src/notes/note.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/notes/notes.module.ts
+++ b/src/notes/notes.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/notes/tag.entity.ts
+++ b/src/notes/tag.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/permissions/note-group-permission.entity.ts
+++ b/src/permissions/note-group-permission.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/permissions/note-user-permission.entity.ts
+++ b/src/permissions/note-user-permission.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/permissions/permissions.module.ts
+++ b/src/permissions/permissions.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/revisions/authorship.entity.ts
+++ b/src/revisions/authorship.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/revisions/revision-metadata.dto.ts
+++ b/src/revisions/revision-metadata.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/revisions/revision.dto.ts
+++ b/src/revisions/revision.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/revisions/revision.entity.ts
+++ b/src/revisions/revision.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/revisions/revisions.module.ts
+++ b/src/revisions/revisions.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/revisions/revisions.service.spec.ts
+++ b/src/revisions/revisions.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/revisions/revisions.service.ts
+++ b/src/revisions/revisions.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/users/auth-token.entity.ts
+++ b/src/users/auth-token.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/users/identity.entity.ts
+++ b/src/users/identity.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/users/session.entity.ts
+++ b/src/users/session.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/users/user-info.dto.ts
+++ b/src/users/user-info.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/test/public-api/fixtures/test.png.license
+++ b/test/public-api/fixtures/test.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/test/public-api/media.e2e-spec.ts
+++ b/test/public-api/media.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/test/public-api/users.e2e-spec.ts
+++ b/test/public-api/users.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/tsconfig.build.json.license
+++ b/tsconfig.build.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/tsconfig.json.license
+++ b/tsconfig.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/yarn.lock.license
+++ b/yarn.lock.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
### Component/Part
Everything with our copyright notice

### Description
This PR changes the year in the copyright notice from 2020 to 2021

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Additional Information

:tada:  Happy new year