### PR TITLE
Delete slide options that are not defined

### DIFF
--- a/public/js/slide.js
+++ b/public/js/slide.js
@@ -124,6 +124,12 @@ var options = {
   width: meta.slideOptions.width
 } || {}
 
+for (const key in options) {
+  if (options.hasOwnProperty(key) && options[key] === undefined) {
+    delete options[key]
+  }
+}
+
 const view = $('.reveal')
 
 // text language


### PR DESCRIPTION
### Component/Part
Reveal.js

### Description
Reveal.js doesn't set the default value of an option in the provided config object
if the key is set with "undefined" as value. This leads to a broken slide mode,
because some critical settings are missing.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.