### PR TITLE
HistoryService: Add setHistory method 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,12 @@ module.exports = {
             assertFunctionNames: ['expect', 'request.**.expect'],
           },
         ],
+        'jest/no-standalone-expect': [
+          'error',
+          {
+            additionalTestBlockFunctions: ['afterEach', 'beforeAll'],
+          },
+        ],
       },
     },
   ],

--- a/src/api/private/me/history/history.controller.spec.ts
+++ b/src/api/private/me/history/history.controller.spec.ts
@@ -10,7 +10,11 @@ import { LoggerModule } from '../../../../logger/logger.module';
 import { UsersModule } from '../../../../users/users.module';
 import { HistoryModule } from '../../../../history/history.module';
 import { NotesModule } from '../../../../notes/notes.module';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  getConnectionToken,
+  getRepositoryToken,
+  TypeOrmModule,
+} from '@nestjs/typeorm';
 import { User } from '../../../../users/user.entity';
 import { Note } from '../../../../notes/note.entity';
 import { AuthToken } from '../../../../auth/auth-token.entity';
@@ -41,8 +45,11 @@ describe('HistoryController', () => {
           isGlobal: true,
           load: [appConfigMock],
         }),
+        TypeOrmModule.forRoot(),
       ],
     })
+      .overrideProvider(getConnectionToken())
+      .useValue({})
       .overrideProvider(getRepositoryToken(User))
       .useValue({})
       .overrideProvider(getRepositoryToken(Note))

--- a/src/api/private/notes/notes.controller.spec.ts
+++ b/src/api/private/notes/notes.controller.spec.ts
@@ -7,7 +7,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotesController } from './notes.controller';
 import { NotesService } from '../../../notes/notes.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  getConnectionToken,
+  getRepositoryToken,
+  TypeOrmModule,
+} from '@nestjs/typeorm';
 import { Note } from '../../../notes/note.entity';
 import { Tag } from '../../../notes/tag.entity';
 import { RevisionsModule } from '../../../revisions/revisions.module';
@@ -61,8 +65,11 @@ describe('NotesController', () => {
           isGlobal: true,
           load: [appConfigMock, mediaConfigMock],
         }),
+        TypeOrmModule.forRoot(),
       ],
     })
+      .overrideProvider(getConnectionToken())
+      .useValue({})
       .overrideProvider(getRepositoryToken(Note))
       .useValue({})
       .overrideProvider(getRepositoryToken(Revision))

--- a/src/api/public/me/me.controller.spec.ts
+++ b/src/api/public/me/me.controller.spec.ts
@@ -5,7 +5,11 @@
  */
 
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  getConnectionToken,
+  getRepositoryToken,
+  TypeOrmModule,
+} from '@nestjs/typeorm';
 import { HistoryModule } from '../../../history/history.module';
 import { LoggerModule } from '../../../logger/logger.module';
 import { AuthorColor } from '../../../notes/author-color.entity';
@@ -45,8 +49,11 @@ describe('Me Controller', () => {
         NotesModule,
         LoggerModule,
         MediaModule,
+        TypeOrmModule.forRoot(),
       ],
     })
+      .overrideProvider(getConnectionToken())
+      .useValue({})
       .overrideProvider(getRepositoryToken(User))
       .useValue({})
       .overrideProvider(getRepositoryToken(Note))

--- a/src/api/public/notes/notes.controller.spec.ts
+++ b/src/api/public/notes/notes.controller.spec.ts
@@ -5,7 +5,11 @@
  */
 
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  getConnectionToken,
+  getRepositoryToken,
+  TypeOrmModule,
+} from '@nestjs/typeorm';
 import { LoggerModule } from '../../../logger/logger.module';
 import { AuthorColor } from '../../../notes/author-color.entity';
 import { Note } from '../../../notes/note.entity';
@@ -61,8 +65,11 @@ describe('Notes Controller', () => {
           isGlobal: true,
           load: [appConfigMock, mediaConfigMock],
         }),
+        TypeOrmModule.forRoot(),
       ],
     })
+      .overrideProvider(getConnectionToken())
+      .useValue({})
       .overrideProvider(getRepositoryToken(Note))
       .useValue({})
       .overrideProvider(getRepositoryToken(Revision))

--- a/src/history/history.service.spec.ts
+++ b/src/history/history.service.spec.ts
@@ -143,10 +143,8 @@ describe('HistoryService', () => {
     describe('works', () => {
       const user = {} as User;
       const alias = 'alias';
-      const pinStatus = true;
-      const lastVisited = new Date('2020-12-01 12:23:34');
       const historyEntry = HistoryEntry.create(user, Note.create(user, alias));
-      it('without an preexisting entry, without pinStatus and without lastVisited', async () => {
+      it('without an preexisting entry', async () => {
         jest.spyOn(historyRepo, 'findOne').mockResolvedValueOnce(undefined);
         jest
           .spyOn(historyRepo, 'save')
@@ -163,65 +161,7 @@ describe('HistoryService', () => {
         expect(createHistoryEntry.pinStatus).toEqual(false);
       });
 
-      it('without an preexisting entry, with pinStatus and without lastVisited', async () => {
-        jest.spyOn(historyRepo, 'findOne').mockResolvedValueOnce(undefined);
-        jest
-          .spyOn(historyRepo, 'save')
-          .mockImplementation(
-            async (entry: HistoryEntry): Promise<HistoryEntry> => entry,
-          );
-        const createHistoryEntry = await service.createOrUpdateHistoryEntry(
-          Note.create(user, alias),
-          user,
-          pinStatus,
-        );
-        expect(createHistoryEntry.note.alias).toEqual(alias);
-        expect(createHistoryEntry.note.owner).toEqual(user);
-        expect(createHistoryEntry.user).toEqual(user);
-        expect(createHistoryEntry.pinStatus).toEqual(pinStatus);
-      });
-
-      it('without an preexisting entry, without pinStatus and with lastVisited', async () => {
-        jest.spyOn(historyRepo, 'findOne').mockResolvedValueOnce(undefined);
-        jest
-          .spyOn(historyRepo, 'save')
-          .mockImplementation(
-            async (entry: HistoryEntry): Promise<HistoryEntry> => entry,
-          );
-        const createHistoryEntry = await service.createOrUpdateHistoryEntry(
-          Note.create(user, alias),
-          user,
-          undefined,
-          lastVisited,
-        );
-        expect(createHistoryEntry.note.alias).toEqual(alias);
-        expect(createHistoryEntry.note.owner).toEqual(user);
-        expect(createHistoryEntry.user).toEqual(user);
-        expect(createHistoryEntry.pinStatus).toEqual(false);
-        expect(createHistoryEntry.updatedAt).toEqual(lastVisited);
-      });
-
-      it('without an preexisting entry, with pinStatus and with lastVisited', async () => {
-        jest.spyOn(historyRepo, 'findOne').mockResolvedValueOnce(undefined);
-        jest
-          .spyOn(historyRepo, 'save')
-          .mockImplementation(
-            async (entry: HistoryEntry): Promise<HistoryEntry> => entry,
-          );
-        const createHistoryEntry = await service.createOrUpdateHistoryEntry(
-          Note.create(user, alias),
-          user,
-          pinStatus,
-          lastVisited,
-        );
-        expect(createHistoryEntry.note.alias).toEqual(alias);
-        expect(createHistoryEntry.note.owner).toEqual(user);
-        expect(createHistoryEntry.user).toEqual(user);
-        expect(createHistoryEntry.pinStatus).toEqual(pinStatus);
-        expect(createHistoryEntry.updatedAt).toEqual(lastVisited);
-      });
-
-      it('with an preexisting entry, without pinStatus and without lastVisited', async () => {
+      it('with an preexisting entry', async () => {
         jest.spyOn(historyRepo, 'findOne').mockResolvedValueOnce(historyEntry);
         jest
           .spyOn(historyRepo, 'save')
@@ -239,67 +179,6 @@ describe('HistoryService', () => {
         expect(createHistoryEntry.updatedAt.getTime()).toBeGreaterThanOrEqual(
           historyEntry.updatedAt.getTime(),
         );
-      });
-
-      it('with an preexisting entry, with pinStatus and without lastVisited', async () => {
-        jest.spyOn(historyRepo, 'findOne').mockResolvedValueOnce(historyEntry);
-        jest
-          .spyOn(historyRepo, 'save')
-          .mockImplementation(
-            async (entry: HistoryEntry): Promise<HistoryEntry> => entry,
-          );
-        const createHistoryEntry = await service.createOrUpdateHistoryEntry(
-          Note.create(user, alias),
-          user,
-          pinStatus,
-        );
-        expect(createHistoryEntry.note.alias).toEqual(alias);
-        expect(createHistoryEntry.note.owner).toEqual(user);
-        expect(createHistoryEntry.user).toEqual(user);
-        expect(createHistoryEntry.pinStatus).not.toEqual(pinStatus);
-        expect(createHistoryEntry.updatedAt.getTime()).toBeGreaterThanOrEqual(
-          historyEntry.updatedAt.getTime(),
-        );
-      });
-
-      it('with an preexisting entry, without pinStatus and with lastVisited', async () => {
-        jest.spyOn(historyRepo, 'findOne').mockResolvedValueOnce(historyEntry);
-        jest
-          .spyOn(historyRepo, 'save')
-          .mockImplementation(
-            async (entry: HistoryEntry): Promise<HistoryEntry> => entry,
-          );
-        const createHistoryEntry = await service.createOrUpdateHistoryEntry(
-          Note.create(user, alias),
-          user,
-          undefined,
-          lastVisited,
-        );
-        expect(createHistoryEntry.note.alias).toEqual(alias);
-        expect(createHistoryEntry.note.owner).toEqual(user);
-        expect(createHistoryEntry.user).toEqual(user);
-        expect(createHistoryEntry.pinStatus).toEqual(false);
-        expect(createHistoryEntry.updatedAt).not.toEqual(lastVisited);
-      });
-
-      it('with an preexisting entry, with pinStatus and with lastVisited', async () => {
-        jest.spyOn(historyRepo, 'findOne').mockResolvedValueOnce(historyEntry);
-        jest
-          .spyOn(historyRepo, 'save')
-          .mockImplementation(
-            async (entry: HistoryEntry): Promise<HistoryEntry> => entry,
-          );
-        const createHistoryEntry = await service.createOrUpdateHistoryEntry(
-          Note.create(user, alias),
-          user,
-          pinStatus,
-          lastVisited,
-        );
-        expect(createHistoryEntry.note.alias).toEqual(alias);
-        expect(createHistoryEntry.note.owner).toEqual(user);
-        expect(createHistoryEntry.user).toEqual(user);
-        expect(createHistoryEntry.pinStatus).not.toEqual(pinStatus);
-        expect(createHistoryEntry.updatedAt).not.toEqual(lastVisited);
       });
     });
   });

--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -80,25 +80,15 @@ export class HistoryService {
    * Create or update a history entry by the user and note. If the entry is merely updated the updatedAt date is set to the current date.
    * @param {Note} note - the note that the history entry belongs to
    * @param {User} user - the user that the history entry belongs to
-   * @param {boolean} pinStatus - if the pinStatus of the history entry should be set
-   * @param {Date} lastVisited - the last time the associated note was accessed
    * @return {HistoryEntry} the requested history entry
    */
   async createOrUpdateHistoryEntry(
     note: Note,
     user: User,
-    pinStatus?: boolean,
-    lastVisited?: Date,
   ): Promise<HistoryEntry> {
     let entry = await this.getEntryByNote(note, user);
     if (!entry) {
       entry = HistoryEntry.create(user, note);
-      if (pinStatus !== undefined) {
-        entry.pinStatus = pinStatus;
-      }
-      if (lastVisited !== undefined) {
-        entry.updatedAt = lastVisited;
-      }
     } else {
       entry.updatedAt = new Date();
     }


### PR DESCRIPTION
### Component/Part
history service

### Description
This PR reimplements the business logic of the history controllers setHistory method (of the private api) in the history serivce in  a transactional way. This should prevent the problem that the history gets deleted, but a later error in the handling of the list of HistoryEntryImportDto let's the call fail.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #1126 