### PR TITLE
Raise minimum required Node.js version to 12 [master]

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x, 16.x]
+        node-version: [12.x, 14.x, 15.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x, 16.x]
+        node-version: [12.x, 14.x, 15.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/bin/setup
+++ b/bin/setup
@@ -23,7 +23,7 @@ fi
 
 if version_lt "$(yarn --version)" '1.22.0'; then
   cat << EOF
-FATAL: Your Yarn version is outdated.
+FATAL: Your Yarn version is not supported.
 
 Please upgrade to version 1.22.0 or higher and try again.
 See https://classic.yarnpkg.com/en/docs/install for instructions.
@@ -33,7 +33,7 @@ fi
 
 if version_lt "$(node --version)" 'v12.0.0'; then
   cat << EOF
-FATAL: Your Node.js version is outdated.
+FATAL: Your Node.js version is not supported.
 
 Please upgrade to version 12 or higher and try again.
 We recommend running the latest LTS release, see https://nodejs.org/en/about/releases/ for details.

--- a/bin/setup
+++ b/bin/setup
@@ -31,11 +31,11 @@ EOF
   exit 1
 fi
 
-if version_lt "$(node --version)" 'v10.13.0'; then
+if version_lt "$(node --version)" 'v12.0.0'; then
   cat << EOF
 FATAL: Your Node.js version is outdated.
 
-Please upgrade to version 10.13 or higher and try again.
+Please upgrade to version 12 or higher and try again.
 We recommend running the latest LTS release, see https://nodejs.org/en/about/releases/ for details.
 EOF
   exit 1

--- a/docs/content/setup/manual-setup.md
+++ b/docs/content/setup/manual-setup.md
@@ -1,7 +1,7 @@
 # Manual Installation
 
 !!! info "Requirements on your server"
-    - Node.js 10.13 or higher
+    - Node.js 12 or higher
     - Database (PostgreSQL, MySQL, MariaDB, SQLite, MSSQL)  
       The database must use charset `utf8`. This is typically the default in PostgreSQL and SQLite.  
       In MySQL and MariaDB UTF-8 might need to be set with `alter database <DBNAME> character set utf8 collate utf8_bin;`  

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "**/request": "^2.88.0"
   },
   "engines": {
-    "node": ">=10.13"
+    "node": ">=12"
   },
   "bugs": "https://github.com/hedgedoc/hedgedoc/issues",
   "keywords": [

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -1,5 +1,8 @@
 # Release Notes
 ## <i class="fa fa-tag"></i> 1.8.0 <i class="fa fa-calendar-o"></i> UNRELEASED
+
+**Please note:** This release dropped support for Node 10, which is end-of-life since April 2021. You now need at least Node 12 to run HedgeDoc, but we recommend running [the latest LTS release](https://nodejs.org/en/about/releases/).
+
 ### Features
 - Database migrations are now automatically applied on application startup.  
   The separate `.sequelizerc` configuration file is no longer necessary and can be safely deleted.


### PR DESCRIPTION
### Component/Part
package metadata, docs, setup script, CI

### Description
As Node 10 will be EOL at April 30th, we should stop supporting
and/or promoting the usage of that version.

See also https://endoflife.date/nodejs
### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
