### PR TITLE
Interceptor: Add version interceptor

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,15 +14,17 @@ import { MediaConfig } from './config/media.config';
 import { NestConsoleLoggerService } from './logger/nest-console-logger.service';
 import { setupPrivateApiDocs, setupPublicApiDocs } from './utils/swagger';
 import { BackendType } from './media/backends/backend-type.enum';
+import { AddVersionInterceptor } from './utils/version.interceptor';
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
   const logger = await app.resolve(NestConsoleLoggerService);
-  logger.log('Switching logger', 'AppBootstrap');
-  app.useLogger(logger);
   const configService = app.get(ConfigService);
   const appConfig = configService.get<AppConfig>('appConfig');
   const mediaConfig = configService.get<MediaConfig>('mediaConfig');
+  logger.log('Switching logger', 'AppBootstrap');
+  app.useLogger(logger);
+  app.useGlobalInterceptors(new AddVersionInterceptor(appConfig));
 
   setupPublicApiDocs(app);
   if (process.env.NODE_ENV === 'development') {

--- a/src/utils/serverVersion.spec.ts
+++ b/src/utils/serverVersion.spec.ts
@@ -5,23 +5,36 @@
  */
 
 import { promises as fs } from 'fs';
-import { getServerVersionFromPackageJson } from './serverVersion';
+import {
+  getServerVersionFromPackageJson,
+  getVersionString,
+} from './serverVersion';
 
-it('getServerVersionFromPackageJson works', async () => {
+describe('serverVersion', () => {
   const major = 2;
   const minor = 0;
   const patch = 0;
   const preRelease = 'dev';
-  /* eslint-disable @typescript-eslint/require-await*/
-  jest.spyOn(fs, 'readFile').mockImplementationOnce(async (_) => {
-    return `{
+  beforeEach(() => {
+    /* eslint-disable @typescript-eslint/require-await*/
+  jest.spyOn(fs, 'readFile').mockImplementationOnce(async (path, _) => {
+      return `{
 "version": "${major}.${minor}.${patch}"
 }
 `;
+    });
   });
-  const serverVersion = await getServerVersionFromPackageJson();
-  expect(serverVersion.major).toEqual(major);
-  expect(serverVersion.minor).toEqual(minor);
-  expect(serverVersion.patch).toEqual(patch);
-  expect(serverVersion.preRelease).toEqual(preRelease);
+
+  it('getServerVersionFromPackageJson works', async () => {
+    const serverVersion = await getServerVersionFromPackageJson();
+    expect(serverVersion.major).toEqual(major);
+    expect(serverVersion.minor).toEqual(minor);
+    expect(serverVersion.patch).toEqual(patch);
+    expect(serverVersion.preRelease).toEqual(preRelease);
+  });
+
+  it('getVersionString', async () => {
+    const version = await getVersionString();
+    expect(version).toEqual(`${major}.${minor}.${patch}-${preRelease}`);
+  });
 });

--- a/src/utils/serverVersion.ts
+++ b/src/utils/serverVersion.ts
@@ -32,3 +32,15 @@ export async function getServerVersionFromPackageJson(): Promise<ServerVersion> 
 
   return versionCache;
 }
+
+export async function getVersionString(): Promise<string> {
+  const serverVersion = await this.getServerVersionFromPackageJson();
+  let versionString = `${serverVersion.major}.${serverVersion.minor}.${serverVersion.patch}`;
+  if (serverVersion.preRelease) {
+    versionString += `-${serverVersion.preRelease}`;
+  }
+  if (serverVersion.commit) {
+    return serverVersion.commit;
+  }
+  return versionString;
+}

--- a/src/utils/version.interceptor.ts
+++ b/src/utils/version.interceptor.ts
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Inject,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import appConfiguration, { AppConfig } from '../config/app.config';
+import { getVersionString } from './serverVersion';
+
+@Injectable()
+export class AddVersionInterceptor<T> implements NestInterceptor {
+  constructor(
+    @Inject(appConfiguration.KEY)
+    private appConfig: AppConfig,
+  ) {}
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<T>> {
+    return next.handle().pipe(
+      tap(async () => {
+        const version = await getVersionString();
+        let response = context.switchToHttp().getResponse();
+        response.header('HedgeDoc-Version', version);
+      }),
+    );
+  }
+}


### PR DESCRIPTION
### Component/Part
version interceptor

### Description
This PR adds a version interceptor.

This interceptor adds the header `HedgeDoc-Version` to all responses of the api. This should make it easy to identify the version of HedgeDoc that answers each request. Also this is the same behavior the 1.x code showed.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x