### PR TITLE
Remove license of deleted file

### DIFF
--- a/config.json.example.license
+++ b/config.json.example.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
-
-SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
### Component/Part
Licensing

### Description
config.json.example was deleted, but the license file was not. This
removes the leftover file.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ ] Added implementation
- [ ] Added / updated tests
- [ ] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
