### PR TITLE
Replace codimd.org link with hedgedoc.org

### DIFF
--- a/docs/content/setup/getting-started.md
+++ b/docs/content/setup/getting-started.md
@@ -7,4 +7,4 @@ To set up your instance follow these steps:
 2. [Configure your reverse proxy](https://docs.hedgedoc.org/guides/reverse-proxy/)
 3. [Configure HedgeDoc](https://docs.hedgedoc.org/configuration/)
 
-Follow us on <a href="http://social.codimd.org/" target="_blank" rel="noreferer noopener">:fontawesome-brands-mastodon:{: .mastodon }Mastodon</a> or <a href="http://social.codimd.org/twitter" target="_blank" rel="noreferer noopener">:fontawesome-brands-twitter:{: .twitter }Twitter</a> for updates.
+Follow us on <a href="https://social.hedgedoc.org/" target="_blank" rel="noreferer noopener">:fontawesome-brands-mastodon:{: .mastodon }Mastodon</a> or <a href="https://social.hedgedoc.org/twitter" target="_blank" rel="noreferer noopener">:fontawesome-brands-twitter:{: .twitter }Twitter</a> for updates.


### PR DESCRIPTION
### Component/Part
Docs

### Description
This PR replaces a codimd.org link with hedgedoc.org in the docs.

### Steps
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
