### PR TITLE
Swagger: Split public and private API

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,11 +8,11 @@ import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { AppConfig } from './config/app.config';
-import { NestConsoleLoggerService } from './logger/nest-console-logger.service';
 import { MediaConfig } from './config/media.config';
+import { NestConsoleLoggerService } from './logger/nest-console-logger.service';
+import { setupPrivateApiDocs, setupPublicApiDocs } from './utils/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -23,16 +23,10 @@ async function bootstrap() {
   const appConfig = configService.get<AppConfig>('appConfig');
   const mediaConfig = configService.get<MediaConfig>('mediaConfig');
 
-  const swaggerOptions = new DocumentBuilder()
-    .setTitle('HedgeDoc')
-    .setVersion('2.0-dev')
-    .addSecurity('token', {
-      type: 'http',
-      scheme: 'bearer',
-    })
-    .build();
-  const document = SwaggerModule.createDocument(app, swaggerOptions);
-  SwaggerModule.setup('apidoc', app, document);
+  setupPublicApiDocs(app);
+  if (process.env.NODE_ENV === 'development') {
+    setupPrivateApiDocs(app);
+  }
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/utils/swagger.ts
+++ b/src/utils/swagger.ts
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { INestApplication } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { PrivateApiModule } from '../api/private/private-api.module';
+import { PublicApiModule } from '../api/public/public-api.module';
+
+export function setupPublicApiDocs(app: INestApplication) {
+  const publicApiOptions = new DocumentBuilder()
+    .setTitle('HedgeDoc Public API')
+    // TODO: Use real version
+    .setVersion('2.0-dev')
+    .addSecurity('token', {
+      type: 'http',
+      scheme: 'bearer',
+    })
+    .build();
+  const publicApi = SwaggerModule.createDocument(app, publicApiOptions, {
+    include: [PublicApiModule],
+  });
+  SwaggerModule.setup('apidoc', app, publicApi);
+}
+
+export function setupPrivateApiDocs(app: INestApplication) {
+  const privateApiOptions = new DocumentBuilder()
+    .setTitle('HedgeDoc Private API')
+    // TODO: Use real version
+    .setVersion('2.0-dev')
+    .build();
+
+  const privateApi = SwaggerModule.createDocument(app, privateApiOptions, {
+    include: [PrivateApiModule],
+  });
+  SwaggerModule.setup('private/apidoc', app, privateApi);
+}


### PR DESCRIPTION
### Component/Part
Swagger config

### Description
This PR splits the Swagger docs into the public and private API.

The docs for the public API continue to be available under `/apidocs`, the docs for the private API are now separated under `/private/apidocs`.

### Steps
- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
Fixes #759