### PR TITLE
Remove banner from frontend config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@ dist
 
 public/uploads/*
 !public/uploads/.gitkeep
+!public/.gitkeep
 uploads
 test_uploads

--- a/src/frontend-config/frontend-config.dto.ts
+++ b/src/frontend-config/frontend-config.dto.ts
@@ -7,7 +7,6 @@
 import {
   IsArray,
   IsBoolean,
-  IsDate,
   IsNumber,
   IsOptional,
   IsString,
@@ -76,22 +75,6 @@ export class AuthProviders {
    */
   @IsBoolean()
   internal: boolean;
-}
-
-export class BannerDto {
-  /**
-   * The text that is shown in the banner
-   * @example This is a test banner
-   */
-  @IsString()
-  text: string;
-
-  /**
-   * When the banner was last changed
-   * @example "2020-12-01 12:23:34"
-   */
-  @IsDate()
-  updateTime: Date;
 }
 
 export class BrandingDto {
@@ -226,12 +209,6 @@ export class FrontendConfigDto {
    */
   @ValidateNested()
   branding: BrandingDto;
-
-  /**
-   * An optional banner that will be shown
-   */
-  @ValidateNested()
-  banner: BannerDto;
 
   /**
    * The custom names of auth providers, which can be specified multiple times

--- a/src/frontend-config/frontend-config.service.spec.ts
+++ b/src/frontend-config/frontend-config.service.spec.ts
@@ -276,10 +276,6 @@ describe('FrontendConfigService', () => {
                               authConfig.oauth2.length !== 0,
                             );
                             expect(config.allowAnonymous).toEqual(false);
-                            expect(config.banner.text).toEqual('');
-                            expect(config.banner.updateTime).toEqual(
-                              new Date(0),
-                            );
                             expect(config.branding.name).toEqual(customName);
                             expect(config.branding.logo).toEqual(
                               customLogo ? new URL(customLogo) : undefined,

--- a/src/frontend-config/frontend-config.service.ts
+++ b/src/frontend-config/frontend-config.service.ts
@@ -8,7 +8,6 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
 import {
   AuthProviders,
-  BannerDto,
   BrandingDto,
   CustomAuthNamesDto,
   FrontendConfigDto,
@@ -24,8 +23,6 @@ import externalServicesConfiguration, {
   ExternalServicesConfig,
 } from '../config/external-services.config';
 import { getServerVersionFromPackageJson } from '../utils/serverVersion';
-import { promises as fs, Stats } from 'fs';
-import { join } from 'path';
 
 @Injectable()
 export class FrontendConfigService {
@@ -49,7 +46,6 @@ export class FrontendConfigService {
       allowAnonymous: false,
       allowRegister: this.authConfig.email.enableRegister,
       authProviders: this.getAuthProviders(),
-      banner: await FrontendConfigService.getBanner(),
       branding: this.getBranding(),
       customAuthNames: this.getCustomAuthNames(),
       iframeCommunication: this.getIframeCommunication(),
@@ -137,24 +133,5 @@ export class FrontendConfigService {
         ? new URL(this.appConfig.rendererOrigin)
         : new URL(this.appConfig.domain),
     };
-  }
-
-  private static async getBanner(): Promise<BannerDto> {
-    const path = join(__dirname, '../../banner.md');
-    try {
-      const bannerContent: string = await fs.readFile(path, {
-        encoding: 'utf8',
-      });
-      const fileStats: Stats = await fs.stat(path);
-      return {
-        text: bannerContent,
-        updateTime: fileStats.mtime,
-      };
-    } catch (e) {
-      return {
-        text: '',
-        updateTime: new Date(0),
-      };
-    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,13 @@ async function bootstrap(): Promise<void> {
       prefix: '/uploads/',
     });
   }
+  logger.log(
+    `Serving the local folder 'public' under '/public'`,
+    'AppBootstrap',
+  );
+  app.useStaticAssets('public', {
+    prefix: '/public/',
+  });
   await app.listen(appConfig.port);
   logger.log(`Listening on port ${appConfig.port}`, 'AppBootstrap');
 }


### PR DESCRIPTION
### Component/Part
Frontend config api call

### Description
This PR:
- adds serving of static assets under the relative URL '/public'
- removes the banner fields from the frontend config
  - NestJS adds the headers "Last Modified" and "ETag" to asset serving responses.
Therefore all the information we need for the banner are already given by the
file content or the file meta data.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
