### PR TITLE
Fix note creation in FreeURL-mode does not apply default template

### DIFF
--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -93,10 +93,11 @@ module.exports = function (sequelize, DataTypes) {
           if (!note.content) {
             var body = null
             let filePath = null
-            if (!note.alias) {
-              filePath = config.defaultNotePath
-            } else {
+            if (note.alias) {
               filePath = path.join(config.docsPath, note.alias + '.md')
+            }
+            if (!filePath || !Note.checkFileExist(filePath)) {
+              filePath = config.defaultNotePath
             }
             if (Note.checkFileExist(filePath)) {
               var fsCreatedTime = moment(fs.statSync(filePath).ctime)


### PR DESCRIPTION
### Component/Part
Note creation

### Description
As explained in #391, the previous note creation logic didn't handle the case "alias is set, but it's not a file on disk". The fix introduces a separate if-statement for this scenario at the cost of a doubled filesystem read access.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #391 
