### PR TITLE
AppConfig: Move default for rendererOrigin to config file

### DIFF
--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -20,7 +20,10 @@ export interface AppConfig {
 
 const schema = Joi.object({
   domain: Joi.string().label('HD_DOMAIN'),
-  rendererOrigin: Joi.string().optional().label('HD_RENDERER_ORIGIN'),
+  rendererOrigin: Joi.string()
+    .default(Joi.ref('domain'))
+    .optional()
+    .label('HD_RENDERER_ORIGIN'),
   port: Joi.number().default(3000).optional().label('PORT'),
   loglevel: Joi.string()
     .valid(...Object.values(Loglevel))

--- a/src/frontend-config/frontend-config.service.spec.ts
+++ b/src/frontend-config/frontend-config.service.spec.ts
@@ -21,6 +21,7 @@ import { Loglevel } from '../config/loglevel.enum';
  */
 
 describe('FrontendConfigService', () => {
+  const domain = 'http://md.example.com';
   const emptyAuthConfig: AuthConfig = {
     email: {
       enableLogin: false,
@@ -183,8 +184,8 @@ describe('FrontendConfigService', () => {
                         ]) {
                           it(`combination #${index} works`, async () => {
                             const appConfig: AppConfig = {
-                              domain: 'http://md.example.com',
-                              rendererOrigin: renderOrigin,
+                              domain: domain,
+                              rendererOrigin: renderOrigin ?? domain,
                               port: 3000,
                               loglevel: Loglevel.ERROR,
                               forbiddenNoteIds: [],

--- a/src/frontend-config/frontend-config.service.ts
+++ b/src/frontend-config/frontend-config.service.ts
@@ -133,9 +133,7 @@ export class FrontendConfigService {
   private getIframeCommunication(): IframeCommunicationDto {
     return {
       editorOrigin: new URL(this.appConfig.domain),
-      rendererOrigin: this.appConfig.rendererOrigin
-        ? new URL(this.appConfig.rendererOrigin)
-        : new URL(this.appConfig.domain),
+      rendererOrigin: new URL(this.appConfig.rendererOrigin),
     };
   }
 


### PR DESCRIPTION
### Component/Part
config

### Description
As we only use rendererOrigin in the frontend config service, where domain will be used if it is not defined, it makes more sense to move this default behavior to the app config directly. That makes it easier to understand what this variable contains and that it defaults to domain.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
