### PR TITLE
added sanitation to the slideMode in frontmatter

### DIFF
--- a/public/js/reveal-markdown.js
+++ b/public/js/reveal-markdown.js
@@ -103,7 +103,7 @@ import { md } from './extra'
 
     // prevent script end tags in the content from interfering
     // with parsing
-    content = content.replace(/<\/script>/g, SCRIPT_END_PLACEHOLDER)
+    content = content.replace(/<\/script>/gi, SCRIPT_END_PLACEHOLDER)
 
     return '<script type="text/template">' + content + '</script>'
   }

--- a/public/js/slide.js
+++ b/public/js/slide.js
@@ -72,7 +72,56 @@ const defaultOptions = {
 
 // options from yaml meta
 const meta = JSON.parse($('#meta').text())
-var options = meta.slideOptions || {}
+var options = {
+  autoPlayMedia: meta.slideOptions.autoPlayMedia,
+  autoSlide: meta.slideOptions.autoSlide,
+  autoSlideStoppable: meta.slideOptions.autoSlideStoppable,
+  backgroundTransition: meta.slideOptions.backgroundTransition,
+  center: meta.slideOptions.center,
+  controls: meta.slideOptions.controls,
+  controlsBackArrows: meta.slideOptions.controlsBackArrows,
+  controlsLayout: meta.slideOptions.controlsLayout,
+  controlsTutorial: meta.slideOptions.controlsTutorial,
+  defaultTiming: meta.slideOptions.defaultTiming,
+  display: meta.slideOptions.display,
+  embedded: meta.slideOptions.embedded,
+  fragmentInURL: meta.slideOptions.fragmentInURL,
+  fragments: meta.slideOptions.fragments,
+  hash: meta.slideOptions.hash,
+  height: meta.slideOptions.height,
+  help: meta.slideOptions.help,
+  hideAddressBar: meta.slideOptions.hideAddressBar,
+  hideCursorTime: meta.slideOptions.hideCursorTime,
+  hideInactiveCursor: meta.slideOptions.hideInactiveCursor,
+  history: meta.slideOptions.history,
+  keyboard: meta.slideOptions.keyboard,
+  loop: meta.slideOptions.loop,
+  margin: meta.slideOptions.margin,
+  maxScale: meta.slideOptions.maxScale,
+  minScale: meta.slideOptions.minScale,
+  minimumTimePerSlide: meta.slideOptions.minimumTimePerSlide,
+  mobileViewDistance: meta.slideOptions.mobileViewDistance,
+  mouseWheel: meta.slideOptions.mouseWheel,
+  navigationMode: meta.slideOptions.navigationMode,
+  overview: meta.slideOptions.overview,
+  parallaxBackgroundHorizontal: meta.slideOptions.parallaxBackgroundHorizontal,
+  parallaxBackgroundImage: meta.slideOptions.parallaxBackgroundImage,
+  parallaxBackgroundSize: meta.slideOptions.parallaxBackgroundSize,
+  parallaxBackgroundVertical: meta.slideOptions.parallaxBackgroundVertical,
+  preloadIframes: meta.slideOptions.preloadIframes,
+  previewLinks: meta.slideOptions.previewLinks,
+  progress: meta.slideOptions.progress,
+  rtl: meta.slideOptions.rtl,
+  showNotes: meta.slideOptions.showNotes,
+  shuffle: meta.slideOptions.shuffle,
+  slideNumber: meta.slideOptions.slideNumber,
+  totalTime: meta.slideOptions.totalTime,
+  touch: meta.slideOptions.touch,
+  transition: meta.slideOptions.transition,
+  transitionSpeed: meta.slideOptions.transitionSpeed,
+  viewDistance: meta.slideOptions.viewDistance,
+  width: meta.slideOptions.width
+} || {}
 
 const view = $('.reveal')
 

--- a/public/js/slide.js
+++ b/public/js/slide.js
@@ -115,6 +115,7 @@ var options = {
   showNotes: meta.slideOptions.showNotes,
   shuffle: meta.slideOptions.shuffle,
   slideNumber: meta.slideOptions.slideNumber,
+  theme: meta.slideOptions.theme,
   totalTime: meta.slideOptions.totalTime,
   touch: meta.slideOptions.touch,
   transition: meta.slideOptions.transition,


### PR DESCRIPTION
### Component/Part
slideOptions

### Description
This PR adds sanitation to the slideMode in frontmatter 

Specifically left out are
- dependency (user can't really include anything anyway, because CSP forbids most domains)
- autoSlideMethod (nothing our users should be able to change as they won't write JS to be affected by this)
- keyboard (this let's users write arbitrary code and seems therefore to problematic)


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
https://github.com/hakimel/reveal.js/blob/3.9.2/README.md#configuration
https://github.com/hackmdio/codimd/issues/1648
