### PR TITLE
CSP: Remove yahoo domain from defaults

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -5,7 +5,7 @@ const CspStrategy = {}
 
 const defaultDirectives = {
   defaultSrc: ['\'self\''],
-  scriptSrc: ['\'self\'', 'vimeo.com', 'https://gist.github.com', 'www.slideshare.net', 'https://query.yahooapis.com', '\'unsafe-eval\''],
+  scriptSrc: ['\'self\'', 'vimeo.com', 'https://gist.github.com', 'www.slideshare.net', '\'unsafe-eval\''],
   // ^ TODO: Remove unsafe-eval - webpack script-loader issues https://github.com/hackmdio/codimd/issues/594
   imgSrc: ['*'],
   styleSrc: ['\'self\'', '\'unsafe-inline\'', 'https://github.githubassets.com'], // unsafe-inline is required for some libs, plus used in views


### PR DESCRIPTION
### Component/Part
Default CSP rules

### Description
This PR removes the yahoo domain from the default CSP rules.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
closes #923 
