### PR TITLE
API: Add option keep media to DELETE /notes/{note}

### DIFF
--- a/src/media/media-upload.entity.ts
+++ b/src/media/media-upload.entity.ts
@@ -24,7 +24,7 @@ export class MediaUpload {
   id: string;
 
   @ManyToOne((_) => Note, (note) => note.mediaUploads, {
-    nullable: false,
+    nullable: true,
   })
   note: Note;
 

--- a/src/media/media.service.spec.ts
+++ b/src/media/media.service.spec.ts
@@ -265,4 +265,27 @@ describe('MediaService', () => {
       });
     });
   });
+
+  describe('removeNoteFromMediaUpload', () => {
+    it('works', async () => {
+      const mockMediaUploadEntry = {
+        id: 'testMediaUpload',
+        backendData: 'testBackendData',
+        note: {
+          alias: 'test',
+        } as Note,
+        user: {
+          userName: 'hardcoded',
+        } as User,
+      } as MediaUpload;
+      jest
+        .spyOn(mediaRepo, 'save')
+        .mockImplementationOnce(async (entry: MediaUpload) => {
+          expect(entry.note).toBeNull();
+          return entry;
+        });
+      await service.removeNoteFromMediaUpload(mockMediaUploadEntry);
+      expect(mediaRepo.save).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -176,6 +176,20 @@ export class MediaService {
     return mediaUploads;
   }
 
+  /**
+   * @async
+   * Set the note of a mediaUpload to null
+   * @param {MediaUpload} mediaUpload - the media upload to be changed
+   */
+  async removeNoteFromMediaUpload(mediaUpload: MediaUpload): Promise<void> {
+    this.logger.debug(
+      'Setting note to null for mediaUpload: ' + mediaUpload.id,
+      'removeNoteFromMediaUpload',
+    );
+    mediaUpload.note = null;
+    await this.mediaUploadRepository.save(mediaUpload);
+  }
+
   private chooseBackendType(): BackendType {
     switch (this.mediaConfig.backend.use) {
       case 'filesystem':

--- a/src/notes/note.media-deletion.dto.ts
+++ b/src/notes/note.media-deletion.dto.ts
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { IsBoolean } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NoteMediaDeletionDto {
+  /**
+   * Should the associated mediaUploads be keept
+   * @default false
+   * @example false
+   */
+  @IsBoolean()
+  @ApiProperty()
+  keepMedia: boolean;
+}

--- a/test/private-api/notes.e2e-spec.ts
+++ b/test/private-api/notes.e2e-spec.ts
@@ -38,6 +38,7 @@ describe('Notes', () => {
   let content: string;
   let forbiddenNoteId: string;
   let uploadPath: string;
+  let testImage: Buffer;
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -80,6 +81,7 @@ describe('Notes', () => {
     user = await userService.createUser('hardcoded', 'Testy');
     user2 = await userService.createUser('hardcoded2', 'Max Mustermann');
     content = 'This is a test note.';
+    testImage = await fs.readFile('test/public-api/fixtures/test.png');
   });
 
   it('POST /notes', async () => {
@@ -152,12 +154,49 @@ describe('Notes', () => {
   });
 
   describe('DELETE /notes/{note}', () => {
-    it('works with an existing alias', async () => {
-      await notesService.createNote(content, 'test3', user);
-      await request(app.getHttpServer()).delete('/notes/test3').expect(204);
-      await expect(notesService.getNoteByIdOrAlias('test3')).rejects.toEqual(
-        new NotInDBError("Note with id/alias 'test3' not found."),
-      );
+    describe('works', () => {
+      it('with an existing alias and keepMedia false', async () => {
+        const noteId = 'test3';
+        await notesService.createNote(content, noteId, user);
+        await mediaService.saveFile(testImage, user.userName, noteId);
+        await request(app.getHttpServer())
+          .delete(`/notes/${noteId}`)
+          .set('Content-Type', 'application/json')
+          .send({
+            keepMedia: false,
+          })
+          .expect(204);
+        await expect(notesService.getNoteByIdOrAlias(noteId)).rejects.toEqual(
+          new NotInDBError(`Note with id/alias '${noteId}' not found.`),
+        );
+        expect(await mediaService.listUploadsByUser(user)).toHaveLength(0);
+        await fs.rmdir(uploadPath);
+      });
+      it('with an existing alias and keepMedia true', async () => {
+        const noteId = 'test3a';
+        await notesService.createNote(content, noteId, user);
+        const url = await mediaService.saveFile(
+          testImage,
+          user.userName,
+          noteId,
+        );
+        await request(app.getHttpServer())
+          .delete(`/notes/${noteId}`)
+          .set('Content-Type', 'application/json')
+          .send({
+            keepMedia: true,
+          })
+          .expect(204);
+        await expect(notesService.getNoteByIdOrAlias(noteId)).rejects.toEqual(
+          new NotInDBError(`Note with id/alias '${noteId}' not found.`),
+        );
+        expect(await mediaService.listUploadsByUser(user)).toHaveLength(1);
+        // Remove /upload/ from path as we just need the filename.
+        const fileName = url.replace('/uploads/', '');
+        // delete the file afterwards
+        await fs.unlink(join(uploadPath, fileName));
+        await fs.rmdir(uploadPath);
+      });
     });
     it('fails with a forbidden alias', async () => {
       await request(app.getHttpServer())


### PR DESCRIPTION
### Component/Part
public api, private api

### Description
This PR adds a body to the route DELETE /notes/{note} of the public and private api to specify if the associated media uploads of the note should be kept or deleted.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #1065 