### PR TITLE
Docs: Fix mkdocs link

### DIFF
--- a/docs/content/dev/documentation.md
+++ b/docs/content/dev/documentation.md
@@ -27,4 +27,4 @@ The documentation is deployed with [mkdocs][mkdocs].
 
 The repository [docs.hedgedoc.org](https://github.com/hedgedoc/docs.hedgedoc.org) is used to deploy the actual website to github.io. Currently only the `master` branch is deployed as it contains the latest release.
 
-[mkdocs]: (https://www.mkdocs.org)
+[mkdocs]: https://www.mkdocs.org


### PR DESCRIPTION
### Component/Part
docs

### Description
This PR fixes the mkdocs link the `dev/documentation.md`.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
