### PR TITLE
Get note creation time from database

### DIFF
--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -97,10 +97,10 @@ export class NotesService {
   }
 
   async getCurrentContent(note: Note) {
-    return (await this.getLastRevision(note)).content;
+    return (await this.getLatestRevision(note)).content;
   }
 
-  async getLastRevision(note: Note): Promise<Revision> {
+  async getLatestRevision(note: Note): Promise<Revision> {
     return this.revisionsService.getLatestRevision(note.id);
   }
 
@@ -129,7 +129,7 @@ export class NotesService {
         })),
       },
       tags: note.tags.map((tag) => tag.name),
-      updateTime: (await this.getLastRevision(note)).createdAt,
+      updateTime: (await this.getLatestRevision(note)).createdAt,
       // TODO: Get actual updateUser
       updateUser: {
         displayName: 'Hardcoded User',

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -13,7 +13,7 @@ import { Revision } from '../revisions/revision.entity';
 import { RevisionsService } from '../revisions/revisions.service';
 import { User } from '../users/user.entity';
 import { UsersService } from '../users/users.service';
-import { NoteMetadataDto, NoteMetadataUpdateDto } from './note-metadata.dto';
+import { NoteMetadataDto } from './note-metadata.dto';
 import {
   NotePermissionsDto,
   NotePermissionsUpdateDto,
@@ -104,14 +104,17 @@ export class NotesService {
     return this.revisionsService.getLatestRevision(note.id);
   }
 
+  async getFirstRevision(note: Note): Promise<Revision> {
+    return this.revisionsService.getFirstRevision(note.id);
+  }
+
   async getMetadata(note: Note): Promise<NoteMetadataDto> {
     return {
       // TODO: Convert DB UUID to base64
       id: note.id,
       alias: note.alias,
       title: note.title,
-      // TODO: Get actual createTime
-      createTime: new Date(),
+      createTime: (await this.getFirstRevision(note)).createdAt,
       description: note.description,
       editedBy: note.authorColors.map(
         (authorColor) => authorColor.user.userName,

--- a/src/revisions/revisions.service.ts
+++ b/src/revisions/revisions.service.ts
@@ -62,6 +62,17 @@ export class RevisionsService {
     });
   }
 
+  getFirstRevision(noteId: string): Promise<Revision> {
+    return this.revisionRepository.findOne({
+      where: {
+        note: noteId,
+      },
+      order: {
+        createdAt: 'ASC',
+      },
+    });
+  }
+
   toMetadataDto(revision: Revision): RevisionMetadataDto {
     return {
       id: revision.id,

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -167,7 +167,7 @@ describe('Notes', () => {
 
   it(`GET /notes/{note}/revisions/{revision-id}`, async () => {
     const note = await notesService.createNote('This is a test note.', 'test8');
-    const revision = await notesService.getLastRevision(note);
+    const revision = await notesService.getLatestRevision(note);
     const response = await request(app.getHttpServer())
       .get('/notes/test8/revisions/' + revision.id)
       .expect('Content-Type', /json/)

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -120,34 +120,55 @@ describe('Notes', () => {
       .expect(404);
   });
 
-  it(`GET /notes/{note}/metadata`, async () => {
-    await notesService.createNote('This is a test note.', 'test6');
-    const metadata = await request(app.getHttpServer())
-      .get('/notes/test6/metadata')
-      .expect(200);
-    expect(typeof metadata.body.id).toEqual('string');
-    expect(metadata.body.alias).toEqual('test6');
-    expect(metadata.body.title).toBeNull();
-    expect(metadata.body.description).toBeNull();
-    expect(typeof metadata.body.createTime).toEqual('string');
-    expect(metadata.body.editedBy).toEqual([]);
-    expect(metadata.body.permissions.owner).toBeNull();
-    expect(metadata.body.permissions.sharedToUsers).toEqual([]);
-    expect(metadata.body.permissions.sharedToUsers).toEqual([]);
-    expect(metadata.body.tags).toEqual([]);
-    expect(typeof metadata.body.updateTime).toEqual('string');
-    expect(typeof metadata.body.updateUser.displayName).toEqual('string');
-    expect(typeof metadata.body.updateUser.userName).toEqual('string');
-    expect(typeof metadata.body.updateUser.email).toEqual('string');
-    expect(typeof metadata.body.updateUser.photo).toEqual('string');
-    expect(typeof metadata.body.viewCount).toEqual('number');
-    expect(metadata.body.editedBy).toEqual([]);
+  describe('GET /notes/{note}/metadata', () => {
+    it(`returns complete metadata object`, async () => {
+      await notesService.createNote('This is a test note.', 'test6');
+      const metadata = await request(app.getHttpServer())
+        .get('/notes/test6/metadata')
+        .expect(200);
+      expect(typeof metadata.body.id).toEqual('string');
+      expect(metadata.body.alias).toEqual('test6');
+      expect(metadata.body.title).toBeNull();
+      expect(metadata.body.description).toBeNull();
+      expect(typeof metadata.body.createTime).toEqual('string');
+      expect(metadata.body.editedBy).toEqual([]);
+      expect(metadata.body.permissions.owner).toBeNull();
+      expect(metadata.body.permissions.sharedToUsers).toEqual([]);
+      expect(metadata.body.permissions.sharedToUsers).toEqual([]);
+      expect(metadata.body.tags).toEqual([]);
+      expect(typeof metadata.body.updateTime).toEqual('string');
+      expect(typeof metadata.body.updateUser.displayName).toEqual('string');
+      expect(typeof metadata.body.updateUser.userName).toEqual('string');
+      expect(typeof metadata.body.updateUser.email).toEqual('string');
+      expect(typeof metadata.body.updateUser.photo).toEqual('string');
+      expect(typeof metadata.body.viewCount).toEqual('number');
+      expect(metadata.body.editedBy).toEqual([]);
 
-    // check if a missing note correctly returns 404
-    await request(app.getHttpServer())
-      .get('/notes/i_dont_exist/metadata')
-      .expect('Content-Type', /json/)
-      .expect(404);
+      // check if a missing note correctly returns 404
+      await request(app.getHttpServer())
+        .get('/notes/i_dont_exist/metadata')
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it('has the correct update/create dates', async () => {
+      // create a note
+      const note = await notesService.createNote(
+        'This is a test note.',
+        'test6a',
+      );
+      // save the creation time
+      const createDate = (await note.revisions)[0].createdAt;
+      // wait one second
+      await new Promise((r) => setTimeout(r, 1000));
+      // update the note
+      await notesService.updateNoteByIdOrAlias('test6a', 'More test content');
+      const metadata = await request(app.getHttpServer())
+        .get('/notes/test6a/metadata')
+        .expect(200);
+      expect(metadata.body.createTime).toEqual(createDate.toISOString());
+      expect(metadata.body.updateTime).not.toEqual(createDate.toISOString());
+    });
   });
 
   it(`GET /notes/{note}/revisions`, async () => {


### PR DESCRIPTION
### Component/Part
NotesService

### Description
This PR improves the `NotesService` to get the note creation time from database.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [ ] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
<!-- e.g #123 -->
