### PR TITLE
NotesE2E: Fix e2e test 

### DIFF
--- a/src/api/public/notes/notes.controller.ts
+++ b/src/api/public/notes/notes.controller.ts
@@ -111,21 +111,21 @@ export class NotesController {
     @Request() req,
     @Param('noteIdOrAlias') noteIdOrAlias: string,
   ): Promise<void> {
-    const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
-    if (!this.permissionsService.isOwner(req.user, note)) {
-      throw new UnauthorizedException('Deleting note denied!');
-    }
-    this.logger.debug('Deleting note: ' + noteIdOrAlias, 'deleteNote');
     try {
+      const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
+      if (!this.permissionsService.isOwner(req.user, note)) {
+        throw new UnauthorizedException('Deleting note denied!');
+      }
+      this.logger.debug('Deleting note: ' + noteIdOrAlias, 'deleteNote');
       await this.noteService.deleteNoteByIdOrAlias(noteIdOrAlias);
+      this.logger.debug('Successfully deleted ' + noteIdOrAlias, 'deleteNote');
+      return;
     } catch (e) {
       if (e instanceof NotInDBError) {
         throw new NotFoundException(e.message);
       }
       throw e;
     }
-    this.logger.debug('Successfully deleted ' + noteIdOrAlias, 'deleteNote');
-    return;
   }
 
   @UseGuards(TokenAuthGuard)
@@ -135,12 +135,12 @@ export class NotesController {
     @Param('noteIdOrAlias') noteIdOrAlias: string,
     @MarkdownBody() text: string,
   ): Promise<NoteDto> {
-    const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
-    if (!this.permissionsService.mayWrite(req.user, note)) {
-      throw new UnauthorizedException('Updating note denied!');
-    }
-    this.logger.debug('Got raw markdown:\n' + text, 'updateNote');
     try {
+      const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
+      if (!this.permissionsService.mayWrite(req.user, note)) {
+        throw new UnauthorizedException('Updating note denied!');
+      }
+      this.logger.debug('Got raw markdown:\n' + text, 'updateNote');
       return this.noteService.toNoteDto(
         await this.noteService.updateNoteByIdOrAlias(noteIdOrAlias, text),
       );
@@ -159,11 +159,11 @@ export class NotesController {
     @Request() req,
     @Param('noteIdOrAlias') noteIdOrAlias: string,
   ): Promise<string> {
-    const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
-    if (!this.permissionsService.mayRead(req.user, note)) {
-      throw new UnauthorizedException('Reading note denied!');
-    }
     try {
+      const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
+      if (!this.permissionsService.mayRead(req.user, note)) {
+        throw new UnauthorizedException('Reading note denied!');
+      }
       return await this.noteService.getNoteContent(noteIdOrAlias);
     } catch (e) {
       if (e instanceof NotInDBError) {
@@ -179,11 +179,11 @@ export class NotesController {
     @Request() req,
     @Param('noteIdOrAlias') noteIdOrAlias: string,
   ): Promise<NoteMetadataDto> {
-    const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
-    if (!this.permissionsService.mayRead(req.user, note)) {
-      throw new UnauthorizedException('Reading note denied!');
-    }
     try {
+      const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
+      if (!this.permissionsService.mayRead(req.user, note)) {
+        throw new UnauthorizedException('Reading note denied!');
+      }
       return this.noteService.toNoteMetadataDto(
         await this.noteService.getNoteByIdOrAlias(noteIdOrAlias),
       );
@@ -202,11 +202,11 @@ export class NotesController {
     @Param('noteIdOrAlias') noteIdOrAlias: string,
     @Body() updateDto: NotePermissionsUpdateDto,
   ): Promise<NotePermissionsDto> {
-    const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
-    if (!this.permissionsService.isOwner(req.user, note)) {
-      throw new UnauthorizedException('Updating note denied!');
-    }
     try {
+      const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
+      if (!this.permissionsService.isOwner(req.user, note)) {
+        throw new UnauthorizedException('Updating note denied!');
+      }
       return this.noteService.toNotePermissionsDto(
         await this.noteService.updateNotePermissions(noteIdOrAlias, updateDto),
       );
@@ -224,11 +224,11 @@ export class NotesController {
     @Request() req,
     @Param('noteIdOrAlias') noteIdOrAlias: string,
   ): Promise<RevisionMetadataDto[]> {
-    const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
-    if (!this.permissionsService.mayRead(req.user, note)) {
-      throw new UnauthorizedException('Reading note denied!');
-    }
     try {
+      const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
+      if (!this.permissionsService.mayRead(req.user, note)) {
+        throw new UnauthorizedException('Reading note denied!');
+      }
       const revisions = await this.revisionsService.getAllRevisions(
         noteIdOrAlias,
       );
@@ -252,11 +252,11 @@ export class NotesController {
     @Param('noteIdOrAlias') noteIdOrAlias: string,
     @Param('revisionId') revisionId: number,
   ): Promise<RevisionDto> {
-    const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
-    if (!this.permissionsService.mayRead(req.user, note)) {
-      throw new UnauthorizedException('Reading note denied!');
-    }
     try {
+      const note = await this.noteService.getNoteByIdOrAlias(noteIdOrAlias);
+      if (!this.permissionsService.mayRead(req.user, note)) {
+        throw new UnauthorizedException('Reading note denied!');
+      }
       return this.revisionsService.toRevisionDto(
         await this.revisionsService.getRevision(noteIdOrAlias, revisionId),
       );

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -20,11 +20,15 @@ import { PermissionsModule } from '../../src/permissions/permissions.module';
 import { AuthModule } from '../../src/auth/auth.module';
 import { TokenAuthGuard } from '../../src/auth/token-auth.guard';
 import { MockAuthGuard } from '../../src/auth/mock-auth.guard';
+import { UsersService } from '../../src/users/users.service';
+import { User } from '../../src/users/user.entity';
 import { UsersModule } from '../../src/users/users.module';
 
 describe('Notes', () => {
   let app: INestApplication;
   let notesService: NotesService;
+  let user: User;
+  let content: string;
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -56,14 +60,16 @@ describe('Notes', () => {
     app = moduleRef.createNestApplication();
     await app.init();
     notesService = moduleRef.get(NotesService);
+    const userService = moduleRef.get(UsersService);
+    user = await userService.createUser('hardcoded', 'Testy');
+    content = 'This is a test note.';
   });
 
-  it(`POST /notes`, async () => {
-    const newNote = 'This is a test note.';
+  it('POST /notes', async () => {
     const response = await request(app.getHttpServer())
       .post('/notes')
       .set('Content-Type', 'text/markdown')
-      .send(newNote)
+      .send(content)
       .expect('Content-Type', /json/)
       .expect(201);
     expect(response.body.metadata?.id).toBeDefined();
@@ -71,88 +77,98 @@ describe('Notes', () => {
       await notesService.getCurrentContent(
         await notesService.getNoteByIdOrAlias(response.body.metadata.id),
       ),
-    ).toEqual(newNote);
+    ).toEqual(content);
   });
 
-  it(`GET /notes/{note}`, async () => {
-    // check if we can succefully get a note that exists
-    await notesService.createNote('This is a test note.', 'test1');
-    const response = await request(app.getHttpServer())
-      .get('/notes/test1')
-      .expect('Content-Type', /json/)
-      .expect(200);
-    expect(response.body.content).toEqual('This is a test note.');
-
-    // check if a missing note correctly returns 404
-    await request(app.getHttpServer())
-      .get('/notes/i_dont_exist')
-      .expect('Content-Type', /json/)
-      .expect(404);
+  describe('GET /notes/{note}', () => {
+    it('works with an existing note', async () => {
+      // check if we can succefully get a note that exists
+      await notesService.createNote(content, 'test1', user);
+      const response = await request(app.getHttpServer())
+        .get('/notes/test1')
+        .expect('Content-Type', /json/)
+        .expect(200);
+      expect(response.body.content).toEqual(content);
+    });
+    it('fails with an non-existing note', async () => {
+      // check if a missing note correctly returns 404
+      await request(app.getHttpServer())
+        .get('/notes/i_dont_exist')
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
   });
 
-  it(`POST /notes/{note}`, async () => {
-    const newNote = 'This is a test note.';
-    const response = await request(app.getHttpServer())
-      .post('/notes/test2')
-      .set('Content-Type', 'text/markdown')
-      .send(newNote)
-      .expect('Content-Type', /json/)
-      .expect(201);
-    expect(response.body.metadata?.id).toBeDefined();
-    return expect(
-      await notesService.getCurrentContent(
-        await notesService.getNoteByIdOrAlias(response.body.metadata?.id),
-      ),
-    ).toEqual(newNote);
+  describe('POST /notes/{note}', () => {
+    it('works with a non-existing alias', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/notes/test2')
+        .set('Content-Type', 'text/markdown')
+        .send(content)
+        .expect('Content-Type', /json/)
+        .expect(201);
+      expect(response.body.metadata?.id).toBeDefined();
+      return expect(
+        await notesService.getCurrentContent(
+          await notesService.getNoteByIdOrAlias(response.body.metadata?.id),
+        ),
+      ).toEqual(content);
+    });
   });
 
-  it(`DELETE /notes/{note}`, async () => {
-    await notesService.createNote('This is a test note.', 'test3');
-    await request(app.getHttpServer()).delete('/notes/test3').expect(200);
-    await expect(notesService.getNoteByIdOrAlias('test3')).rejects.toEqual(
-      new NotInDBError("Note with id/alias 'test3' not found."),
-    );
-    // check if a missing note correctly returns 404
-    await request(app.getHttpServer())
-      .delete('/notes/i_dont_exist')
-      .expect(404);
+  describe('DELETE /notes/{note}', () => {
+    it('works with an existing alias', async () => {
+      await notesService.createNote(content, 'test3', user);
+      await request(app.getHttpServer()).delete('/notes/test3').expect(200);
+      await expect(notesService.getNoteByIdOrAlias('test3')).rejects.toEqual(
+        new NotInDBError("Note with id/alias 'test3' not found."),
+      );
+    });
+    it('fails with a non-existing alias', async () => {
+      await request(app.getHttpServer())
+        .delete('/notes/i_dont_exist')
+        .expect(404);
+    });
   });
 
-  it(`PUT /notes/{note}`, async () => {
-    await notesService.createNote('This is a test note.', 'test4');
-    const response = await request(app.getHttpServer())
-      .put('/notes/test4')
-      .set('Content-Type', 'text/markdown')
-      .send('New note text')
-      .expect(200);
-    await expect(
-      await notesService.getCurrentContent(
-        await notesService.getNoteByIdOrAlias('test4'),
-      ),
-    ).toEqual('New note text');
-    expect(response.body.content).toEqual('New note text');
-
-    // check if a missing note correctly returns 404
-    await request(app.getHttpServer())
-      .put('/notes/i_dont_exist')
-      .set('Content-Type', 'text/markdown')
-      .expect('Content-Type', /json/)
-      .expect(404);
+  describe('PUT /notes/{note}', () => {
+    const changedContent = 'New note text';
+    it('works with existing alias', async () => {
+      await notesService.createNote(content, 'test4', user);
+      const response = await request(app.getHttpServer())
+        .put('/notes/test4')
+        .set('Content-Type', 'text/markdown')
+        .send(changedContent)
+        .expect(200);
+      await expect(
+        await notesService.getCurrentContent(
+          await notesService.getNoteByIdOrAlias('test4'),
+        ),
+      ).toEqual(changedContent);
+      expect(response.body.content).toEqual(changedContent);
+    });
+    it('fails with a non-existing alias', async () => {
+      await request(app.getHttpServer())
+        .put('/notes/i_dont_exist')
+        .set('Content-Type', 'text/markdown')
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
   });
 
   describe('GET /notes/{note}/metadata', () => {
-    it(`returns complete metadata object`, async () => {
-      await notesService.createNote('This is a test note.', 'test6');
+    it('returns complete metadata object', async () => {
+      await notesService.createNote(content, 'test5', user);
       const metadata = await request(app.getHttpServer())
-        .get('/notes/test6/metadata')
+        .get('/notes/test5/metadata')
         .expect(200);
       expect(typeof metadata.body.id).toEqual('string');
-      expect(metadata.body.alias).toEqual('test6');
+      expect(metadata.body.alias).toEqual('test5');
       expect(metadata.body.title).toBeNull();
       expect(metadata.body.description).toBeNull();
       expect(typeof metadata.body.createTime).toEqual('string');
       expect(metadata.body.editedBy).toEqual([]);
-      expect(metadata.body.permissions.owner).toBeNull();
+      expect(metadata.body.permissions.owner.userName).toEqual('hardcoded');
       expect(metadata.body.permissions.sharedToUsers).toEqual([]);
       expect(metadata.body.permissions.sharedToUsers).toEqual([]);
       expect(metadata.body.tags).toEqual([]);
@@ -163,7 +179,9 @@ describe('Notes', () => {
       expect(typeof metadata.body.updateUser.photo).toEqual('string');
       expect(typeof metadata.body.viewCount).toEqual('number');
       expect(metadata.body.editedBy).toEqual([]);
+    });
 
+    it('fails with non-existing alias', async () => {
       // check if a missing note correctly returns 404
       await request(app.getHttpServer())
         .get('/notes/i_dont_exist/metadata')
@@ -173,66 +191,75 @@ describe('Notes', () => {
 
     it('has the correct update/create dates', async () => {
       // create a note
-      const note = await notesService.createNote(
-        'This is a test note.',
-        'test6a',
-      );
+      const note = await notesService.createNote(content, 'test5a', user);
       // save the creation time
       const createDate = (await note.revisions)[0].createdAt;
       // wait one second
       await new Promise((r) => setTimeout(r, 1000));
       // update the note
-      await notesService.updateNoteByIdOrAlias('test6a', 'More test content');
+      await notesService.updateNoteByIdOrAlias('test5a', 'More test content');
       const metadata = await request(app.getHttpServer())
-        .get('/notes/test6a/metadata')
+        .get('/notes/test5a/metadata')
         .expect(200);
       expect(metadata.body.createTime).toEqual(createDate.toISOString());
       expect(metadata.body.updateTime).not.toEqual(createDate.toISOString());
     });
   });
 
-  it(`GET /notes/{note}/revisions`, async () => {
-    await notesService.createNote('This is a test note.', 'test7');
-    const response = await request(app.getHttpServer())
-      .get('/notes/test7/revisions')
-      .expect('Content-Type', /json/)
-      .expect(200);
-    expect(response.body).toHaveLength(1);
+  describe('GET /notes/{note}/revisions', () => {
+    it('works with existing alias', async () => {
+      await notesService.createNote(content, 'test6', user);
+      const response = await request(app.getHttpServer())
+        .get('/notes/test6/revisions')
+        .expect('Content-Type', /json/)
+        .expect(200);
+      expect(response.body).toHaveLength(1);
+    });
 
-    // check if a missing note correctly returns 404
-    await request(app.getHttpServer())
-      .get('/notes/i_dont_exist/revisions')
-      .expect('Content-Type', /json/)
-      .expect(404);
+    it('fails with non-existing alias', async () => {
+      // check if a missing note correctly returns 404
+      await request(app.getHttpServer())
+        .get('/notes/i_dont_exist/revisions')
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
   });
 
-  it(`GET /notes/{note}/revisions/{revision-id}`, async () => {
-    const note = await notesService.createNote('This is a test note.', 'test8');
-    const revision = await notesService.getLatestRevision(note);
-    const response = await request(app.getHttpServer())
-      .get('/notes/test8/revisions/' + revision.id)
-      .expect('Content-Type', /json/)
-      .expect(200);
-    expect(response.body.content).toEqual('This is a test note.');
-
-    // check if a missing note correctly returns 404
-    await request(app.getHttpServer())
-      .get('/notes/i_dont_exist/revisions/1')
-      .expect('Content-Type', /json/)
-      .expect(404);
+  describe('GET /notes/{note}/revisions/{revision-id}', () => {
+    it('works with an existing alias', async () => {
+      const note = await notesService.createNote(content, 'test7', user);
+      const revision = await notesService.getLatestRevision(note);
+      const response = await request(app.getHttpServer())
+        .get('/notes/test7/revisions/' + revision.id)
+        .expect('Content-Type', /json/)
+        .expect(200);
+      expect(response.body.content).toEqual(content);
+    });
+    it('fails with non-existing alias', async () => {
+      // check if a missing note correctly returns 404
+      await request(app.getHttpServer())
+        .get('/notes/i_dont_exist/revisions/1')
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
   });
 
-  it(`GET /notes/{note}/content`, async () => {
-    await notesService.createNote('This is a test note.', 'test9');
-    const response = await request(app.getHttpServer())
-      .get('/notes/test9/content')
-      .expect(200);
-    expect(response.text).toEqual('This is a test note.');
+  describe('GET /notes/{note}/content', () => {
+    it('works with an existing alias', async () => {
+      await notesService.createNote(content, 'test8', user);
+      const response = await request(app.getHttpServer())
+        .get('/notes/test8/content')
+        .expect(200);
+      expect(response.text).toEqual(content);
+    });
 
-    // check if a missing note correctly returns 404
-    await request(app.getHttpServer())
-      .get('/notes/i_dont_exist/content')
-      .expect(404);
+    it('fails with non-existing alias', async () => {
+      // check if a missing note correctly returns 404
+      await request(app.getHttpServer())
+        .get('/notes/i_dont_exist/content')
+        .expect('Content-Type', /text\/markdown/)
+        .expect(404);
+    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
### Component/Part
notes e2e tests

### Description
This PR
- splits success and fail cases in separate tests for better readability
- adds the correct user to all notes created by service (instead of api) to make the permissions checks viable.
- extracts test content of notes to a global variable.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x