### PR TITLE
MediaConfigMock: Change upload path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ dist
 public/uploads/*
 !public/uploads/.gitkeep
 uploads
+test_uploads

--- a/src/config/mock/media.config.mock.ts
+++ b/src/config/mock/media.config.mock.ts
@@ -10,7 +10,7 @@ export default registerAs('mediaConfig', () => ({
   backend: {
     use: 'filesystem',
     filesystem: {
-      uploadPath: 'uploads',
+      uploadPath: 'test_uploads',
     },
   },
 }));

--- a/src/media/backends/filesystem-backend.ts
+++ b/src/media/backends/filesystem-backend.ts
@@ -36,7 +36,7 @@ export class FilesystemBackend implements MediaBackend {
     await this.ensureDirectory();
     try {
       await fs.writeFile(filePath, buffer, null);
-      return ['/' + filePath, null];
+      return ['/uploads/' + fileName, null];
     } catch (e) {
       this.logger.error((e as Error).message, (e as Error).stack, 'saveFile');
       throw new MediaBackendError(`Could not save '${filePath}'`);


### PR DESCRIPTION
### Component/Part
media config mock

### Description
This PR changes the upload path of the media config mock to 'test_uploads' to ensure no real uploads are lost.

Also a bug in the filesystem media backend was fixed. All urls generated by this backend should be of the form `uploads/<filename>.<extension>` regardless of what the uploadDirectory is, because the backend proxies all locally uploaded files.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x