### PR TITLE
MediaBackendInterface: Remove getFileURL

### DIFF
--- a/src/media/backends/filesystem-backend.ts
+++ b/src/media/backends/filesystem-backend.ts
@@ -53,12 +53,6 @@ export class FilesystemBackend implements MediaBackend {
     }
   }
 
-  getFileURL(fileName: string, _: BackendData): Promise<string> {
-    const filePath = this.getFilePath(fileName);
-    // TODO: Add server address to url
-    return Promise.resolve('/' + filePath);
-  }
-
   private getFilePath(fileName: string): string {
     return join(this.uploadDirectory, fileName);
   }

--- a/src/media/media-backend.interface.ts
+++ b/src/media/media-backend.interface.ts
@@ -20,7 +20,7 @@ export interface MediaBackend {
    * Delete a file from the backend
    * @param fileName String to identify the file
    * @param backendData Internal backend data
-   * @throws {MediaBackendError} - there was an error retrieving the url
+   * @throws {MediaBackendError} - there was an error deleting the file
    */
   deleteFile(fileName: string, backendData: BackendData): Promise<void>;
 }

--- a/src/media/media-backend.interface.ts
+++ b/src/media/media-backend.interface.ts
@@ -17,14 +17,6 @@ export interface MediaBackend {
   saveFile(buffer: Buffer, fileName: string): Promise<[string, BackendData]>;
 
   /**
-   * Retrieve the URL of a previously saved file.
-   * @param fileName String to identify the file
-   * @param backendData Internal backend data
-   * @throws {MediaBackendError} - there was an error deleting the file
-   */
-  getFileURL(fileName: string, backendData: BackendData): Promise<string>;
-
-  /**
    * Delete a file from the backend
    * @param fileName String to identify the file
    * @param backendData Internal backend data


### PR DESCRIPTION
### Component/Part
media backend interface

### Description
This PR removed the gitFileUrl method from media backend interface.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
closes #957
