### PR TITLE
FilesystemBackend: Fix functionContext logging

### DIFF
--- a/src/media/backends/filesystem-backend.ts
+++ b/src/media/backends/filesystem-backend.ts
@@ -58,19 +58,24 @@ export class FilesystemBackend implements MediaBackend {
   }
 
   private async ensureDirectory(): Promise<void> {
+    this.logger.debug(
+      `Ensuring presence of directory at ${this.uploadDirectory}`,
+      'ensureDirectory',
+    );
     try {
       await fs.access(this.uploadDirectory);
     } catch (e) {
       try {
         this.logger.debug(
           `The directory '${this.uploadDirectory}' can't be accessed. Trying to create the directory`,
+          'ensureDirectory',
         );
         await fs.mkdir(this.uploadDirectory);
       } catch (e) {
         this.logger.error(
           (e as Error).message,
           (e as Error).stack,
-          'deleteFile',
+          'ensureDirectory',
         );
         throw new MediaBackendError(
           `Could not create '${this.uploadDirectory}'`,


### PR DESCRIPTION
### Component/Part
FilesystemBackend

### Description
This PR adds a few missing `functionContext` parameters in calls to
`this.logger` and fixes a copy-paste error in `ensureDirectory`

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
