### PR TITLE
Config: Add forbiddenNoteIds to AppConfig

### DIFF
--- a/src/api/public/me/me.controller.spec.ts
+++ b/src/api/public/me/me.controller.spec.ts
@@ -23,6 +23,8 @@ import { HistoryEntry } from '../../../history/history-entry.entity';
 import { NoteGroupPermission } from '../../../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
 import { Group } from '../../../groups/group.entity';
+import { ConfigModule } from '@nestjs/config';
+import appConfigMock from '../../../config/app.config.mock';
 
 describe('Me Controller', () => {
   let controller: MeController;
@@ -30,7 +32,16 @@ describe('Me Controller', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MeController],
-      imports: [UsersModule, HistoryModule, NotesModule, LoggerModule],
+      imports: [
+        UsersModule,
+        HistoryModule,
+        NotesModule,
+        LoggerModule,
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [appConfigMock],
+        }),
+      ],
     })
       .overrideProvider(getRepositoryToken(User))
       .useValue({})

--- a/src/api/public/notes/notes.controller.spec.ts
+++ b/src/api/public/notes/notes.controller.spec.ts
@@ -26,6 +26,8 @@ import { NoteGroupPermission } from '../../../permissions/note-group-permission.
 import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
 import { Group } from '../../../groups/group.entity';
 import { GroupsModule } from '../../../groups/groups.module';
+import { ConfigModule } from '@nestjs/config';
+import appConfigMock from '../../../config/app.config.mock';
 
 describe('Notes Controller', () => {
   let controller: NotesController;
@@ -51,6 +53,10 @@ describe('Notes Controller', () => {
         LoggerModule,
         PermissionsModule,
         HistoryModule,
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [appConfigMock],
+        }),
       ],
     })
       .overrideProvider(getRepositoryToken(Note))

--- a/src/api/public/notes/notes.controller.ts
+++ b/src/api/public/notes/notes.controller.ts
@@ -21,6 +21,7 @@ import {
 } from '@nestjs/common';
 import {
   AlreadyInDBError,
+  ForbiddenIdError,
   NotInDBError,
   PermissionsUpdateInconsistentError,
 } from '../../../errors/errors';
@@ -86,6 +87,9 @@ export class NotesController {
       if (e instanceof NotInDBError) {
         throw new NotFoundException(e.message);
       }
+      if (e instanceof ForbiddenIdError) {
+        throw new BadRequestException(e.message);
+      }
       throw e;
     }
     if (!this.permissionsService.mayRead(req.user, note)) {
@@ -114,6 +118,9 @@ export class NotesController {
       if (e instanceof AlreadyInDBError) {
         throw new BadRequestException(e.message);
       }
+      if (e instanceof ForbiddenIdError) {
+        throw new BadRequestException(e.message);
+      }
       throw e;
     }
   }
@@ -136,6 +143,9 @@ export class NotesController {
     } catch (e) {
       if (e instanceof NotInDBError) {
         throw new NotFoundException(e.message);
+      }
+      if (e instanceof ForbiddenIdError) {
+        throw new BadRequestException(e.message);
       }
       throw e;
     }
@@ -161,6 +171,9 @@ export class NotesController {
       if (e instanceof NotInDBError) {
         throw new NotFoundException(e.message);
       }
+      if (e instanceof ForbiddenIdError) {
+        throw new BadRequestException(e.message);
+      }
       throw e;
     }
   }
@@ -181,6 +194,9 @@ export class NotesController {
     } catch (e) {
       if (e instanceof NotInDBError) {
         throw new NotFoundException(e.message);
+      }
+      if (e instanceof ForbiddenIdError) {
+        throw new BadRequestException(e.message);
       }
       throw e;
     }
@@ -205,6 +221,9 @@ export class NotesController {
       if (e instanceof PermissionsUpdateInconsistentError) {
         throw new BadRequestException(e.message);
       }
+      if (e instanceof ForbiddenIdError) {
+        throw new BadRequestException(e.message);
+      }
       throw e;
     }
   }
@@ -227,6 +246,9 @@ export class NotesController {
     } catch (e) {
       if (e instanceof NotInDBError) {
         throw new NotFoundException(e.message);
+      }
+      if (e instanceof ForbiddenIdError) {
+        throw new BadRequestException(e.message);
       }
       throw e;
     }
@@ -253,6 +275,9 @@ export class NotesController {
       if (e instanceof NotInDBError) {
         throw new NotFoundException(e.message);
       }
+      if (e instanceof ForbiddenIdError) {
+        throw new BadRequestException(e.message);
+      }
       throw e;
     }
   }
@@ -275,6 +300,9 @@ export class NotesController {
     } catch (e) {
       if (e instanceof NotInDBError) {
         throw new NotFoundException(e.message);
+      }
+      if (e instanceof ForbiddenIdError) {
+        throw new BadRequestException(e.message);
       }
       throw e;
     }

--- a/src/config/app.config.mock.ts
+++ b/src/config/app.config.mock.ts
@@ -8,4 +8,5 @@ import { registerAs } from '@nestjs/config';
 
 export default registerAs('appConfig', () => ({
   port: 3000,
+  forbiddenNoteIds: ['forbiddenNoteId'],
 }));

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -7,12 +7,13 @@
 import { registerAs } from '@nestjs/config';
 import * as Joi from 'joi';
 import { Loglevel } from './loglevel.enum';
-import { buildErrorMessage } from './utils';
+import { buildErrorMessage, toArrayConfig } from './utils';
 
 export interface AppConfig {
   domain: string;
   port: number;
   loglevel: Loglevel;
+  forbiddenNoteIds: string[];
 }
 
 const schema = Joi.object({
@@ -23,6 +24,10 @@ const schema = Joi.object({
     .default(Loglevel.WARN)
     .optional()
     .label('HD_LOGLEVEL'),
+  forbiddenNoteIds: Joi.string()
+    .optional()
+    .default([])
+    .label('HD_FORBIDDEN_NOTE_IDS'),
 });
 
 export default registerAs('appConfig', () => {
@@ -31,6 +36,7 @@ export default registerAs('appConfig', () => {
       domain: process.env.HD_DOMAIN,
       port: parseInt(process.env.PORT) || undefined,
       loglevel: process.env.HD_LOGLEVEL,
+      forbiddenNoteIds: toArrayConfig(process.env.HD_FORBIDDEN_NOTE_IDS, ','),
     },
     {
       abortEarly: false,

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -12,6 +12,10 @@ export class AlreadyInDBError extends Error {
   name = 'AlreadyInDBError';
 }
 
+export class ForbiddenIdError extends Error {
+  name = 'ForbiddenIdError';
+}
+
 export class ClientError extends Error {
   name = 'ClientError';
 }

--- a/src/history/history.module.ts
+++ b/src/history/history.module.ts
@@ -11,6 +11,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { HistoryEntry } from './history-entry.entity';
 import { UsersModule } from '../users/users.module';
 import { NotesModule } from '../notes/notes.module';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   providers: [HistoryService],
@@ -20,6 +21,7 @@ import { NotesModule } from '../notes/notes.module';
     TypeOrmModule.forFeature([HistoryEntry]),
     UsersModule,
     NotesModule,
+    ConfigModule,
   ],
 })
 export class HistoryModule {}

--- a/src/history/history.service.spec.ts
+++ b/src/history/history.service.spec.ts
@@ -30,6 +30,8 @@ import { NotInDBError } from '../errors/errors';
 import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../permissions/note-user-permission.entity';
 import { Group } from '../groups/group.entity';
+import { ConfigModule } from '@nestjs/config';
+import appConfigMock from '../config/app.config.mock';
 
 describe('HistoryService', () => {
   let service: HistoryService;
@@ -45,7 +47,15 @@ describe('HistoryService', () => {
           useClass: Repository,
         },
       ],
-      imports: [LoggerModule, UsersModule, NotesModule],
+      imports: [
+        LoggerModule,
+        UsersModule,
+        NotesModule,
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [appConfigMock],
+        }),
+      ],
     })
       .overrideProvider(getRepositoryToken(User))
       .useValue({})

--- a/src/media/media.service.spec.ts
+++ b/src/media/media.service.spec.ts
@@ -34,6 +34,7 @@ import { ClientError, NotInDBError, PermissionError } from '../errors/errors';
 import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../permissions/note-user-permission.entity';
 import { Group } from '../groups/group.entity';
+import appConfigMock from '../../src/config/app.config.mock';
 
 describe('MediaService', () => {
   let service: MediaService;
@@ -54,7 +55,7 @@ describe('MediaService', () => {
       imports: [
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [mediaConfigMock],
+          load: [mediaConfigMock, appConfigMock],
         }),
         LoggerModule,
         NotesModule,

--- a/src/notes/notes.module.ts
+++ b/src/notes/notes.module.ts
@@ -16,6 +16,7 @@ import { Tag } from './tag.entity';
 import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../permissions/note-user-permission.entity';
 import { GroupsModule } from '../groups/groups.module';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { GroupsModule } from '../groups/groups.module';
     UsersModule,
     GroupsModule,
     LoggerModule,
+    ConfigModule,
   ],
   controllers: [],
   providers: [NotesService],

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -26,6 +26,8 @@ import { NotesService } from './notes.service';
 import { Repository } from 'typeorm';
 import { Tag } from './tag.entity';
 import {
+  AlreadyInDBError,
+  ForbiddenIdError,
   NotInDBError,
   PermissionsUpdateInconsistentError,
 } from '../errors/errors';
@@ -46,6 +48,7 @@ describe('NotesService', () => {
   let revisionRepo: Repository<Revision>;
   let userRepo: Repository<User>;
   let groupRepo: Repository<Group>;
+  let forbiddenNoteId: string;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -95,6 +98,8 @@ describe('NotesService', () => {
       .useClass(Repository)
       .compile();
 
+    const config = module.get<ConfigService>(ConfigService);
+    forbiddenNoteId = config.get('appConfig').forbiddenNoteIds[0];
     service = module.get<NotesService>(NotesService);
     noteRepo = module.get<Repository<Note>>(getRepositoryToken(Note));
     revisionRepo = module.get<Repository<Revision>>(
@@ -135,10 +140,10 @@ describe('NotesService', () => {
   });
 
   describe('createNote', () => {
+    const user = User.create('hardcoded', 'Testy') as User;
+    const alias = 'alias';
+    const content = 'testContent';
     describe('works', () => {
-      const user = User.create('hardcoded', 'Testy') as User;
-      const alias = 'alias';
-      const content = 'testContent';
       beforeEach(() => {
         jest
           .spyOn(noteRepo, 'save')
@@ -193,6 +198,26 @@ describe('NotesService', () => {
         expect(newNote.tags).toHaveLength(0);
         expect(newNote.owner).toEqual(user);
         expect(newNote.alias).toEqual(alias);
+      });
+    });
+    describe('fails:', () => {
+      it('alias is forbidden', async () => {
+        try {
+          await service.createNote(content, forbiddenNoteId);
+        } catch (e) {
+          expect(e).toBeInstanceOf(ForbiddenIdError);
+        }
+      });
+
+      it('alias is already used', async () => {
+        jest.spyOn(noteRepo, 'save').mockImplementationOnce(async () => {
+          throw new Error();
+        });
+        try {
+          await service.createNote(content, alias);
+        } catch (e) {
+          expect(e).toBeInstanceOf(AlreadyInDBError);
+        }
       });
     });
   });
@@ -252,13 +277,23 @@ describe('NotesService', () => {
       const foundNote = await service.getNoteByIdOrAlias('noteThatExists');
       expect(foundNote).toEqual(note);
     });
-    it('fails: no note found', async () => {
-      jest.spyOn(noteRepo, 'findOne').mockResolvedValueOnce(undefined);
-      try {
-        await service.getNoteByIdOrAlias('noteThatDoesNoteExist');
-      } catch (e) {
-        expect(e).toBeInstanceOf(NotInDBError);
-      }
+    describe('fails:', () => {
+      it('no note found', async () => {
+        jest.spyOn(noteRepo, 'findOne').mockResolvedValueOnce(undefined);
+        try {
+          await service.getNoteByIdOrAlias('noteThatDoesNoteExist');
+        } catch (e) {
+          expect(e).toBeInstanceOf(NotInDBError);
+        }
+      });
+      it('id is forbidden', async () => {
+        jest.spyOn(noteRepo, 'findOne').mockResolvedValueOnce(undefined);
+        try {
+          await service.getNoteByIdOrAlias(forbiddenNoteId);
+        } catch (e) {
+          expect(e).toBeInstanceOf(ForbiddenIdError);
+        }
+      });
     });
   });
 

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -37,6 +37,8 @@ import { NoteGroupPermission } from '../permissions/note-group-permission.entity
 import { NoteUserPermission } from '../permissions/note-user-permission.entity';
 import { GroupsModule } from '../groups/groups.module';
 import { Group } from '../groups/group.entity';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import appConfigMock from '../config/app.config.mock';
 
 describe('NotesService', () => {
   let service: NotesService;
@@ -58,7 +60,16 @@ describe('NotesService', () => {
           useClass: Repository,
         },
       ],
-      imports: [LoggerModule, UsersModule, GroupsModule, RevisionsModule],
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [appConfigMock],
+        }),
+        LoggerModule,
+        UsersModule,
+        GroupsModule,
+        RevisionsModule,
+      ],
     })
       .overrideProvider(getRepositoryToken(Note))
       .useClass(Repository)

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -30,6 +30,7 @@ import { NoteUserPermission } from '../permissions/note-user-permission.entity';
 import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
 import { GroupsService } from '../groups/groups.service';
 import { checkArrayForDuplicates } from '../utils/arrayDuplicatCheck';
+import appConfiguration, { AppConfig } from '../config/app.config';
 
 @Injectable()
 export class NotesService {
@@ -41,6 +42,8 @@ export class NotesService {
     @Inject(GroupsService) private groupsService: GroupsService,
     @Inject(forwardRef(() => RevisionsService))
     private revisionsService: RevisionsService,
+    @Inject(appConfiguration.KEY)
+    private appConfig: AppConfig,
   ) {
     this.logger.setContext(NotesService.name);
   }

--- a/src/permissions/permissions.service.spec.ts
+++ b/src/permissions/permissions.service.spec.ts
@@ -28,6 +28,8 @@ import { NoteGroupPermission } from './note-group-permission.entity';
 import { NoteUserPermission } from './note-user-permission.entity';
 import { PermissionsModule } from './permissions.module';
 import { GuestPermission, PermissionsService } from './permissions.service';
+import { ConfigModule } from '@nestjs/config';
+import appConfigMock from '../config/app.config.mock';
 
 describe('PermissionsService', () => {
   let permissionsService: PermissionsService;
@@ -35,7 +37,16 @@ describe('PermissionsService', () => {
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [PermissionsService],
-      imports: [PermissionsModule, UsersModule, LoggerModule, NotesModule],
+      imports: [
+        PermissionsModule,
+        UsersModule,
+        LoggerModule,
+        NotesModule,
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [appConfigMock],
+        }),
+      ],
     })
       .overrideProvider(getRepositoryToken(User))
       .useValue({})

--- a/src/revisions/revisions.module.ts
+++ b/src/revisions/revisions.module.ts
@@ -11,12 +11,14 @@ import { NotesModule } from '../notes/notes.module';
 import { Authorship } from './authorship.entity';
 import { Revision } from './revision.entity';
 import { RevisionsService } from './revisions.service';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Revision, Authorship]),
     forwardRef(() => NotesModule),
     LoggerModule,
+    ConfigModule,
   ],
   providers: [RevisionsService],
   exports: [RevisionsService],

--- a/src/revisions/revisions.service.spec.ts
+++ b/src/revisions/revisions.service.spec.ts
@@ -20,6 +20,8 @@ import { Tag } from '../notes/tag.entity';
 import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../permissions/note-user-permission.entity';
 import { Group } from '../groups/group.entity';
+import { ConfigModule } from '@nestjs/config';
+import appConfigMock from '../config/app.config.mock';
 
 describe('RevisionsService', () => {
   let service: RevisionsService;
@@ -33,7 +35,14 @@ describe('RevisionsService', () => {
           useValue: {},
         },
       ],
-      imports: [NotesModule, LoggerModule],
+      imports: [
+        NotesModule,
+        LoggerModule,
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [appConfigMock],
+        }),
+      ],
     })
       .overrideProvider(getRepositoryToken(Authorship))
       .useValue({})

--- a/test/public-api/me.e2e-spec.ts
+++ b/test/public-api/me.e2e-spec.ts
@@ -31,6 +31,7 @@ import { UsersModule } from '../../src/users/users.module';
 import { HistoryModule } from '../../src/history/history.module';
 import { ConfigModule } from '@nestjs/config';
 import mediaConfigMock from '../../src/config/media.config.mock';
+import appConfigMock from '../../src/config/app.config.mock';
 import { User } from '../../src/users/user.entity';
 
 // TODO Tests have to be reworked using UserService functions
@@ -47,7 +48,7 @@ describe('Notes', () => {
       imports: [
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [mediaConfigMock],
+          load: [mediaConfigMock, appConfigMock],
         }),
         PublicApiModule,
         NotesModule,

--- a/test/public-api/media.e2e-spec.ts
+++ b/test/public-api/media.e2e-spec.ts
@@ -17,6 +17,7 @@ import { promises as fs } from 'fs';
 import * as request from 'supertest';
 import { PublicApiModule } from '../../src/api/public/public-api.module';
 import mediaConfigMock from '../../src/config/media.config.mock';
+import appConfigMock from '../../src/config/app.config.mock';
 import { GroupsModule } from '../../src/groups/groups.module';
 import { LoggerModule } from '../../src/logger/logger.module';
 import { NestConsoleLoggerService } from '../../src/logger/nest-console-logger.service';
@@ -40,7 +41,7 @@ describe('Notes', () => {
       imports: [
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [mediaConfigMock],
+          load: [mediaConfigMock, appConfigMock],
         }),
         PublicApiModule,
         MediaModule,

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -16,6 +16,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import * as request from 'supertest';
 import { PublicApiModule } from '../../src/api/public/public-api.module';
 import mediaConfigMock from '../../src/config/media.config.mock';
+import appConfigMock from '../../src/config/app.config.mock';
 import { NotInDBError } from '../../src/errors/errors';
 import { GroupsModule } from '../../src/groups/groups.module';
 import { LoggerModule } from '../../src/logger/logger.module';
@@ -40,7 +41,7 @@ describe('Notes', () => {
       imports: [
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [mediaConfigMock],
+          load: [mediaConfigMock, appConfigMock],
         }),
         PublicApiModule,
         NotesModule,


### PR DESCRIPTION
### Component/Part
config, notesService

### Description
This PR adds the forbiddenNoteIds to the AppConfig.

Also uses this config in the notes service and the appropriate tests.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #519 
