### PR TITLE
Improved CSS in night-mode

### DIFF
--- a/public/css/markdown.css
+++ b/public/css/markdown.css
@@ -74,9 +74,10 @@
 }
 
 .night .markdown-body .gist table tr:nth-child(2n){
-
     background-color: #ddd;
-
+}
+.night .markdown-body .gist table tr:nth-child(2n+1) {
+    background-color: #e3e3e3;
 }
 
 .markdown-body code[data-gist-id] {
@@ -133,8 +134,8 @@
     white-space: inherit;
 }
 
-.night .markdown-body pre.graphviz .graph > polygon{
-    fill: #333;
+.night .markdown-body pre.graphviz {
+    filter: none;
 }
 
 .night .markdown-body pre.mermaid .titleText,
@@ -160,25 +161,13 @@
     height: 100%;
 }
 
-.night .markdown-body .abc path{
-    fill: #eee;
-}
-
-.night .markdown-body .abc path.note_selected{
-    fill: ##4DD0E1;
-}
-
-.night tspan{
-    fill: #fefefe;
+.night .markdown-body .abc {
+    background-color: #fff;
+    filter: none;
 }
 
 .night pre rect{
     fill: transparent;
-}
-
-.night pre.flow-chart rect,
-.night pre.flow-chart path{
-    stroke: white;
 }
 
 .markdown-body pre > code.wrap {


### PR DESCRIPTION
### Component/Part
CSS of markdown renderer

### Description
This PR fixes several readability issues with diagrams/embeddings in night-mode.
 - Sequence diagrams and flow-charts are now properly white-on-dark.
 - Graphviz diagrams were previously hard to read, therefore they're now not inverted anymore.
 - GitHub Gist embeddings have each second line in a different color, they're now in a more similar color to not distract readers that much anymore.
 - ABC.js sheets are now black-on-white again as that's easier to read.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
fixes #773
