### PR TITLE
Gitignore: Add .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ backups/
 # ignore config files
 config.json
 .sequelizerc
+.env
 
 # ignore webpack build
 public/build


### PR DESCRIPTION
### Component/Part
`.gitignore`

### Description
Because the new config is done via the file `.env`, it should not be possible to include it in the git repository.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x