### PR TITLE
Check for existing notes on POST and don't override them

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -20,6 +20,9 @@ module.exports = {
   errorBadRequest: function (res) {
     responseError(res, '400', 'Bad Request', 'something not right.')
   },
+  errorConflict: function (res) {
+    responseError(res, '409', 'Conflict', 'This note already exists.')
+  },
   errorTooLong: function (res) {
     responseError(res, '413', 'Payload Too Large', 'Shorten your note!')
   },

--- a/lib/web/note/util.js
+++ b/lib/web/note/util.js
@@ -46,7 +46,7 @@ exports.checkViewPermission = function (req, note) {
   }
 }
 
-exports.newNote = function (req, res, body) {
+exports.newNote = async function (req, res, body) {
   let owner = null
   const noteId = req.params.noteId ? req.params.noteId : null
   if (req.isAuthenticated()) {
@@ -59,6 +59,19 @@ exports.newNote = function (req, res, body) {
       req.alias = noteId
     } else {
       return req.method === 'POST' ? errors.errorForbidden(res) : errors.errorNotFound(res)
+    }
+    try {
+      const count = await models.Note.count({
+        where: {
+          alias: req.alias
+        }
+      })
+      if (count > 0) {
+        return errors.errorConflict(res)
+      }
+    } catch (err) {
+      logger.error(err)
+      return errors.errorInternalError(res)
     }
   }
   models.Note.create({

--- a/lib/web/note/util.js
+++ b/lib/web/note/util.js
@@ -70,7 +70,7 @@ exports.newNote = async function (req, res, body) {
         return errors.errorConflict(res)
       }
     } catch (err) {
-      logger.error(err)
+      logger.error('Error while checking for possible duplicate: ' + err)
       return errors.errorInternalError(res)
     }
   }
@@ -82,7 +82,7 @@ exports.newNote = async function (req, res, body) {
   }).then(function (note) {
     return res.redirect(config.serverURL + '/' + (note.alias ? note.alias : models.Note.encodeNoteId(note.id)))
   }).catch(function (err) {
-    logger.error(err)
+    logger.error('Note could not be created: ' + err)
     return errors.errorInternalError(res)
   })
 }


### PR DESCRIPTION
### Component/Part
Note controller

### Description
Previously one could override notes in FreeURL-mode by sending multiple POST requests to the /new/<alias> endpoint. This PR adds a check for an already existing note with the requested alias and returns a HTTP 409 Conflict error in case that happens.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #371 
