### PR TITLE
Document supported databases

### DIFF
--- a/docs/content/dev/2.0.md
+++ b/docs/content/dev/2.0.md
@@ -3,6 +3,13 @@ This document collects notes and decisions taken during the development of Hedge
 It should be converted to a properly structured documentation, but having unstructured docs
 is better than having no docs.
 
+## Supported databases
+We intend to officially support and test these databases:
+- SQLite (for development and smaller instances)
+- PostgreSQL
+- MariaDB
+
+
 ## Dev Setup
 - Clone backend and frontend in two folders.
 - Run `yarn install` in both projects

--- a/docs/content/dev/2.0.md
+++ b/docs/content/dev/2.0.md
@@ -1,4 +1,7 @@
-# 2.0 Development Hints
+# 2.0 Development Notes
+This document collects notes and decisions taken during the development of HedgeDoc 2.0.
+It should be converted to a properly structured documentation, but having unstructured docs
+is better than having no docs.
 
 ## Dev Setup
 - Clone backend and frontend in two folders.


### PR DESCRIPTION
### Component/Part
Docs
### Description
This PR improves the 2.0 development documentation:
- document what the file is for
- list the supported databases (closes #447)

### Steps
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#447
