### PR TITLE
Renovate: Maintain lock files once per week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
     ":gitSignOff",
     ":prHourlyLimitNone",
     ":dependencyDashboard",
-    ":rebaseStalePrs"
+    ":rebaseStalePrs",
+    ":maintainLockFilesWeekly"
   ],
   "labels": [
     "type: maintenance"


### PR DESCRIPTION
### Component/Part
Renovate config

### Description
This option makes Renovate refresh yarn.lock once per week
See https://docs.renovatebot.com/configuration-options/#lockfilemaintenance

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
<!-- e.g #123 -->
