### PR TITLE
renovatebot: Configure renovatebot to update 1.x and 2.x branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
     ":rebaseStalePrs",
     ":maintainLockFilesWeekly"
   ],
+  "baseBranches": [
+    "master",
+    "develop"
+  ],
   "labels": [
     "type: maintenance"
   ],


### PR DESCRIPTION
Currently renovatebot only cares about the default branch, which is
currently develop. In order to keep everything up-to-date we should
configure it, to also make sure that the master branch for 1.x will be
updated.

Therefore this patch adds the `baseBranches` config option, which allows
to define an array of branches to update.

Reference:

https://docs.renovatebot.com/configuration-options/#basebranches

### DCO

- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

