### PR TITLE
Fix emoji replacement in SAML docs

### DIFF
--- a/docs/content/guides/auth/saml.md
+++ b/docs/content/guides/auth/saml.md
@@ -14,8 +14,8 @@ you want to match your IdP, you can use more configurations as below.
 
   - `identifierFormat`: A format of unique id to identify the user of IdP, which is the format based on email address as
     default. It is recommend that you use as below.
-    - urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress (default)
-    - urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
+    - `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress` (default)
+    - `urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified`
 
   - `config.json`:
     ```javascript


### PR DESCRIPTION
### Component/Part
SAML Documentation

### Description
This PR fixes a wrong emoji replacement in the SAML documentation

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
