### PR TITLE
Docs: Emphasize the difference between branches

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,9 @@ This PR fixes/adds/improves/...
 - [ ] Added / updated tests
 - [ ] Added / updated documentation
 - [ ] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
-  signed-off my commits to accept the DCO.
+  made sure that:
+  - My commits are signed-off to accept the DCO.
+  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
 
 ### Related Issue(s)
 <!-- e.g #123 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,10 @@ Please note we have a [code of conduct][code-of-conduct], please follow it in al
 * Please note that we only accept PRs for the 1.x releases if they fix critical issues. If you are unsure if your fix is
   critical, it's best to ask us before you start coding.
 
+* **Choose the correct base branch:**  
+  The code for 1.x lives in the `master` branch. docs.hedgedoc.org is also deployed from there until 2.0 is released.  
+  HedgeDoc 2.x is developed in the `develop` branch.
+
 ### Do you intend to add a new feature or change an existing one?
 
 * Suggest your idea via a new GitHub issue. After a confirmation about your idea, you can start writing code. Our
@@ -72,7 +76,7 @@ like `git config --global alias.ci 'commit -s'`. Now you can commit with `git ci
 1. Submit an issue describing your proposed change. We will try to respond to your issue promptly.
 2. Fork this repo, develop and test your code changes. Ensure you follow the commit guidelines (see below)
    and signed all your commits (see above for details).
-3. Submit a pull request against this repo's `develop` branch.
+3. Submit a pull request against this repo's `develop` branch for 2.x or the `master` branch for 1.x.
 4. Your branch may be merged once all configured checks pass.
 
 ### Commit guidelines

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ HedgeDoc 2
 HedgeDoc lets you create real-time collaborative markdown notes. Have a look at [our website](https://hedgedoc.org) for
 more details.
 
-**Important:** We are currently working on HedgeDoc 2, a complete rewrite of HedgeDoc. Please note the following:
+⚠️⚠️⚠️ **Important:** We are currently working on HedgeDoc 2, a complete rewrite of HedgeDoc. Please note the following:
 
-- This branch contains the latest development code and does not implement all features yet. If you are looking for the
-  1.x source code, have a look at the `master` branch.
+- This branch contains the latest development code and does not implement all features yet. **If you are looking for the
+  1.x source code, have a look at the `master` branch.**
 - HedgeDoc 2 will be split in two components: the backend (this repo) and the frontend in
   the [react-client repo](https://github.com/hedgedoc/react-client).
 - The 1.x release is maintenance-only. We do not accept feature requests or PRs for this release anymore and may choose


### PR DESCRIPTION
### Component/Part
docs

### Description
To further reduce confusion between the `develop` and `master` branches,
this PR adds more information about them in the README
and the contribution docs.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.
