### PR TITLE
NoteService: Rename getNoteContentByNote

### DIFF
--- a/src/api/public/notes/notes.controller.ts
+++ b/src/api/public/notes/notes.controller.ts
@@ -176,7 +176,7 @@ export class NotesController {
       if (!this.permissionsService.mayRead(req.user, note)) {
         throw new UnauthorizedException('Reading note denied!');
       }
-      return await this.noteService.getNoteContentByNote(note);
+      return await this.noteService.getNoteContent(note);
     } catch (e) {
       if (e instanceof NotInDBError) {
         throw new NotFoundException(e.message);

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -180,7 +180,7 @@ describe('NotesService', () => {
     });
   });
 
-  describe('getNoteContentByNote', () => {
+  describe('getNoteContent', () => {
     it('works', async () => {
       const content = 'testContent';
       jest
@@ -189,7 +189,7 @@ describe('NotesService', () => {
       const newNote = await service.createNote(content);
       const revisions = await newNote.revisions;
       jest.spyOn(revisionRepo, 'findOne').mockResolvedValueOnce(revisions[0]);
-      service.getNoteContentByNote(newNote).then((result) => {
+      service.getNoteContent(newNote).then((result) => {
         expect(result).toEqual(content);
       });
     });

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -575,22 +575,6 @@ describe('NotesService', () => {
     });
   });
 
-  describe('getNoteContentByIdOrAlias', () => {
-    it('works', async () => {
-      const content = 'testContent';
-      jest
-        .spyOn(noteRepo, 'save')
-        .mockImplementation(async (note: Note): Promise<Note> => note);
-      const newNote = await service.createNote(content);
-      const revisions = await newNote.revisions;
-      jest.spyOn(noteRepo, 'findOne').mockResolvedValueOnce(newNote);
-      jest.spyOn(revisionRepo, 'findOne').mockResolvedValueOnce(revisions[0]);
-      service.getNoteContentByIdOrAlias('noteThatExists').then((result) => {
-        expect(result).toEqual(content);
-      });
-    });
-  });
-
   describe('toTagList', () => {
     it('works', async () => {
       const note = {} as Note;

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -112,7 +112,7 @@ export class NotesService {
    * @param {Note} note - the note to use
    * @return {string} the content of the note
    */
-  async getNoteContentByNote(note: Note): Promise<string> {
+  async getNoteContent(note: Note): Promise<string> {
     return (await this.getLatestRevision(note)).content;
   }
 
@@ -349,7 +349,7 @@ export class NotesService {
    */
   async toNoteDto(note: Note): Promise<NoteDto> {
     return {
-      content: await this.getNoteContentByNote(note),
+      content: await this.getNoteContent(note),
       metadata: await this.toNoteMetadataDto(note),
       editedByAtPosition: [],
     };

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -268,17 +268,6 @@ export class NotesService {
 
   /**
    * @async
-   * Get the current content of the note by either their id or alias.
-   * @param {string} noteIdOrAlias - the notes id or alias
-   * @return {string} the content of the note
-   */
-  async getNoteContentByIdOrAlias(noteIdOrAlias: string): Promise<string> {
-    const note = await this.getNoteByIdOrAlias(noteIdOrAlias);
-    return this.getNoteContentByNote(note);
-  }
-
-  /**
-   * @async
    * Calculate the updateUser (for the NoteDto) for a Note.
    * @param {Note} note - the note to use
    * @return {User} user to be used as updateUser in the NoteDto

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -74,7 +74,7 @@ describe('Notes', () => {
       .expect(201);
     expect(response.body.metadata?.id).toBeDefined();
     expect(
-      await notesService.getNoteContentByNote(
+      await notesService.getNoteContent(
         await notesService.getNoteByIdOrAlias(response.body.metadata.id),
       ),
     ).toEqual(content);
@@ -109,7 +109,7 @@ describe('Notes', () => {
         .expect(201);
       expect(response.body.metadata?.id).toBeDefined();
       return expect(
-        await notesService.getNoteContentByNote(
+        await notesService.getNoteContent(
           await notesService.getNoteByIdOrAlias(response.body.metadata?.id),
         ),
       ).toEqual(content);
@@ -150,7 +150,7 @@ describe('Notes', () => {
         .send(changedContent)
         .expect(200);
       await expect(
-        await notesService.getNoteContentByNote(
+        await notesService.getNoteContent(
           await notesService.getNoteByIdOrAlias('test4'),
         ),
       ).toEqual(changedContent);


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
This PR deletes the unused `getNoteContentByIdOrAlias` and changed name of `getNoteContentByNote` to `getNoteContent` to make it uniform with other methods.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
