### PR TITLE
README: Change order of paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ more details.
 
 ## Community and Contributions
 
-We welcome contributions!  
-Have a look at our [contribution docs](CONTRIBUTING.md) to find out how you can help. If you want to contribute to
-HedgeDoc 2, please join our [development chat][matrix.org-dev-url].
-
 To stay up to date with our work or get support it's recommended to join our
 [Matrix channel][matrix.org-url], stop by our [community forums][hedgedoc-community]
 or subscribe to the [release feed][github-release-feed]. We also engage in
 regular [community calls][hedgedoc-community-calls] ([RSS](https://community.codimd.org/t/codimd-community-call/19.rss))
 which you are very welcome to join.
+
+We welcome contributions!  
+Have a look at our [contribution docs](CONTRIBUTING.md) to find out how you can help. If you want to contribute to
+HedgeDoc 2, please join our [development chat][matrix.org-dev-url].
 
 # License
 


### PR DESCRIPTION
### Component/Part
readme

### Description
This PR switches paragraphs in the readme around.

With this change our support chat is mentioned before our dev chat. Hopefully that should direct people in the correct chat for them…


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
