### PR TITLE
Guest notes auto-lock

### DIFF
--- a/app.js
+++ b/app.js
@@ -276,6 +276,13 @@ models.sequelize.authenticate().then(function () {
     } else {
       throw new Error('server still not ready after db synced')
     }
+    // Allow to timeout-lock guest notes so they can no longer be changed after the timeout period
+    if (config.lockGuestNotes.timeout > 0) {
+      setInterval(models.Note.lockOldGuestNotes, (config.lockGuestNotes.timeout / 2) * 1000, config.lockGuestNotes.timeout, config.lockGuestNotes.permission)
+      // Additional call of the lockOldGuestNotes function to make sure notes that weren't locked during the last app run, can get locked.
+      // We run this 30 seconds after start, to give the app a bit of warmup, but not waiting too long.
+      setTimeout(models.Note.lockOldGuestNotes, 30 * 1000, config.lockGuestNotes.timeout, config.lockGuestNotes.permission)
+    }
   })
 })
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -102,6 +102,14 @@ these are rarely used for various reasons.
 | `sessionLife`         | `CMD_SESSION_LIFE`          | **`14 * 24 * 60 * 60 * 1000`**, `1209600000` (14 days)                  | Cookie session life time in milliseconds.                                                                                                                      |
 | `sessionSecret`       | `CMD_SESSION_SECRET`        | **`secret`**                                                            | Cookie session secret used to sign the session cookie. If none is set, one will randomly generated on each startup, meaning all your users will be logged out. |
 
+## Guest Notes autolock
+
+| config file           | environment                 | **default** and example value                                           | description                                                                                                                                                    |
+| --------------------- | --------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lockGuestNotes` | | `{ timeout: 0,  permission: 'locked' }` | If the `timeout` setting is `>` 0, the autolock feature is activated. It'll automatically set the permission of guest notes, which have a creation date older than the timeout setting, to the permission defined in the `permission` setting. |
+| | `CMD_LOCKGUESTNOTES_TIMEOUT` | `0` | This is the maximum age in seconds a note is allowed to have before before the `CMD_LOCKGUESTNOTES_PERMISSION` is applied to it. If the timeout is set to 0, the autolock feature is disabled |
+| | `CMD_LOCKGUESTNOTES_PERMISSION` | `locked` | This variable defines the permission used when locking guest notes. |
+
 ## Login methods
 
 ### Email (local account)

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -175,5 +175,9 @@ module.exports = {
   //    Generated id:   "31-good-morning-my-friend---do-you-have-5"
   //    2nd appearance: "31-good-morning-my-friend---do-you-have-5-1"
   //    3rd appearance: "31-good-morning-my-friend---do-you-have-5-2"
-  linkifyHeaderStyle: 'keep-case'
+  linkifyHeaderStyle: 'keep-case',
+  lockGuestNotes: {
+    timeout: 0,
+    permission: 'locked'
+  }
 }

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -142,5 +142,9 @@ module.exports = {
   allowEmailRegister: toBooleanConfig(process.env.CMD_ALLOW_EMAIL_REGISTER),
   allowGravatar: toBooleanConfig(process.env.CMD_ALLOW_GRAVATAR),
   openID: toBooleanConfig(process.env.CMD_OPENID),
-  linkifyHeaderStyle: process.env.CMD_LINKIFY_HEADER_STYLE
+  linkifyHeaderStyle: process.env.CMD_LINKIFY_HEADER_STYLE,
+  lockGuestNotes: {
+    timeout: process.env.CMD_LOCKGUESTNOTES_TIMEOUT,
+    permission: process.env.CMD_LOCKGUESTNOTES_PERMISSION
+  }
 }

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -80,6 +80,15 @@ if (!(config.defaultPermission in config.permission)) {
   config.defaultPermission = config.permission.editable
 }
 
+if (!(config.lockGuestNotes.permission in config.permission)) {
+  logger.error('Invalid lockGuestNotes permission: %s\nAvailable permissions are: %s', config.lockGuestNotes, Object.keys(config.permission).toString())
+}
+
+if (!(config.lockGuestNotes.timeout >= 0)) {
+  logger.warn('Invalid lockGuestNotes timeout. Timeout has to be positive number. Disabled feature.')
+  config.lockGuestNotes.timeout = 0
+}
+
 // cache result, cannot change config in runtime!!!
 config.isStandardHTTPsPort = (function isStandardHTTPsPort () {
   return config.useSSL && config.port === 443

--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -22,6 +22,8 @@ const logger = require('../logger')
 // ot
 const ot = require('../ot')
 
+const Op = Sequelize.Op
+
 // permission types
 const permissionTypes = ['freely', 'editable', 'limited', 'locked', 'protected', 'private']
 
@@ -582,6 +584,35 @@ module.exports = function (sequelize, DataTypes) {
       }
     }
     return operations
+  }
+
+  Note.lockOldGuestNotes = async function (secondsUntilLock, permission) {
+    if (typeof secondsUntilLock !== 'number') {
+      throw new Error("Parameter 'secondsUntilLock' has to be of type 'number'")
+    }
+    if (!permissionTypes.includes(permission)) {
+      throw new Error('Unexpected permission for locking old guest notes')
+    }
+    const notes = await Note.findAll({
+      attributes: ['id'],
+      where: {
+        // Only guest notes
+        ownerId: null,
+        // Select only notes whose permissions require adjustment
+        permission: {
+          [Op.ne]: permission
+        },
+        // Select only notes who are beyond the timeout
+        createdAt: {
+          [Op.lt]: new Date(new Date() - secondsUntilLock * 1000)
+        }
+      }
+    })
+    notes.forEach(async function (note) {
+      note.permission = permission
+      await note.save()
+      logger.info(`Locked guest note ${note.id}`)
+    })
   }
 
   return Note

--- a/lib/realtime.js
+++ b/lib/realtime.js
@@ -625,31 +625,42 @@ function updateUserData (socket, user) {
 function ifMayEdit (socket, callback) {
   const noteId = socket.noteId
   if (!noteId || !notes[noteId]) return
-  const note = notes[noteId]
-  let mayEdit = true
-  switch (note.permission) {
-    case 'freely':
-      // not blocking anyone
-      break
-    case 'editable': case 'limited':
-      // only login user can change
-      if (!socket.request.user || !socket.request.user.logged_in) { mayEdit = false }
-      break
-    case 'locked': case 'private': case 'protected':
-      // only owner can change
-      if (!note.owner || note.owner !== socket.request.user.id) { mayEdit = false }
-      break
-  }
-  // if user may edit and this is a text operation
-  if (socket.origin === 'operation' && mayEdit) {
-    // save for the last change user id
-    if (socket.request.user && socket.request.user.logged_in) {
-      note.lastchangeuser = socket.request.user.id
-    } else {
-      note.lastchangeuser = null
+  models.Note.findOne({
+    where: {
+      id: noteId
+    },
+    attributes: ['id', 'permission']
+  }).then(function (note) {
+    let mayEdit = true
+    switch (note.permission) {
+      case 'freely':
+        // not blocking anyone
+        break
+      case 'editable': case 'limited':
+        // only login user can change
+        if (!socket.request.user || !socket.request.user.logged_in) { mayEdit = false }
+        break
+      case 'locked': case 'private': case 'protected':
+        // only owner can change
+        if (!note.owner || note.owner !== socket.request.user.id) { mayEdit = false }
+        break
     }
-  }
-  return callback(mayEdit)
+    // if user may edit and this is a text operation
+    if (socket.origin === 'operation' && mayEdit) {
+      // save for the last change user id
+      if (socket.request.user && socket.request.user.logged_in) {
+        note.lastchangeuser = socket.request.user.id
+      } else {
+        note.lastchangeuser = null
+      }
+    }
+    return callback(mayEdit)
+  }).catch(function (error) {
+    logger.error(error)
+    // false is required here in as the callback function only expects a boolean.
+    // Not accepting changes the best way to handle such an unknown situation is to not accept changes.
+    return callback(false) // eslint-disable-line node/no-callback-literal
+  })
 }
 
 function operationCallback (socket, operation) {

--- a/lib/realtime.js
+++ b/lib/realtime.js
@@ -629,20 +629,29 @@ function ifMayEdit (socket, callback) {
     where: {
       id: noteId
     },
+    include: [{
+      model: models.User,
+      as: 'owner',
+      attributes: ['id']
+    }],
     attributes: ['id', 'permission']
   }).then(function (note) {
-    let mayEdit = true
+    let mayEdit = false
     switch (note.permission) {
       case 'freely':
+        mayEdit = true
         // not blocking anyone
         break
-      case 'editable': case 'limited':
+      case 'editable':
+      case 'limited':
         // only login user can change
-        if (!socket.request.user || !socket.request.user.logged_in) { mayEdit = false }
+        mayEdit = (socket.request.user && socket.request.user.logged_in)
         break
-      case 'locked': case 'private': case 'protected':
+      case 'locked':
+      case 'private':
+      case 'protected':
         // only owner can change
-        if (!note.owner || note.owner !== socket.request.user.id) { mayEdit = false }
+        mayEdit = (note.owner && socket.request.user && note.owner.id === socket.request.user.id)
         break
     }
     // if user may edit and this is a text operation


### PR DESCRIPTION
### Component/Part
Guest Notes

### Description
This patch adds a basic implementation for an auto-lock feature for guest
notes. It uses the config options `CMD_LOCKGUESTNOTES_TIMEOUT` to set
a timeout in seconds when a note should be locked. As well as
`CMD_LOCKGUESTNOTES_PERMISSION` to set the desired permission.

It is possible to extend this feature later on to allow a deletion of
notes or to lock the note based on the absence of activity instead of
statically based on its creation date. However this patch doesn't
facilitate those possibilities.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
https://matrix.to/#/!ybaSlrrMNLeuoQuUuR:matrix.org/$1618218839141841VlNVd:matrix.org?via=matrix.org&via=kif.rocks&via=tchncs.de
