### PR TITLE
Documentation updates after #969

### DIFF
--- a/.sequelizerc.example
+++ b/.sequelizerc.example
@@ -1,8 +1,0 @@
-var path = require('path');
-
-module.exports = {
-    'config':          path.resolve('config.json'),
-    'migrations-path': path.resolve('lib', 'migrations'),
-    'models-path':     path.resolve('lib', 'models'),
-    'url':             'change this'
-}

--- a/bin/heroku
+++ b/bin/heroku
@@ -2,18 +2,6 @@
 
 set -e
 
-cat << EOF > .sequelizerc
-var path = require('path');
-
-module.exports = {
-    'config':          path.resolve('config.json'),
-    'migrations-path': path.resolve('lib', 'migrations'),
-    'models-path':     path.resolve('lib', 'models'),
-    'url':             process.env.DATABASE_URL
-}
-
-EOF
-
 cat << EOF > config.json
 
 {

--- a/bin/setup
+++ b/bin/setup
@@ -54,7 +54,7 @@ cat << EOF
 
 
 Edit the following config file to setup HedgeDoc server and client.
-Read more info at https://github.com/hedgedoc/hedgedoc#configuration-files
+Read more info at https://docs.hedgedoc.org/configuration/
 
 * config.json           -- HedgeDoc config
 EOF

--- a/bin/setup
+++ b/bin/setup
@@ -46,10 +46,6 @@ if [ ! -f config.json ]; then
   cp config.json.example config.json
 fi
 
-if [ ! -f .sequelizerc ]; then
-  cp .sequelizerc.example .sequelizerc
-fi
-
 echo "Installing packages..."
 yarn install --pure-lockfile
 yarn install --production=false --pure-lockfile
@@ -61,7 +57,6 @@ Edit the following config file to setup HedgeDoc server and client.
 Read more info at https://github.com/hedgedoc/hedgedoc#configuration-files
 
 * config.json           -- HedgeDoc config
-* .sequelizerc          -- db config
 EOF
 
 # change directory back

--- a/docs/content/setup/manual-setup.md
+++ b/docs/content/setup/manual-setup.md
@@ -24,12 +24,8 @@
 4. Modify the file named `config.json` or configure HedgeDoc through environment variables which will overwrite the configs, see docs [here](../configuration.md).
 5. **If using the release tarball for 1.7.0 or newer, this step can be skipped.**  
    Build the frontend bundle by `yarn run build` (use `yarn run dev` if you are in development)
-6. Modify the file named `.sequelizerc`, change the value of the variable `url` to your db connection string. For example:
-   - `postgres://username:password@localhost:5432/hedgedoc`
-   - `mysql://username:password@localhost:3306/hedgedoc`
-   - `sqlite:///opt/hedgedoc/hedgedoc.sqlite` (note that you need to use an absolute path to the SQLite file)
-7. It is recommended to start your server manually once: `NODE_ENV=production yarn start`, this way it's easier to see warnings or errors that might occur (leave out `NODE_ENV=production` for development).
-8. Run the server as you like (node, forever, pm2, SystemD, Init-Scripts)
+6. It is recommended to start your server manually once: `NODE_ENV=production yarn start`, this way it's easier to see warnings or errors that might occur (leave out `NODE_ENV=production` for development).
+7. Run the server as you like (node, forever, pm2, SystemD, Init-Scripts)
 
 ## How to upgrade your installation
 

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -1,4 +1,9 @@
 # Release Notes
+## <i class="fa fa-tag"></i> 1.8.0 <i class="fa fa-calendar-o"></i> UNRELEASED
+### Features
+- Database migrations are now automatically applied on application startup.  
+  The separate `.sequelizerc` configuration file is no longer necessary and can be safely deleted.
+  
 ## <i class="fa fa-tag"></i> 1.7.2 <i class="fa fa-calendar-o"></i> 2021-01-15
 This release fixes a security issue. We recommend upgrading as soon as possible.
 ### Security Fixes


### PR DESCRIPTION
### Component/Part
Config, setup scripts, release notes

### Description
After https://github.com/hedgedoc/hedgedoc/pull/969 was merged,
a separate configuration file for the sequelize-cli is no longer
required.

This PR updates the docs and setup scripts accordingly.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
