### PR TITLE
[1.x] Remove unneeded polyfill

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -1,15 +1,6 @@
 'use strict'
 // external modules
 const Sequelize = require('sequelize')
-const crypto = require('crypto')
-if (!crypto.scrypt) {
-  // polyfill for node.js 8.0, see https://github.com/chrisveness/scrypt-kdf#openssl-implementation
-  const scryptAsync = require('scrypt-async')
-  crypto.scrypt = function (password, salt, keylen, options, callback) {
-    const opt = Object.assign({}, options, { dkLen: keylen })
-    scryptAsync(password, salt, opt, (derivedKey) => callback(null, Buffer.from(derivedKey)))
-  }
-}
 const scrypt = require('scrypt-kdf')
 
 // core

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "readline-sync": "^1.4.7",
     "reveal.js": "^3.9.2",
     "rimraf": "^3.0.2",
-    "scrypt-async": "^2.0.1",
     "scrypt-kdf": "^2.0.1",
     "select2": "^3.5.2-browserify",
     "sequelize": "^5.21.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9451,11 +9451,6 @@ script-loader@0.7.2:
   dependencies:
     raw-loader "~0.5.1"
 
-scrypt-async@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/scrypt-async/-/scrypt-async-2.0.1.tgz#4318dae48a8b7cc3b8fe05f75f4164a7d973d25d"
-  integrity sha512-wHR032jldwZNy7Tzrfu7RccOgGf8r5hyDMSP2uV6DpLiBUsR8JsDcx/in73o2UGVVrH5ivRFdNsFPcjtl3LErQ==
-
 scrypt-kdf@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-kdf/-/scrypt-kdf-2.0.1.tgz#3355224c52d398331b2cbf2b70a7be26b52c53e6"


### PR DESCRIPTION
### Component/Part
password hashing for user accounts

### Description
This PR removes the `async-scrypt` polyfill. This polyfill was added because node versions less than 10.5.0 didn't include scrypt support. As we now raised the minimum required version to 12.0.0, this polyfill isn't needed anymore.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
