### PR TITLE
[Documentation] Fix link in manual setup

### DIFF
--- a/docs/content/setup/manual-setup.md
+++ b/docs/content/setup/manual-setup.md
@@ -21,7 +21,7 @@
 2. Download a [release](https://github.com/hedgedoc/hedgedoc/releases) tarball and extract it.
    Alternatively, you can use Git to clone the repository and checkout a release, e.g. with `git clone -b 1.7.2 https://github.com/hedgedoc/hedgedoc.git`.
 3. Enter the directory and type `bin/setup`, which will install the dependencies and create configs.
-4. Modify the file named `config.json` or configure HedgeDoc through environment variables which will overwrite the configs, see docs [here](https://github.com/hedgedoc/hedgedoc/blob/master/docs/configuration.md).
+4. Modify the file named `config.json` or configure HedgeDoc through environment variables which will overwrite the configs, see docs [here](../configuration.md).
 5. **If using the release tarball for 1.7.0 or newer, this step can be skipped.**  
    Build the frontend bundle by `yarn run build` (use `yarn run dev` if you are in development)
 6. Modify the file named `.sequelizerc`, change the value of the variable `url` to your db connection string. For example:


### PR DESCRIPTION
### Component/Part
Documentation

### Description
This PR fixes a wrong link in the documentation

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)

#747
