### PR TITLE
ImageUpload: Fix errors with .jpeg and .svg 

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -179,7 +179,6 @@ switch (config.imageUploadType) {
     config.allowedUploadMimeTypes = [
       'image/jpeg',
       'image/png',
-      'image/jpg',
       'image/gif'
     ]
     break
@@ -187,7 +186,6 @@ switch (config.imageUploadType) {
     config.allowedUploadMimeTypes = [
       'image/jpeg',
       'image/png',
-      'image/jpg',
       'image/gif',
       'image/svg+xml'
     ]

--- a/lib/web/imageRouter/index.js
+++ b/lib/web/imageRouter/index.js
@@ -7,6 +7,7 @@ const FileType = require('file-type')
 const fs = require('fs')
 const os = require('os')
 const rimraf = require('rimraf')
+const isSvg = require('is-svg')
 
 const config = require('../../config')
 const logger = require('../../logger')
@@ -15,12 +16,26 @@ const errors = require('../../errors')
 const imageRouter = (module.exports = Router())
 
 async function checkUploadType (filePath) {
-  const typeFromMagic = await FileType.fromFile(filePath)
+  const extension = path.extname(filePath).toLowerCase()
+  let typeFromMagic = await FileType.fromFile(filePath)
+  if (extension === '.svg' && (typeFromMagic === undefined || typeFromMagic.mime === 'application/xml')) {
+    const fileContent = fs.readFileSync(filePath)
+    if (isSvg(fileContent)) {
+      typeFromMagic = {
+        ext: 'svg',
+        mime: 'image/svg+xml'
+      }
+    }
+  }
   if (typeFromMagic === undefined) {
     logger.error('Image upload error: Could not determine MIME-type')
     return false
   }
-  if (path.extname(filePath) !== '.' + typeFromMagic.ext) {
+  // .jpeg, .jfif, .jpe files are identified by FileType to have the extension jpg
+  if (['.jpeg', '.jfif', '.jpe'].includes(extension) && typeFromMagic.ext === 'jpg') {
+    typeFromMagic.ext = extension.substr(1)
+  }
+  if (extension !== '.' + typeFromMagic.ext) {
     logger.error(
       'Image upload error: Provided file extension does not match MIME-type'
     )

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "i18n": "^0.13.0",
     "imgur": "git+https://github.com/hackmdio/node-imgur.git",
     "ionicons": "^2.0.1",
+    "is-svg": "^4.3.1",
     "jquery": "^3.5.1",
     "jquery-mousewheel": "^3.1.13",
     "jquery-ui": "^1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,7 +448,6 @@
 
 "Idle.Js@git+https://github.com/shawnmclean/Idle.js":
   version "0.0.1"
-  uid db9beb3483a460ad638ec947867720f0ed066a62
   resolved "git+https://github.com/shawnmclean/Idle.js#db9beb3483a460ad638ec947867720f0ed066a62"
 
 JSV@^4.0.x:
@@ -2193,7 +2192,6 @@ code-point-at@^1.0.0:
 
 "codemirror@git+https://github.com/hedgedoc/CodeMirror.git":
   version "5.58.2"
-  uid f780b569b3717cdff4c8507538cc63101bfa02e1
   resolved "git+https://github.com/hedgedoc/CodeMirror.git#f780b569b3717cdff4c8507538cc63101bfa02e1"
 
 collection-visit@^1.0.0:
@@ -3225,7 +3223,6 @@ detect-libc@^1.0.2:
 
 "diff-match-patch@git+https://github.com/hackmdio/diff-match-patch.git":
   version "1.1.1"
-  uid c2f8fb9d69aa9490b764850aa86ba442c93ccf78
   resolved "git+https://github.com/hackmdio/diff-match-patch.git#c2f8fb9d69aa9490b764850aa86ba442c93ccf78"
 
 diff@5.0.0:
@@ -4019,7 +4016,7 @@ fast-safe-stringify@^2.0.4:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
-fast-xml-parser@^3.17.5:
+fast-xml-parser@^3.17.5, fast-xml-parser@^3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
   integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
@@ -4930,7 +4927,6 @@ image-size@~0.5.0:
 
 "imgur@git+https://github.com/hackmdio/node-imgur.git":
   version "0.5.0"
-  uid de0a7a1f1eb2cb6628385fedb990ad396a190573
   resolved "git+https://github.com/hackmdio/node-imgur.git#de0a7a1f1eb2cb6628385fedb990ad396a190573"
   dependencies:
     commander "^2.13.0"
@@ -5406,6 +5402,13 @@ is-svg@^3.0.0:
   dependencies:
     html-comment-regex "^1.1.0"
 
+is-svg@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-4.3.1.tgz#8c63ec8c67c8c7f0a8de0a71c8c7d58eccf4406b"
+  integrity sha512-h2CGs+yPUyvkgTJQS9cJzo9lYK06WgRiXUqBBHtglSzVKAuH4/oWsqk7LGfbSa1hGk9QcZ0SyQtVggvBA8LZXA==
+  dependencies:
+    fast-xml-parser "^3.19.0"
+
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
@@ -5533,7 +5536,6 @@ js-cookie@^2.1.3:
 
 "js-sequence-diagrams@git+https://github.com/hedgedoc/js-sequence-diagrams.git":
   version "2.0.1"
-  uid bda0e49b6c2754f3c7158b1dfb9ccf26efc24b39
   resolved "git+https://github.com/hedgedoc/js-sequence-diagrams.git#bda0e49b6c2754f3c7158b1dfb9ccf26efc24b39"
   dependencies:
     lodash "4.17.x"
@@ -6097,7 +6099,6 @@ lutim@^1.0.2:
 
 "lz-string@git+https://github.com/hackmdio/lz-string.git":
   version "1.4.4"
-  uid efd1f64676264d6d8871b01f4f375fc6ef4f9022
   resolved "git+https://github.com/hackmdio/lz-string.git#efd1f64676264d6d8871b01f4f375fc6ef4f9022"
 
 make-dir@^1.0.0:
@@ -6411,7 +6412,6 @@ messageformat@^2.3.0:
 
 "meta-marked@git+https://github.com/hedgedoc/meta-marked":
   version "0.4.5"
-  uid "4fb5cb5a204969cc91e66eee92c0211188e69a2b"
   resolved "git+https://github.com/hedgedoc/meta-marked#4fb5cb5a204969cc91e66eee92c0211188e69a2b"
   dependencies:
     js-yaml "~3.14.0"


### PR DESCRIPTION
### Component/Part
Image upload

### Description
This PR checks all files that claim to be an svg (by their extension) that they really are and defines the typeFromMagic accordingly
Files that got identified as jpg, but have the extension .jpeg get their extension fixed.
The files extensions will work in all cases now.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #744 