### PR TITLE
fixed last line statusbar cover problem

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -64,7 +64,7 @@ body:not(.night) .night {
     overflow-y: auto !important;
 }
 .CodeMirror-code {
-    /*padding-bottom: 36px;*/
+    margin-bottom: 36px;
 }
 .CodeMirror-gutter-elt {
     text-align: center;


### PR DESCRIPTION
### Component/Part
editor

### Description
This PR fixes a problem that the last line of code becomes covered by statusbar and can't be moved without changing the note.

Thanks to @mhdrone for reporting this and suggesting the fix

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
fixes #724  
