### PR TITLE
Refactoring of controllers and service interfaces

### DIFF
--- a/src/api/public/me/me.controller.ts
+++ b/src/api/public/me/me.controller.ts
@@ -79,9 +79,9 @@ export class MeController {
   @UseGuards(TokenAuthGuard)
   @Get('notes')
   async getMyNotes(@Request() req): Promise<NoteMetadataDto[]> {
-    const notes = await this.notesService.getUserNotes(req.user)
+    const notes = await this.notesService.getUserNotes(req.user);
     return Promise.all(
-      notes.map(note => this.notesService.toNoteMetadataDto(note))
+      notes.map((note) => this.notesService.toNoteMetadataDto(note)),
     );
   }
 }

--- a/src/api/public/me/me.controller.ts
+++ b/src/api/public/me/me.controller.ts
@@ -78,7 +78,10 @@ export class MeController {
 
   @UseGuards(TokenAuthGuard)
   @Get('notes')
-  getMyNotes(@Request() req): NoteMetadataDto[] {
-    return this.notesService.getUserNotes(req.user.userName);
+  async getMyNotes(@Request() req): Promise<NoteMetadataDto[]> {
+    const notes = await this.notesService.getUserNotes(req.user)
+    return Promise.all(
+      notes.map(note => this.notesService.toNoteMetadataDto(note))
+    );
   }
 }

--- a/src/api/public/media/media.controller.ts
+++ b/src/api/public/media/media.controller.ts
@@ -29,6 +29,7 @@ import { MediaService } from '../../../media/media.service';
 import { MulterFile } from '../../../media/multer-file.interface';
 import { TokenAuthGuard } from '../../../auth/token-auth.guard';
 import { ApiSecurity } from '@nestjs/swagger';
+import { MediaUploadUrlDto } from '../../../media/media-upload-url.dto';
 
 @ApiSecurity('token')
 @Controller('media')
@@ -47,7 +48,7 @@ export class MediaController {
     @Request() req,
     @UploadedFile() file: MulterFile,
     @Headers('HedgeDoc-Note') noteId: string,
-  ) {
+  ) : Promise<MediaUploadUrlDto> {
     const username = req.user.userName;
     this.logger.debug(
       `Recieved filename '${file.originalname}' for note '${noteId}' from user '${username}'`,
@@ -59,9 +60,7 @@ export class MediaController {
         username,
         noteId,
       );
-      return {
-        link: url,
-      };
+      return this.mediaService.toMediaUploadUrlDto(url)
     } catch (e) {
       if (e instanceof ClientError || e instanceof NotInDBError) {
         throw new BadRequestException(e.message);
@@ -72,7 +71,7 @@ export class MediaController {
 
   @UseGuards(TokenAuthGuard)
   @Delete(':filename')
-  async deleteMedia(@Request() req, @Param('filename') filename: string) {
+  async deleteMedia(@Request() req, @Param('filename') filename: string) : Promise<void> {
     const username = req.user.userName;
     try {
       await this.mediaService.deleteFile(filename, username);

--- a/src/api/public/media/media.controller.ts
+++ b/src/api/public/media/media.controller.ts
@@ -48,7 +48,7 @@ export class MediaController {
     @Request() req,
     @UploadedFile() file: MulterFile,
     @Headers('HedgeDoc-Note') noteId: string,
-  ) : Promise<MediaUploadUrlDto> {
+  ): Promise<MediaUploadUrlDto> {
     const username = req.user.userName;
     this.logger.debug(
       `Recieved filename '${file.originalname}' for note '${noteId}' from user '${username}'`,
@@ -60,7 +60,7 @@ export class MediaController {
         username,
         noteId,
       );
-      return this.mediaService.toMediaUploadUrlDto(url)
+      return this.mediaService.toMediaUploadUrlDto(url);
     } catch (e) {
       if (e instanceof ClientError || e instanceof NotInDBError) {
         throw new BadRequestException(e.message);
@@ -71,7 +71,10 @@ export class MediaController {
 
   @UseGuards(TokenAuthGuard)
   @Delete(':filename')
-  async deleteMedia(@Request() req, @Param('filename') filename: string) : Promise<void> {
+  async deleteMedia(
+    @Request() req,
+    @Param('filename') filename: string,
+  ): Promise<void> {
     const username = req.user.userName;
     try {
       await this.mediaService.deleteFile(filename, username);

--- a/src/api/public/monitoring/monitoring.controller.ts
+++ b/src/api/public/monitoring/monitoring.controller.ts
@@ -8,6 +8,7 @@ import { Controller, Get, UseGuards } from '@nestjs/common';
 import { MonitoringService } from '../../../monitoring/monitoring.service';
 import { TokenAuthGuard } from '../../../auth/token-auth.guard';
 import { ApiSecurity } from '@nestjs/swagger';
+import { ServerStatusDto } from '../../../monitoring/server-status.dto';
 
 @ApiSecurity('token')
 @Controller('monitoring')
@@ -16,7 +17,8 @@ export class MonitoringController {
 
   @UseGuards(TokenAuthGuard)
   @Get()
-  getStatus() {
+  getStatus() : Promise<ServerStatusDto> {
+    // TODO: toServerStatusDto.
     return this.monitoringService.getServerStatus();
   }
 

--- a/src/api/public/monitoring/monitoring.controller.ts
+++ b/src/api/public/monitoring/monitoring.controller.ts
@@ -17,7 +17,7 @@ export class MonitoringController {
 
   @UseGuards(TokenAuthGuard)
   @Get()
-  getStatus() : Promise<ServerStatusDto> {
+  getStatus(): Promise<ServerStatusDto> {
     // TODO: toServerStatusDto.
     return this.monitoringService.getServerStatus();
   }

--- a/src/api/public/notes/notes.controller.ts
+++ b/src/api/public/notes/notes.controller.ts
@@ -19,7 +19,10 @@ import {
 } from '@nestjs/common';
 import { NotInDBError } from '../../../errors/errors';
 import { ConsoleLoggerService } from '../../../logger/console-logger.service';
-import { NotePermissionsDto, NotePermissionsUpdateDto } from '../../../notes/note-permissions.dto';
+import {
+  NotePermissionsDto,
+  NotePermissionsUpdateDto,
+} from '../../../notes/note-permissions.dto';
 import { NotesService } from '../../../notes/notes.service';
 import { RevisionsService } from '../../../revisions/revisions.service';
 import { MarkdownBody } from '../../utils/markdownbody-decorator';
@@ -43,11 +46,14 @@ export class NotesController {
 
   @UseGuards(TokenAuthGuard)
   @Post()
-  async createNote(@Request() req, @MarkdownBody() text: string): Promise<NoteDto> {
+  async createNote(
+    @Request() req,
+    @MarkdownBody() text: string,
+  ): Promise<NoteDto> {
     // ToDo: provide user for createNoteDto
     this.logger.debug('Got raw markdown:\n' + text);
     return this.noteService.toNoteDto(
-      await this.noteService.createNote(text, undefined, req.user)
+      await this.noteService.createNote(text, undefined, req.user),
     );
   }
 
@@ -61,17 +67,20 @@ export class NotesController {
     // ToDo: check if user is allowed to view this note
     this.logger.debug('Got raw markdown:\n' + text);
     return this.noteService.toNoteDto(
-      await this.noteService.createNote(text, noteAlias, req.user)
+      await this.noteService.createNote(text, noteAlias, req.user),
     );
   }
 
   @UseGuards(TokenAuthGuard)
   @Get(':noteIdOrAlias')
-  async getNote(@Request() req, @Param('noteIdOrAlias') noteIdOrAlias: string) : Promise<NoteDto> {
+  async getNote(
+    @Request() req,
+    @Param('noteIdOrAlias') noteIdOrAlias: string,
+  ): Promise<NoteDto> {
     // ToDo: check if user is allowed to view this note
     try {
       return this.noteService.toNoteDto(
-        await this.noteService.getNoteByIdOrAlias(noteIdOrAlias)
+        await this.noteService.getNoteByIdOrAlias(noteIdOrAlias),
       );
     } catch (e) {
       if (e instanceof NotInDBError) {
@@ -107,12 +116,12 @@ export class NotesController {
     @Request() req,
     @Param('noteIdOrAlias') noteIdOrAlias: string,
     @MarkdownBody() text: string,
-  ) : Promise<NoteDto> {
+  ): Promise<NoteDto> {
     // ToDo: check if user is allowed to change this note
     this.logger.debug('Got raw markdown:\n' + text);
     try {
       return this.noteService.toNoteDto(
-        await this.noteService.updateNoteByIdOrAlias(noteIdOrAlias, text)
+        await this.noteService.updateNoteByIdOrAlias(noteIdOrAlias, text),
       );
     } catch (e) {
       if (e instanceof NotInDBError) {
@@ -128,7 +137,7 @@ export class NotesController {
   async getNoteContent(
     @Request() req,
     @Param('noteIdOrAlias') noteIdOrAlias: string,
-  ) : Promise<string> {
+  ): Promise<string> {
     // ToDo: check if user is allowed to view this notes content
     try {
       return await this.noteService.getNoteContent(noteIdOrAlias);
@@ -145,11 +154,11 @@ export class NotesController {
   async getNoteMetadata(
     @Request() req,
     @Param('noteIdOrAlias') noteIdOrAlias: string,
-  ) : Promise<NoteMetadataDto> {
+  ): Promise<NoteMetadataDto> {
     // ToDo: check if user is allowed to view this notes metadata
     try {
       return this.noteService.toNoteMetadataDto(
-        await this.noteService.getNoteByIdOrAlias(noteIdOrAlias)
+        await this.noteService.getNoteByIdOrAlias(noteIdOrAlias),
       );
     } catch (e) {
       if (e instanceof NotInDBError) {
@@ -165,14 +174,11 @@ export class NotesController {
     @Request() req,
     @Param('noteIdOrAlias') noteIdOrAlias: string,
     @Body() updateDto: NotePermissionsUpdateDto,
-  ) : Promise<NotePermissionsDto> {
+  ): Promise<NotePermissionsDto> {
     // ToDo: check if user is allowed to view this notes permissions
     try {
       return this.noteService.toNotePermissionsDto(
-        await this.noteService.updateNotePermissions(
-          noteIdOrAlias,
-          updateDto,
-        )
+        await this.noteService.updateNotePermissions(noteIdOrAlias, updateDto),
       );
     } catch (e) {
       if (e instanceof NotInDBError) {
@@ -187,14 +193,16 @@ export class NotesController {
   async getNoteRevisions(
     @Request() req,
     @Param('noteIdOrAlias') noteIdOrAlias: string,
-  ) : Promise<RevisionMetadataDto[]> {
+  ): Promise<RevisionMetadataDto[]> {
     // ToDo: check if user is allowed to view this notes revisions
     try {
       const revisions = await this.revisionsService.getAllRevisions(
         noteIdOrAlias,
       );
       return Promise.all(
-        revisions.map(revision => this.revisionsService.toRevisionMetadataDto(revision))
+        revisions.map((revision) =>
+          this.revisionsService.toRevisionMetadataDto(revision),
+        ),
       );
     } catch (e) {
       if (e instanceof NotInDBError) {
@@ -210,14 +218,11 @@ export class NotesController {
     @Request() req,
     @Param('noteIdOrAlias') noteIdOrAlias: string,
     @Param('revisionId') revisionId: number,
-  ) : Promise<RevisionDto> {
+  ): Promise<RevisionDto> {
     // ToDo: check if user is allowed to view this notes revision
     try {
       return this.revisionsService.toRevisionDto(
-        await this.revisionsService.getRevision(
-          noteIdOrAlias,
-          revisionId,
-        )
+        await this.revisionsService.getRevision(noteIdOrAlias, revisionId),
       );
     } catch (e) {
       if (e instanceof NotInDBError) {

--- a/src/auth/mock-auth.guard.ts
+++ b/src/auth/mock-auth.guard.ts
@@ -5,14 +5,20 @@
  */
 
 import { ExecutionContext, Injectable } from '@nestjs/common';
+import { UsersService } from '../users/users.service';
+import { User } from '../users/user.entity';
 
 @Injectable()
 export class MockAuthGuard {
-  canActivate(context: ExecutionContext) {
+  private user: User;
+  constructor(private usersService: UsersService) {}
+
+  async canActivate(context: ExecutionContext) {
     const req = context.switchToHttp().getRequest();
-    req.user = {
-      userName: 'hardcoded',
-    };
+    if (!this.user) {
+      this.user = await this.usersService.createUser('hardcoded', 'Testy');
+    }
+    req.user = this.user;
     return true;
   }
 }

--- a/src/media/media-upload-url.dto.ts
+++ b/src/media/media-upload-url.dto.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+
+
+import { IsString } from 'class-validator';
+
+export class MediaUploadUrlDto {
+  @IsString()
+  link: string
+}

--- a/src/media/media-upload-url.dto.ts
+++ b/src/media/media-upload-url.dto.ts
@@ -4,11 +4,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-
-
 import { IsString } from 'class-validator';
 
 export class MediaUploadUrlDto {
   @IsString()
-  link: string
+  link: string;
 }

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -59,7 +59,11 @@ export class MediaService {
     return allowedTypes.includes(mimeType);
   }
 
-  public async saveFile(fileBuffer: Buffer, username: string, noteId: string): Promise<string> {
+  public async saveFile(
+    fileBuffer: Buffer,
+    username: string,
+    noteId: string,
+  ): Promise<string> {
     this.logger.debug(
       `Saving file for note '${noteId}' and user '${username}'`,
       'saveFile',
@@ -137,6 +141,6 @@ export class MediaService {
   toMediaUploadUrlDto(url: string): MediaUploadUrlDto {
     return {
       link: url,
-    }
+    };
   }
 }

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -18,6 +18,7 @@ import { BackendType } from './backends/backend-type.enum';
 import { FilesystemBackend } from './backends/filesystem-backend';
 import { MediaBackend } from './media-backend.interface';
 import { MediaUpload } from './media-upload.entity';
+import { MediaUploadUrlDto } from './media-upload-url.dto';
 
 @Injectable()
 export class MediaService {
@@ -58,7 +59,7 @@ export class MediaService {
     return allowedTypes.includes(mimeType);
   }
 
-  public async saveFile(fileBuffer: Buffer, username: string, noteId: string) {
+  public async saveFile(fileBuffer: Buffer, username: string, noteId: string): Promise<string> {
     this.logger.debug(
       `Saving file for note '${noteId}' and user '${username}'`,
       'saveFile',
@@ -88,7 +89,7 @@ export class MediaService {
     return url;
   }
 
-  public async deleteFile(filename: string, username: string) {
+  public async deleteFile(filename: string, username: string): Promise<void> {
     this.logger.debug(
       `Deleting '${filename}' for user '${username}'`,
       'deleteFile',
@@ -130,6 +131,12 @@ export class MediaService {
     switch (type) {
       case BackendType.FILESYSTEM:
         return this.moduleRef.get(FilesystemBackend);
+    }
+  }
+
+  toMediaUploadUrlDto(url: string): MediaUploadUrlDto {
+    return {
+      link: url,
     }
   }
 }

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -35,46 +35,24 @@ export class NotesService {
     this.logger.setContext(NotesService.name);
   }
 
-  getUserNotes(username: string): NoteMetadataDto[] {
+  getUserNotes(user: User): Note[] {
     this.logger.warn('Using hardcoded data!');
     return [
       {
-        alias: null,
-        createTime: new Date(),
-        description: 'Very descriptive text.',
-        editedBy: [],
         id: 'foobar-barfoo',
-        permissions: {
-          owner: {
-            displayName: 'foo',
-            userName: 'fooUser',
-            email: 'foo@example.com',
-            photo: '',
-          },
-          sharedToUsers: [],
-          sharedToGroups: [],
-        },
+        alias: null,
+        shortid: "abc",
+        owner: user,
+        description: 'Very descriptive text.',
+        userPermissions: [],
+        groupPermissions: [],
         tags: [],
+        revisions: Promise.resolve([]),
+        authorColors: [],
         title: 'Title!',
-        updateTime: new Date(),
-        updateUser: {
-          displayName: 'foo',
-          userName: 'fooUser',
-          email: 'foo@example.com',
-          photo: '',
-        },
-        viewCount: 42,
+        viewcount: 42,
       },
     ];
-  }
-
-  async createNoteDto(
-    noteContent: string,
-    alias?: NoteMetadataDto['alias'],
-    owner?: User,
-  ): Promise<NoteDto> {
-    const note = await this.createNote(noteContent, alias, owner);
-    return this.toNoteDto(note);
   }
 
   async createNote(
@@ -96,7 +74,7 @@ export class NotesService {
     return this.noteRepository.save(newNote);
   }
 
-  async getCurrentContent(note: Note) {
+  async getCurrentContent(note: Note): Promise<string> {
     return (await this.getLatestRevision(note)).content;
   }
 
@@ -106,42 +84,6 @@ export class NotesService {
 
   async getFirstRevision(note: Note): Promise<Revision> {
     return this.revisionsService.getFirstRevision(note.id);
-  }
-
-  async getMetadata(note: Note): Promise<NoteMetadataDto> {
-    return {
-      // TODO: Convert DB UUID to base64
-      id: note.id,
-      alias: note.alias,
-      title: note.title,
-      createTime: (await this.getFirstRevision(note)).createdAt,
-      description: note.description,
-      editedBy: note.authorColors.map(
-        (authorColor) => authorColor.user.userName,
-      ),
-      // TODO: Extract into method
-      permissions: {
-        owner: this.usersService.toUserDto(note.owner),
-        sharedToUsers: note.userPermissions.map((noteUserPermission) => ({
-          user: this.usersService.toUserDto(noteUserPermission.user),
-          canEdit: noteUserPermission.canEdit,
-        })),
-        sharedToGroups: note.groupPermissions.map((noteGroupPermission) => ({
-          group: noteGroupPermission.group,
-          canEdit: noteGroupPermission.canEdit,
-        })),
-      },
-      tags: note.tags.map((tag) => tag.name),
-      updateTime: (await this.getLatestRevision(note)).createdAt,
-      // TODO: Get actual updateUser
-      updateUser: {
-        displayName: 'Hardcoded User',
-        userName: 'hardcoded',
-        email: 'foo@example.com',
-        photo: '',
-      },
-      viewCount: 42,
-    };
   }
 
   async getNoteByIdOrAlias(noteIdOrAlias: string): Promise<Note> {
@@ -178,45 +120,47 @@ export class NotesService {
     return note;
   }
 
-  async getNoteDtoByIdOrAlias(noteIdOrAlias: string): Promise<NoteDto> {
-    const note = await this.getNoteByIdOrAlias(noteIdOrAlias);
-    return this.toNoteDto(note);
-  }
-
   async deleteNoteByIdOrAlias(noteIdOrAlias: string) {
     const note = await this.getNoteByIdOrAlias(noteIdOrAlias);
     return await this.noteRepository.remove(note);
   }
 
-  async updateNoteByIdOrAlias(noteIdOrAlias: string, noteContent: string) {
+  async updateNoteByIdOrAlias(noteIdOrAlias: string, noteContent: string): Promise<Note> {
     const note = await this.getNoteByIdOrAlias(noteIdOrAlias);
     const revisions = await note.revisions;
     //TODO: Calculate patch
     revisions.push(Revision.create(noteContent, noteContent));
     note.revisions = Promise.resolve(revisions);
-    await this.noteRepository.save(note);
-    return this.toNoteDto(note);
-  }
-
-  async getNoteMetadata(noteIdOrAlias: string): Promise<NoteMetadataDto> {
-    const note = await this.getNoteByIdOrAlias(noteIdOrAlias);
-    return this.getMetadata(note);
+    return this.noteRepository.save(note);
   }
 
   updateNotePermissions(
     noteIdOrAlias: string,
     newPermissions: NotePermissionsUpdateDto,
-  ): NotePermissionsDto {
+  ): Note {
     this.logger.warn('Using hardcoded data!');
     return {
-      owner: {
-        displayName: 'foo',
-        userName: 'fooUser',
-        email: 'foo@example.com',
-        photo: '',
-      },
-      sharedToUsers: [],
-      sharedToGroups: [],
+        id: 'foobar-barfoo',
+        alias: null,
+        shortid: "abc",
+        owner: {
+          authTokens: [],
+          createdAt: new Date(),
+          displayName: 'hardcoded',
+          id: '1',
+          identities: [],
+          ownedNotes: [],
+          updatedAt: new Date(),
+          userName: 'Testy',
+        },
+        description: 'Very descriptive text.',
+        userPermissions: [],
+        groupPermissions: [],
+        tags: [],
+        revisions: Promise.resolve([]),
+        authorColors: [],
+        title: 'Title!',
+        viewcount: 42,
     };
   }
 
@@ -225,10 +169,50 @@ export class NotesService {
     return this.getCurrentContent(note);
   }
 
+  async toNotePermissionsDto(note: Note): Promise<NotePermissionsDto> {
+    return {
+      owner: this.usersService.toUserDto(note.owner),
+      sharedToUsers: note.userPermissions.map((noteUserPermission) => ({
+        user: this.usersService.toUserDto(noteUserPermission.user),
+        canEdit: noteUserPermission.canEdit,
+      })),
+      sharedToGroups: note.groupPermissions.map((noteGroupPermission) => ({
+        group: noteGroupPermission.group,
+        canEdit: noteGroupPermission.canEdit,
+      })),
+    }
+  }
+
+  async toNoteMetadataDto(note: Note): Promise<NoteMetadataDto> {
+    return {
+      // TODO: Convert DB UUID to base64
+      id: note.id,
+      alias: note.alias,
+      title: note.title,
+      createTime: (await this.getFirstRevision(note)).createdAt,
+      description: note.description,
+      editedBy: note.authorColors.map(
+        (authorColor) => authorColor.user.userName,
+      ),
+      // TODO: Extract into method
+      permissions: await this.toNotePermissionsDto(note),
+      tags: note.tags.map((tag) => tag.name),
+      updateTime: (await this.getLatestRevision(note)).createdAt,
+      // TODO: Get actual updateUser
+      updateUser: {
+        displayName: 'Hardcoded User',
+        userName: 'hardcoded',
+        email: 'foo@example.com',
+        photo: '',
+      },
+      viewCount: 42,
+    };
+  }
+
   async toNoteDto(note: Note): Promise<NoteDto> {
     return {
       content: await this.getCurrentContent(note),
-      metadata: await this.getMetadata(note),
+      metadata: await this.toNoteMetadataDto(note),
       editedByAtPosition: [],
     };
   }

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -41,7 +41,7 @@ export class NotesService {
       {
         id: 'foobar-barfoo',
         alias: null,
-        shortid: "abc",
+        shortid: 'abc',
         owner: user,
         description: 'Very descriptive text.',
         userPermissions: [],
@@ -125,7 +125,10 @@ export class NotesService {
     return await this.noteRepository.remove(note);
   }
 
-  async updateNoteByIdOrAlias(noteIdOrAlias: string, noteContent: string): Promise<Note> {
+  async updateNoteByIdOrAlias(
+    noteIdOrAlias: string,
+    noteContent: string,
+  ): Promise<Note> {
     const note = await this.getNoteByIdOrAlias(noteIdOrAlias);
     const revisions = await note.revisions;
     //TODO: Calculate patch
@@ -140,27 +143,27 @@ export class NotesService {
   ): Note {
     this.logger.warn('Using hardcoded data!');
     return {
-        id: 'foobar-barfoo',
-        alias: null,
-        shortid: "abc",
-        owner: {
-          authTokens: [],
-          createdAt: new Date(),
-          displayName: 'hardcoded',
-          id: '1',
-          identities: [],
-          ownedNotes: [],
-          updatedAt: new Date(),
-          userName: 'Testy',
-        },
-        description: 'Very descriptive text.',
-        userPermissions: [],
-        groupPermissions: [],
-        tags: [],
-        revisions: Promise.resolve([]),
-        authorColors: [],
-        title: 'Title!',
-        viewcount: 42,
+      id: 'foobar-barfoo',
+      alias: null,
+      shortid: 'abc',
+      owner: {
+        authTokens: [],
+        createdAt: new Date(),
+        displayName: 'hardcoded',
+        id: '1',
+        identities: [],
+        ownedNotes: [],
+        updatedAt: new Date(),
+        userName: 'Testy',
+      },
+      description: 'Very descriptive text.',
+      userPermissions: [],
+      groupPermissions: [],
+      tags: [],
+      revisions: Promise.resolve([]),
+      authorColors: [],
+      title: 'Title!',
+      viewcount: 42,
     };
   }
 
@@ -180,7 +183,7 @@ export class NotesService {
         group: noteGroupPermission.group,
         canEdit: noteGroupPermission.canEdit,
       })),
-    }
+    };
   }
 
   async toNoteMetadataDto(note: Note): Promise<NoteMetadataDto> {

--- a/src/revisions/revisions.service.ts
+++ b/src/revisions/revisions.service.ts
@@ -24,30 +24,28 @@ export class RevisionsService {
     this.logger.setContext(RevisionsService.name);
   }
 
-  async getNoteRevisionMetadatas(
+  async getAllRevisions(
     noteIdOrAlias: string,
-  ): Promise<RevisionMetadataDto[]> {
+  ): Promise<Revision[]> {
     const note = await this.notesService.getNoteByIdOrAlias(noteIdOrAlias);
-    const revisions = await this.revisionRepository.find({
+    return await this.revisionRepository.find({
       where: {
-        note: note.id,
+        note: note,
       },
     });
-    return revisions.map((revision) => this.toMetadataDto(revision));
   }
 
-  async getNoteRevision(
+  async getRevision(
     noteIdOrAlias: string,
     revisionId: number,
-  ): Promise<RevisionDto> {
+  ): Promise<Revision> {
     const note = await this.notesService.getNoteByIdOrAlias(noteIdOrAlias);
-    const revision = await this.revisionRepository.findOne({
+    return await this.revisionRepository.findOne({
       where: {
         id: revisionId,
         note: note,
       },
     });
-    return this.toDto(revision);
   }
 
   getLatestRevision(noteId: string): Promise<Revision> {
@@ -73,7 +71,7 @@ export class RevisionsService {
     });
   }
 
-  toMetadataDto(revision: Revision): RevisionMetadataDto {
+  toRevisionMetadataDto(revision: Revision): RevisionMetadataDto {
     return {
       id: revision.id,
       length: revision.length,
@@ -81,7 +79,7 @@ export class RevisionsService {
     };
   }
 
-  toDto(revision: Revision): RevisionDto {
+  toRevisionDto(revision: Revision): RevisionDto {
     return {
       id: revision.id,
       content: revision.content,
@@ -90,7 +88,7 @@ export class RevisionsService {
     };
   }
 
-  createRevision(content: string) {
+  createRevision(content: string) : Revision {
     // TODO: Add previous revision
     // TODO: Calculate patch
     // TODO: Save metadata

--- a/src/revisions/revisions.service.ts
+++ b/src/revisions/revisions.service.ts
@@ -24,9 +24,7 @@ export class RevisionsService {
     this.logger.setContext(RevisionsService.name);
   }
 
-  async getAllRevisions(
-    noteIdOrAlias: string,
-  ): Promise<Revision[]> {
+  async getAllRevisions(noteIdOrAlias: string): Promise<Revision[]> {
     const note = await this.notesService.getNoteByIdOrAlias(noteIdOrAlias);
     return await this.revisionRepository.find({
       where: {
@@ -88,7 +86,7 @@ export class RevisionsService {
     };
   }
 
-  createRevision(content: string) : Revision {
+  createRevision(content: string): Revision {
     // TODO: Add previous revision
     // TODO: Calculate patch
     // TODO: Save metadata

--- a/test/public-api/media.e2e-spec.ts
+++ b/test/public-api/media.e2e-spec.ts
@@ -20,7 +20,6 @@ import { MediaService } from '../../src/media/media.service';
 import { NotesModule } from '../../src/notes/notes.module';
 import { NotesService } from '../../src/notes/notes.service';
 import { PermissionsModule } from '../../src/permissions/permissions.module';
-import { UsersService } from '../../src/users/users.service';
 import { AuthModule } from '../../src/auth/auth.module';
 import { TokenAuthGuard } from '../../src/auth/token-auth.guard';
 import { MockAuthGuard } from '../../src/auth/mock-auth.guard';
@@ -65,8 +64,6 @@ describe('Notes', () => {
     app.useLogger(logger);
     const notesService: NotesService = moduleRef.get('NotesService');
     await notesService.createNote('test content', 'test_upload_media');
-    const usersService: UsersService = moduleRef.get('UsersService');
-    await usersService.createUser('hardcoded', 'Hard Coded');
     mediaService = moduleRef.get('MediaService');
   });
 


### PR DESCRIPTION
DTO should only be used for sending information to and from user.
Services now have methods which return normal internal objects and
methods which convert them to DTOs. This conversion is done in the
controlers

Signed-off-by: Yannick Bungers <git@innay.de>

### Component/Part
<!-- e.g database -->

### Description
This PR fixes/adds/improves/...

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.

### Related Issue(s)
<!-- e.g #123 -->
