### PR TITLE
[Project] Add seed script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config jest-e2e.json --runInBand",
-    "test:e2e:cov": "jest --config jest-e2e.json --coverage --runInBand"
+    "test:e2e:cov": "jest --config jest-e2e.json --coverage --runInBand",
+    "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
     "@azure/storage-blob": "12.5.0",

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { createConnection } from 'typeorm';
+import { User } from './users/user.entity';
+import { Note } from './notes/note.entity';
+import { Revision } from './revisions/revision.entity';
+import { Authorship } from './revisions/authorship.entity';
+import { NoteGroupPermission } from './permissions/note-group-permission.entity';
+import { NoteUserPermission } from './permissions/note-user-permission.entity';
+import { Group } from './groups/group.entity';
+import { AuthorColor } from './notes/author-color.entity';
+import { HistoryEntry } from './history/history-entry.entity';
+import { MediaUpload } from './media/media-upload.entity';
+import { Tag } from './notes/tag.entity';
+import { AuthToken } from './auth/auth-token.entity';
+import { Identity } from './users/identity.entity';
+
+/**
+ * This function creates and populates a sqlite db for manual testing
+ */
+createConnection({
+  type: 'sqlite',
+  database: './hedgedoc.sqlite',
+  entities: [
+    User,
+    Note,
+    Revision,
+    Authorship,
+    NoteGroupPermission,
+    NoteUserPermission,
+    Group,
+    AuthorColor,
+    HistoryEntry,
+    MediaUpload,
+    Tag,
+    AuthToken,
+    Identity,
+  ],
+  synchronize: true,
+  logging: false,
+})
+  .then(async (connection) => {
+    const user = User.create('hardcoded', 'Test User');
+    const note = Note.create(undefined, 'test', 'abc');
+    const revision = Revision.create(
+      'This is a test note',
+      'This is a test note',
+    );
+    note.revisions = Promise.all([revision]);
+    note.userPermissions = [];
+    note.groupPermissions = [];
+    user.ownedNotes = [note];
+    await connection.manager.save([user, note, revision]);
+    const foundUser = await connection.manager.findOne(User);
+    const foundNote = await connection.manager.findOne(Note);
+    const historyEntry = HistoryEntry.create(foundUser, foundNote);
+    await connection.manager.save(historyEntry);
+    console.log(`Created User '${foundUser.userName}'`);
+    console.log(`Created Note '${foundNote.alias}'`);
+    console.log(`Created HistoryEntry`);
+  })
+  .catch((error) => console.log(error));


### PR DESCRIPTION
### Component/Part
seed db

### Description
This PR adds a seed script, which invokes src/seed.ts to create a sqlite DB. The DB already contains some objects to manual test with. This ensures that devs easily can spin up a test instance of HedgeDoc and don't need to fumble around with the DB file.

See https://github.com/typeorm/typeorm#creating-a-connection-to-the-database

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #1183 