### PR TITLE
Utils: Fix getServerVersionFromPackageJson

### DIFF
--- a/src/utils/serverVersion.spec.ts
+++ b/src/utils/serverVersion.spec.ts
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { promises as fs } from 'fs';
+import { getServerVersionFromPackageJson } from './serverVersion';
+
+it('getServerVersionFromPackageJson works', async () => {
+  const major = 2;
+  const minor = 0;
+  const patch = 0;
+  const preRelease = 'dev';
+  /* eslint-disable @typescript-eslint/require-await*/
+  jest.spyOn(fs, 'readFile').mockImplementationOnce(async (_) => {
+    return `{
+"version": "${major}.${minor}.${patch}"
+}
+`;
+  });
+  const serverVersion = await getServerVersionFromPackageJson();
+  expect(serverVersion.major).toEqual(major);
+  expect(serverVersion.minor).toEqual(minor);
+  expect(serverVersion.patch).toEqual(patch);
+  expect(serverVersion.preRelease).toEqual(preRelease);
+});

--- a/src/utils/serverVersion.ts
+++ b/src/utils/serverVersion.ts
@@ -11,7 +11,7 @@ import { join as joinPath } from 'path';
 let versionCache: ServerVersion;
 
 export async function getServerVersionFromPackageJson(): Promise<ServerVersion> {
-  if (versionCache === null) {
+  if (versionCache === undefined) {
     const rawFileContent: string = await fs.readFile(
       joinPath(__dirname, '../../package.json'),
       { encoding: 'utf8' },


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
This PR fixes the getServerVersionFromPackageJson utility function.

The cache is never null, because it defaults to undefined, and therefore this function always returns undefined.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x