### PR TITLE
MediaService: Remove allowedMimeType application/pdf

### DIFF
--- a/docs/content/dev/public_api.yml
+++ b/docs/content/dev/public_api.yml
@@ -496,10 +496,6 @@ paths:
         required: true
         description: The binary file to upload.
         content:
-          application/pdf:
-            schema:
-              type: string
-              format: binary
           image/apng:
             schema:
               type: string

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -47,7 +47,6 @@ export class MediaService {
 
   private static isAllowedMimeType(mimeType: string): boolean {
     const allowedTypes = [
-      'application/pdf',
       'image/apng',
       'image/bmp',
       'image/gif',


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
This PR removes the allowedMimeType 'application/pdf'.

Uploading PDFs does not work with imgur and therefore HedgeDoc should not offer this uploading.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
See #533
