### PR TITLE
Add issue config to add external links to the community forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support
+    url: https://community.hedgedoc.org/c/support/6
+    about: Find help with your installation and common problems that appear in administration, configuration or in general
+  - name: Community Feedback
+    url: https://community.hedgedoc.org/c/community/feedback/7
+    about: Provide feedback or ask question about the community
+  - name: Community Chat
+    url: https://chat.hedgedoc.org
+    about: Meet the Community on Matrix
+

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -11,6 +11,10 @@ Files: .github/ISSUE_TEMPLATE/*.md
 Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
+Files: .github/ISSUE_TEMPLATE/*.yml
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+License: CC-BY-SA-4.0
+
 Files: .github/pull_request_template.md
 Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0


### PR DESCRIPTION



### Component/Part
GitHub

### Description
This patch adds a Issue template config, which can be used to link to
the forum for support requests as well as community discussions.


- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  signed-off my commits to accept the DCO.


### Reference:
https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser