### PR TITLE
Notes API: Improve spec compliance

### DIFF
--- a/docs/content/dev/public_api.yml
+++ b/docs/content/dev/public_api.yml
@@ -346,7 +346,7 @@ paths:
           content:
             text/plain:
               example: my-note
-  /notes/{note}/permissions:
+  /notes/{note}/metadata/permissions:
     put:
       tags: [ note ]
       summary: Set permissions of a note

--- a/src/api/public/notes/notes.controller.ts
+++ b/src/api/public/notes/notes.controller.ts
@@ -115,7 +115,7 @@ export class NotesController {
     }
   }
 
-  @Put(':noteIdOrAlias/permissions')
+  @Put(':noteIdOrAlias/metadata/permissions')
   async updateNotePermissions(
     @Param('noteIdOrAlias') noteIdOrAlias: string,
     @Body() updateDto: NotePermissionsUpdateDto,

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -13,7 +13,7 @@ import { Revision } from '../revisions/revision.entity';
 import { RevisionsService } from '../revisions/revisions.service';
 import { User } from '../users/user.entity';
 import { UsersService } from '../users/users.service';
-import { NoteMetadataDto, NoteMetadataUpdateDto } from './note-metadata.dto';
+import { NoteMetadataDto } from './note-metadata.dto';
 import {
   NotePermissionsDto,
   NotePermissionsUpdateDto,
@@ -192,6 +192,7 @@ export class NotesService {
     revisions.push(Revision.create(noteContent, noteContent));
     note.revisions = Promise.resolve(revisions);
     await this.noteRepository.save(note);
+    return this.toNoteDto(note);
   }
 
   async getNoteMetadata(noteIdOrAlias: string): Promise<NoteMetadataDto> {

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -103,7 +103,7 @@ describe('Notes', () => {
 
   it(`PUT /notes/{note}`, async () => {
     await notesService.createNote('This is a test note.', 'test4');
-    await request(app.getHttpServer())
+    const response = await request(app.getHttpServer())
       .put('/notes/test4')
       .set('Content-Type', 'text/markdown')
       .send('New note text')
@@ -111,6 +111,7 @@ describe('Notes', () => {
     await expect(
       (await notesService.getNoteDtoByIdOrAlias('test4')).content,
     ).toEqual('New note text');
+    expect(response.body.content).toEqual('New note text');
 
     // check if a missing note correctly returns 404
     await request(app.getHttpServer())


### PR DESCRIPTION
### Component/Part
Notes API

### Description
This PR improves spec compliance of the note API by returning the changed note on `PUT` requests to `/notes/{noteid}`.
It also moves the route to update note permissions under the `metadata` path. That location seems more sensible, as the metadata object includes the permissions.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
Fixes #702
