### PR TITLE
Add HTTP 404 error on actions for non-existent notes

### DIFF
--- a/lib/web/note/controller.js
+++ b/lib/web/note/controller.js
@@ -119,7 +119,7 @@ exports.doAction = function (req, res, next) {
       default:
         return res.redirect(config.serverURL + '/' + noteId)
     }
-  })
+  }, null, false)
 }
 
 exports.downloadMarkdown = function (req, res, note) {

--- a/lib/web/note/util.js
+++ b/lib/web/note/util.js
@@ -5,7 +5,7 @@ const errors = require('../../errors')
 const fs = require('fs')
 const path = require('path')
 
-exports.findNote = function (req, res, callback, include) {
+exports.findNote = function (req, res, callback, include, createIfNotFound = true) {
   const id = req.params.noteId || req.params.shortid
   models.Note.parseNoteId(id, function (err, _id) {
     if (err) {
@@ -18,8 +18,11 @@ exports.findNote = function (req, res, callback, include) {
       },
       include: include || null
     }).then(function (note) {
-      if (!note) {
+      if (!note && createIfNotFound) {
         return exports.newNote(req, res, '')
+      }
+      if (!note && !createIfNotFound) {
+        return errors.errorNotFound(res)
       }
       if (!exports.checkViewPermission(req, note)) {
         return errors.errorForbidden(res)


### PR DESCRIPTION
### Component/Part
Note retrieval logic

### Description
When FreeURL mode is enabled and you called the /download route, the note was created and the user redirected to the blank note.
This is caused because the findNote method automatically creates a note when no existing one is found.
This commit adds a new parameter to the findNote method which allows to disable this behaviour. In that case a HTTP 404 error will be returned.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #370 
