### PR TITLE
Use upstream imgur library

### DIFF
--- a/lib/web/imageRouter/imgur.js
+++ b/lib/web/imageRouter/imgur.js
@@ -1,8 +1,8 @@
 'use strict'
 const config = require('../../config')
 const logger = require('../../logger')
-
-const imgur = require('imgur')
+const fs = require('fs')
+const fetch = require('node-fetch')
 
 exports.uploadImage = function (imagePath, callback) {
   if (!callback || typeof callback !== 'function') {
@@ -15,12 +15,30 @@ exports.uploadImage = function (imagePath, callback) {
     return
   }
 
-  imgur.setClientId(config.imgur.clientID)
-  imgur.uploadFile(imagePath)
-    .then(function (json) {
+  // The following client ID is for use with HedgeDoc only
+  const clientId = config.imgur.clientID || '032aa2f687790cd'
+
+  const buffer = fs.readFileSync(imagePath)
+
+  const params = new URLSearchParams()
+  params.append('image', buffer.toString('base64'))
+  params.append('type', 'base64')
+  fetch('https://api.imgur.com/3/image', {
+    method: 'POST',
+    body: params,
+    headers: { Authorization: `Client-ID ${clientId}` }
+  })
+    .then((res) => {
+      if (!res.ok) {
+        callback(new Error(res.statusText), null)
+        return
+      }
+      return res.json()
+    })
+    .then((json) => {
       logger.debug(`SERVER uploadimage success: ${JSON.stringify(json)}`)
       callback(null, json.data.link.replace(/^http:\/\//i, 'https://'))
-    }).catch(function (err) {
+    }).catch((err) => {
       callback(new Error(err), null)
     })
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "helmet": "^4.0.0",
     "highlight.js": "^10.0.0",
     "i18n": "^0.13.0",
-    "imgur": "git+https://github.com/hackmdio/node-imgur.git",
     "ionicons": "^2.0.1",
     "is-svg": "^4.3.1",
     "jquery": "^3.5.1",

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -3,7 +3,10 @@
 ### Features
 - Database migrations are now automatically applied on application startup.  
   The separate `.sequelizerc` configuration file is no longer necessary and can be safely deleted.
-  
+
+### Enhancements
+- Removed dependency on external imgur library
+ 
 ## <i class="fa fa-tag"></i> 1.7.2 <i class="fa fa-calendar-o"></i> 2021-01-15
 This release fixes a security issue. We recommend upgrading as soon as possible.
 ### Security Fixes

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,7 +448,6 @@
 
 "Idle.Js@git+https://github.com/shawnmclean/Idle.js":
   version "0.0.1"
-  uid db9beb3483a460ad638ec947867720f0ed066a62
   resolved "git+https://github.com/shawnmclean/Idle.js#db9beb3483a460ad638ec947867720f0ed066a62"
 
 JSV@^4.0.x:
@@ -750,11 +749,6 @@ arraybuffer.slice@~0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
-
-asap@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
 asn1.js@^5.2.0:
   version "5.4.1"
@@ -2193,7 +2187,6 @@ code-point-at@^1.0.0:
 
 "codemirror@git+https://github.com/hedgedoc/CodeMirror.git":
   version "5.58.2"
-  uid f780b569b3717cdff4c8507538cc63101bfa02e1
   resolved "git+https://github.com/hedgedoc/CodeMirror.git#f780b569b3717cdff4c8507538cc63101bfa02e1"
 
 collection-visit@^1.0.0:
@@ -2277,7 +2270,7 @@ combined-stream@^1.0.5, combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.11.0, commander@^2.13.0, commander@^2.19.0, commander@^2.20.0, commander@^2.20.3:
+commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3225,7 +3218,6 @@ detect-libc@^1.0.2:
 
 "diff-match-patch@git+https://github.com/hackmdio/diff-match-patch.git":
   version "1.1.1"
-  uid c2f8fb9d69aa9490b764850aa86ba442c93ccf78
   resolved "git+https://github.com/hackmdio/diff-match-patch.git#c2f8fb9d69aa9490b764850aa86ba442c93ccf78"
 
 diff@5.0.0:
@@ -4928,16 +4920,6 @@ image-size@~0.5.0:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
 
-"imgur@git+https://github.com/hackmdio/node-imgur.git":
-  version "0.5.0"
-  uid de0a7a1f1eb2cb6628385fedb990ad396a190573
-  resolved "git+https://github.com/hackmdio/node-imgur.git#de0a7a1f1eb2cb6628385fedb990ad396a190573"
-  dependencies:
-    commander "^2.13.0"
-    glob "^7.1.2"
-    q "^2.0.3"
-    request "^2.83.0"
-
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -5540,7 +5522,6 @@ js-cookie@^2.1.3:
 
 "js-sequence-diagrams@git+https://github.com/hedgedoc/js-sequence-diagrams.git":
   version "2.0.1"
-  uid bda0e49b6c2754f3c7158b1dfb9ccf26efc24b39
   resolved "git+https://github.com/hedgedoc/js-sequence-diagrams.git#bda0e49b6c2754f3c7158b1dfb9ccf26efc24b39"
   dependencies:
     lodash "4.17.x"
@@ -6114,7 +6095,6 @@ lutim@^1.0.2:
 
 "lz-string@git+https://github.com/hackmdio/lz-string.git":
   version "1.4.4"
-  uid efd1f64676264d6d8871b01f4f375fc6ef4f9022
   resolved "git+https://github.com/hackmdio/lz-string.git#efd1f64676264d6d8871b01f4f375fc6ef4f9022"
 
 make-dir@^1.0.0:
@@ -6428,7 +6408,6 @@ messageformat@^2.3.0:
 
 "meta-marked@git+https://github.com/hedgedoc/meta-marked":
   version "0.4.5"
-  uid "4fb5cb5a204969cc91e66eee92c0211188e69a2b"
   resolved "git+https://github.com/hedgedoc/meta-marked#4fb5cb5a204969cc91e66eee92c0211188e69a2b"
   dependencies:
     js-yaml "~3.14.0"
@@ -7788,11 +7767,6 @@ pluralize@^8.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
-pop-iterate@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/pop-iterate/-/pop-iterate-1.0.1.tgz#ceacfdab4abf353d7a0f2aaa2c1fc7b3f9413ba3"
-  integrity sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M=
-
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -8286,15 +8260,6 @@ q@^1.1.2, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
-
-q@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/q/-/q-2.0.3.tgz#75b8db0255a1a5af82f58c3f3aaa1efec7d0d134"
-  integrity sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=
-  dependencies:
-    asap "^2.0.0"
-    pop-iterate "^1.0.1"
-    weak-map "^1.0.5"
 
 qs@2.3.3:
   version "2.3.3"
@@ -9144,7 +9109,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2.x, "request@>= 2.52.0", request@^2.83.0, request@^2.86.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
+request@2.x, "request@>= 2.52.0", request@^2.86.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -10939,11 +10904,6 @@ watchpack@^1.7.4:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
-
-weak-map@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.5.tgz#79691584d98607f5070bd3b70a40e6bb22e401eb"
-  integrity sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes=
 
 webfontloader@~1.6.x:
   version "1.6.28"


### PR DESCRIPTION
### Component/Part
Imgur media upload

### Description
This PR replaces the dependency `node-imgur`.
We use a hackmd fork of "node-imgur" for no reason. The upstream lib is way more advanced and modern.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
