### PR TITLE
MarkdownBody: Register swagger metadata

### DIFF
--- a/src/api/utils/markdownbody-decorator.ts
+++ b/src/api/utils/markdownbody-decorator.ts
@@ -10,6 +10,7 @@ import {
   ExecutionContext,
   InternalServerErrorException,
 } from '@nestjs/common';
+import { ApiBody, ApiConsumes } from '@nestjs/swagger';
 import * as getRawBody from 'raw-body';
 
 /**
@@ -37,4 +38,17 @@ export const MarkdownBody = createParamDecorator(
       );
     }
   },
+  [
+    (target, key) => {
+      ApiConsumes('text/markdown')(
+        target,
+        key,
+        Object.getOwnPropertyDescriptor(target, key),
+      );
+      ApiBody({
+        required: true,
+        schema: { example: '# Markdown Body' },
+      })(target, key, Object.getOwnPropertyDescriptor(target, key));
+    },
+  ],
 );


### PR DESCRIPTION
### Component/Part
Custom decorator `MarkdwonBody`

### Description
As explained in https://github.com/nestjs/swagger/issues/32#issuecomment-716169471, it's possible to register swagger metadata in custom decorators by providing an array of `enhancers`.
We now add metadata with the `MarkdownBody` decorator: The request needs a `body` with content-type `text/markdown`.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
<!-- e.g #123 -->
