### PR TITLE
Properly clean up socket on exit

### DIFF
--- a/app.js
+++ b/app.js
@@ -301,7 +301,13 @@ function handleTermSignals () {
     }, 0)
   })
   if (config.path) {
-    fs.unlink(config.path)
+    fs.unlink(config.path, err => {
+      if (err) {
+        logger.error(`Could not cleanup socket: ${err.message}`)
+      } else {
+        logger.info('Successfully cleaned up socket')
+      }
+    })
   }
   const checkCleanTimer = setInterval(function () {
     if (realtime.isReady()) {


### PR DESCRIPTION
### Component/Part
term signal handler

### Description
`file.unlink` requires a callback, which we didn't set.
This PR adds a callback with (error) logging, enabling HedgeDoc
to properly clean up the socket.

Closes #784

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

