### PR TITLE
fixed copyright template for idea

### DIFF
--- a/.idea/copyright/hedgedoc.xml
+++ b/.idea/copyright/hedgedoc.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)&#10;&#10;&#83;PDX-License-Identifier: AGPL-3.0-only" />
+    <option name="notice" value="SPDX-FileCopyrightText: $today.year The HedgeDoc developers (see AUTHORS file)&#10;&#10;&#83;PDX-License-Identifier: AGPL-3.0-only" />
     <option name="myName" value="hedgedoc" />
   </copyright>
 </component>


### PR DESCRIPTION
### Component/Part
copyright template idea

### Description
This PR fixes the template to always use the current year.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.
