### PR TITLE
Fix logo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![HedgeDoc Logo](docs/content/images/hedgedoc_logo_horizontal.svg)
+![HedgeDoc Logo](docs/content/images/hedgedoc_logo_black.svg)
 
 # HedgeDoc
 


### PR DESCRIPTION
### Component/Part
README

### Description
This PR fixes the broken logo link in README.md

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
