### PR TITLE
[1.x] Templates: Remove lang and add translation parameter

### DIFF
--- a/public/views/hedgedoc.ejs
+++ b/public/views/hedgedoc.ejs
@@ -1,11 +1,11 @@
  <!DOCTYPE html>
-<html lang="en">
+<html>
 
 <head>
     <%- include('hedgedoc/head') %>
 </head>
 
-<body>
+<body translate="no">
     <%- include('hedgedoc/header') %>
     <%- include('hedgedoc/body') %>
     <%- include('hedgedoc/footer') %>

--- a/public/views/html.hbs
+++ b/public/views/html.hbs
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html>
 
 <head>
     <meta charset="utf-8">
@@ -37,7 +37,7 @@
     <![endif]-->
 </head>
 
-<body>
+<body translate="no">
     {{{html}}}
     <div class="ui-toc dropup unselectable hidden-print" style="display:none;">
         <div class="pull-right dropdown">

--- a/public/views/index.ejs
+++ b/public/views/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 
 <head>
     <%- include('index/head') %>

--- a/public/views/pretty.ejs
+++ b/public/views/pretty.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= lang || "en" %>">
+<html>
 
 <head>
     <meta charset="utf-8">
@@ -60,7 +60,7 @@
             <% } %>
         </small>
     </div>
-    <div id="doc" class="container markdown-body"><%= body %></div>
+    <div id="doc" class="container markdown-body" <% if (lang) { %> lang="<%= lang %>"<% } %>><%= body %></div>
     <div class="ui-toc dropup unselectable hidden-print" style="display:none;">
         <div class="pull-right dropdown">
             <a id="tocLabel" class="ui-toc-label btn btn-default" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" title="Table of content">

--- a/public/views/slide.ejs
+++ b/public/views/slide.ejs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html>
     <head>
         <meta charset="utf-8">
         <meta name="apple-mobile-web-app-capable" content="yes">
@@ -48,7 +48,7 @@
             document.getElementsByTagName( 'head' )[0].appendChild( link );
         </script>
     </head>
-    <body>
+    <body translate="no">
         <div class="container">
             <div class="reveal">
                 <div class="slides"><%= body %></div>


### PR DESCRIPTION
### Component/Part
render templates

### Description

Since the interface is not always in english, we mostly removed the lang attribute from all html tags. Since the error messages in error.ejs are not translated, but always in english, there the global lang="en" should be kept.
Also in the slide and editor template the div, which contains the user generated text, has the attribute translate="no" now, to avoid unwanted translations.
Since on the publish view (pretty.ejs) only the user generated content is shown, we set the lang to the language defined in yaml (or 'en') as a default, but that was also moved to the corresponding markdown div instead of html.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #881
See also #437
