### PR TITLE
Add missing logging context at various places

### DIFF
--- a/src/api/public/notes/notes.controller.ts
+++ b/src/api/public/notes/notes.controller.ts
@@ -54,7 +54,7 @@ export class NotesController {
     @MarkdownBody() text: string,
   ): Promise<NoteDto> {
     // ToDo: provide user for createNoteDto
-    this.logger.debug('Got raw markdown:\n' + text);
+    this.logger.debug('Got raw markdown:\n' + text, 'createNote');
     return this.noteService.toNoteDto(
       await this.noteService.createNote(text, undefined, req.user),
     );
@@ -84,7 +84,7 @@ export class NotesController {
     @MarkdownBody() text: string,
   ): Promise<NoteDto> {
     // ToDo: check if user is allowed to view this note
-    this.logger.debug('Got raw markdown:\n' + text);
+    this.logger.debug('Got raw markdown:\n' + text, 'createNamedNote');
     return this.noteService.toNoteDto(
       await this.noteService.createNote(text, noteAlias, req.user),
     );
@@ -97,7 +97,7 @@ export class NotesController {
     @Param('noteIdOrAlias') noteIdOrAlias: string,
   ): Promise<void> {
     // ToDo: check if user is allowed to delete this note
-    this.logger.debug('Deleting note: ' + noteIdOrAlias);
+    this.logger.debug('Deleting note: ' + noteIdOrAlias, 'deleteNote');
     try {
       await this.noteService.deleteNoteByIdOrAlias(noteIdOrAlias);
     } catch (e) {
@@ -106,7 +106,7 @@ export class NotesController {
       }
       throw e;
     }
-    this.logger.debug('Successfully deleted ' + noteIdOrAlias);
+    this.logger.debug('Successfully deleted ' + noteIdOrAlias, 'deleteNote');
     return;
   }
 
@@ -118,7 +118,7 @@ export class NotesController {
     @MarkdownBody() text: string,
   ): Promise<NoteDto> {
     // ToDo: check if user is allowed to change this note
-    this.logger.debug('Got raw markdown:\n' + text);
+    this.logger.debug('Got raw markdown:\n' + text, 'updateNote');
     try {
       return this.noteService.toNoteDto(
         await this.noteService.updateNoteByIdOrAlias(noteIdOrAlias, text),

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -224,13 +224,17 @@ export class AuthService {
     let removedTokens = 0;
     for (const token of tokens) {
       if (token.validUntil && token.validUntil.getTime() <= currentTime) {
-        this.logger.debug(`AuthToken '${token.keyId}' was removed`);
+        this.logger.debug(
+          `AuthToken '${token.keyId}' was removed`,
+          'removeInvalidTokens',
+        );
         await this.authTokenRepository.remove(token);
         removedTokens++;
       }
     }
     this.logger.log(
       `${removedTokens} invalid AuthTokens were purged from the DB.`,
+      'removeInvalidTokens',
     );
   }
 }

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -144,7 +144,7 @@ export class NotesService {
     noteIdOrAlias: string,
     newPermissions: NotePermissionsUpdateDto,
   ): Note {
-    this.logger.warn('Using hardcoded data!');
+    this.logger.warn('Using hardcoded data!', 'updateNotePermissions');
     return {
       id: 'foobar-barfoo',
       alias: null,


### PR DESCRIPTION
### Component/Part
Logging

### Description
Our custom logger supports providing the name of the function that
calls the logger, this PR adds this context string where it
was previously missing.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
