### PR TITLE
Services: Ensure null is replaced with an empty string

### DIFF
--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -168,7 +168,7 @@ export class HistoryService {
       identifier: entry.note.alias ? entry.note.alias : entry.note.id,
       lastVisited: entry.updatedAt,
       tags: this.notesService.toTagList(entry.note),
-      title: entry.note.title,
+      title: entry.note.title ?? '',
       pinStatus: entry.pinStatus,
     };
   }

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -352,9 +352,9 @@ export class NotesService {
       // TODO: Convert DB UUID to base64
       id: note.id,
       alias: note.alias,
-      title: note.title,
+      title: note.title ?? '',
       createTime: (await this.getFirstRevision(note)).createdAt,
-      description: note.description,
+      description: note.description ?? '',
       editedBy: note.authorColors.map(
         (authorColor) => authorColor.user.userName,
       ),

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -233,8 +233,8 @@ describe('Notes', () => {
         .expect(200);
       expect(typeof metadata.body.id).toEqual('string');
       expect(metadata.body.alias).toEqual('test5');
-      expect(metadata.body.title).toBeNull();
-      expect(metadata.body.description).toBeNull();
+      expect(metadata.body.title).toEqual('');
+      expect(metadata.body.description).toEqual('');
       expect(typeof metadata.body.createTime).toEqual('string');
       expect(metadata.body.editedBy).toEqual([]);
       expect(metadata.body.permissions.owner.userName).toEqual('hardcoded');


### PR DESCRIPTION
### Component/Part
services

### Description
This PR changes some toDto methods to replace null or undefined with an empty string.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x