### PR TITLE
AppConfigMock: Use correct loglevel

### DIFF
--- a/src/config/mock/app.config.mock.ts
+++ b/src/config/mock/app.config.mock.ts
@@ -5,13 +5,13 @@
  */
 
 import { registerAs } from '@nestjs/config';
-import { LogLevel } from 'ts-loader/dist/logger';
+import { Loglevel } from '../loglevel.enum';
 
 export default registerAs('appConfig', () => ({
   domain: 'md.example.com',
   rendererOrigin: 'md-renderer.example.com',
   port: 3000,
-  loglevel: LogLevel.ERROR,
+  loglevel: Loglevel.ERROR,
   maxDocumentLength: 100000,
   forbiddenNoteIds: ['forbiddenNoteId'],
 }));


### PR DESCRIPTION
### Component/Part
app config mock

### Description

Until now the app config mock used ts-loader's LogLevel instead of our own Loglevel, which is obviously wrong. This PR fixes that.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x