### PR TITLE
Add page to setup namespace

### DIFF
--- a/docs/content/setup/index.md
+++ b/docs/content/setup/index.md
@@ -1,0 +1,8 @@
+# Installation / Upgrading
+You can run HedgeDoc in a number of ways, and we created setup instructions for all of these:
+
+- [Docker](docker)
+- [Cloudron](cloudron)
+- [LinuxServer.io (multi-arch docker)](docker-linuxserver)
+- [Heroku](heroku)
+- [Manual setup](manual-setup)

--- a/docs/content/setup/index.md
+++ b/docs/content/setup/index.md
@@ -1,5 +1,5 @@
 # Installation / Upgrading
-You can run HedgeDoc in a number of ways, and we created setup instructions for all of these:
+You can run HedgeDoc in a number of ways:
 
 - [Docker](docker)
 - [Cloudron](cloudron)


### PR DESCRIPTION
### Component/Part
Documentation

### Description
This PR adds a index page to the setup namespace in the docs to make it easier to link to this section.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.
