### PR TITLE
Media E2E tests: Add error handling for upload cleanup

### DIFF
--- a/test/private-api/media.e2e-spec.ts
+++ b/test/private-api/media.e2e-spec.ts
@@ -26,6 +26,7 @@ import { join } from 'path';
 import { PrivateApiModule } from '../../src/api/private/private-api.module';
 import { UsersService } from '../../src/users/users.service';
 import { ConsoleLoggerService } from '../../src/logger/console-logger.service';
+import { ensureDeleted } from '../utils';
 
 describe('Media', () => {
   let app: NestExpressApplication;
@@ -95,7 +96,7 @@ describe('Media', () => {
     });
     describe('fails:', () => {
       beforeEach(async () => {
-        await fs.rmdir(uploadPath, { recursive: true });
+        await ensureDeleted(uploadPath);
       });
       it('MIME type not supported', async () => {
         await request(app.getHttpServer())
@@ -125,14 +126,14 @@ describe('Media', () => {
           .expect(500);
       });
       afterEach(async () => {
-        await fs.rmdir(uploadPath, { recursive: true });
+        await ensureDeleted(uploadPath);
       });
     });
   });
 
   afterAll(async () => {
     // Delete the upload folder
-    await fs.rmdir(uploadPath, { recursive: true });
+    await ensureDeleted(uploadPath);
     await app.close();
   });
 });

--- a/test/public-api/media.e2e-spec.ts
+++ b/test/public-api/media.e2e-spec.ts
@@ -25,6 +25,7 @@ import { TokenAuthGuard } from '../../src/auth/token-auth.guard';
 import { MockAuthGuard } from '../../src/auth/mock-auth.guard';
 import { join } from 'path';
 import { ConsoleLoggerService } from '../../src/logger/console-logger.service';
+import { ensureDeleted } from '../utils';
 
 describe('Media', () => {
   let app: NestExpressApplication;
@@ -91,7 +92,7 @@ describe('Media', () => {
     });
     describe('fails:', () => {
       beforeEach(async () => {
-        await fs.rmdir(uploadPath, { recursive: true });
+        await ensureDeleted(uploadPath);
       });
       it('MIME type not supported', async () => {
         await request(app.getHttpServer())
@@ -121,7 +122,7 @@ describe('Media', () => {
           .expect(500);
       });
       afterEach(async () => {
-        await fs.rmdir(uploadPath, { recursive: true });
+        await ensureDeleted(uploadPath);
       });
     });
   });
@@ -141,7 +142,7 @@ describe('Media', () => {
 
   afterAll(async () => {
     // Delete the upload folder
-    await fs.rmdir(uploadPath, { recursive: true });
+    await ensureDeleted(uploadPath);
     await app.close();
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { promises as fs } from 'fs';
+
+/**
+ * Ensures the directory at `path` is deleted.
+ * If `path` does not exist, nothing happens.
+ */
+export async function ensureDeleted(path: string): Promise<void> {
+  try {
+    await fs.rmdir(path, { recursive: true });
+  } catch (e) {
+    if (e.code && e.code == 'ENOENT') {
+      // ignore error, path is already deleted
+      return;
+    }
+    throw e;
+  }
+}


### PR DESCRIPTION
### Component/Part
E2E tests

### Description
Previously, `fs.rmdir` was called multiple times on the same path,
even when the path was already deleted.
This causes test failures in Node 16.

This PR extracts the cleanup code into a utility function
and ensures that no error is thrown when the given path is already deleted.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
