### PR TITLE
auth: Fix handling of internal server errors

### DIFF
--- a/src/auth/token.strategy.ts
+++ b/src/auth/token.strategy.ts
@@ -6,7 +6,7 @@
 
 import { Strategy } from 'passport-http-bearer';
 import { PassportStrategy } from '@nestjs/passport';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { User } from '../users/user.entity';
 
@@ -17,10 +17,6 @@ export class TokenStrategy extends PassportStrategy(Strategy, 'token') {
   }
 
   async validate(token: string): Promise<User> {
-    const user = await this.authService.validateToken(token);
-    if (!user) {
-      throw new UnauthorizedException();
-    }
-    return user;
+    return this.authService.validateToken(token);
   }
 }


### PR DESCRIPTION


### Component/Part
auth

### Description
This PR catches all NotInDbErrors and TokenNotValidError and transform them to UnauthorizedException with the correct message.
This prevents nest from telling the api user that an internal server error has happened and instead display the correct http error code 401.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
fixes #775 