### PR TITLE
Docs: Remove `GET /me/history/{note}` from public_api.yml

### DIFF
--- a/docs/content/dev/public_api.yml
+++ b/docs/content/dev/public_api.yml
@@ -52,33 +52,6 @@ paths:
                   "$ref": "#/components/schemas/History"
         '401':
           "$ref": "#/components/responses/UnauthorizedError"
-  /me/history/{note}:
-    get:
-      tags:
-        - history
-        - user
-      summary: Returns History data for a note
-      operationId: getHistoryObject
-      description: JSON Object which contains id, title, tags, last visit time and pinned status
-      responses:
-        '200':
-          description: Information about the history entry
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/History"
-        '401':
-          "$ref": "#/components/responses/UnauthorizedError"
-        '404':
-          "$ref": "#/components/responses/NotFoundError"
-      parameters:
-        - name: note
-          in: path
-          required: true
-          description: The name of the note which is used to address it.
-          content:
-            text/plain:
-              example: my-note
     put:
       tags:
         - history


### PR DESCRIPTION
### Component/Part
docs

### Description
This PR removes `GET /me/history/{note}` from public_api.yml

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
This was deemed unnecessary in #475