### PR TITLE
Docs: Fix dev doc 'documentation'

### DIFF
--- a/docs/content/dev/documentation.md
+++ b/docs/content/dev/documentation.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Our documentation is build with [mkdocs](https://www.mkdocs.org).
+Our documentation is build with [mkdocs][mkdocs].
 
 ## Writing
 
@@ -8,11 +8,8 @@ All documentation files are found in the `docs/content` directory of
 the [hedgedoc/hedgedoc repo](https://github.com/hedgedoc/hedgedoc). These files are just normal markdown files with
 nothing special about them.
 
-The configuration for mkdocs lies in the `docs` folder in a file called `mkdocs.yml`. With that file the theme and menu
-
-- amoung others - can be configured.
-  **Please note:** Any new files need to be linked to by other files or put in the navigation or the files will be very
-  hard to find on the documentation website.
+The configuration for mkdocs lies in the `docs` folder in a file called `mkdocs.yml`. With that file the theme and menu - among others - can be configured.
+  **Please note:** Any new files need to be linked to by other files or put in the navigation, otherwise the files will be very hard to find on the documentation website.
 
 ## Building
 
@@ -26,12 +23,8 @@ To build the documentation locally you need to perform the following steps:
 
 ## Deployment
 
-The documentation is deployed with [Messor Structor](https://github.com/traefik/structor).
+The documentation is deployed with [mkdocs][mkdocs].
 
-The necessary Dockerfile and version menu template and also the github action to build the whole documentation can be
-found in the [docs.hedgedoc.org repo](https://github.com/hedgedoc/docs.hedgedoc.org). This repo is also used to deploy
-the actuall website to github.io.
+The repository [docs.hedgedoc.org](https://github.com/hedgedoc/docs.hedgedoc.org) is used to deploy the actual website to github.io. Currently only the `master` branch is deployed as it contains the latest release.
 
-Messor Structor builds and deploys the documentation by finding all branches that follow the pattern `v*`. For each
-branch the docs are generated separately by first installing the dependencies from `requirements.txt` and then running
-mkdocs. Afterwards the menu go template is used to include a version switcher in the theme.
+[mkdocs]: (https://www.mkdocs.org)


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
This PR fixes the dev doc 'documentation'.
Specific changes include:
- Fix typos
- Rewrite 'Deployment' paragraph. We currently don't and probably won't use Messor Structor.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x