### PR TITLE
ESLint: Add custom rule 'correct-logger-context'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = {
       },
     },
   ],
-  plugins: ['@typescript-eslint', 'jest'],
+  plugins: ['@typescript-eslint', 'jest', 'eslint-plugin-local-rules'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
@@ -46,6 +46,7 @@ module.exports = {
     jest: true,
   },
   rules: {
+    'local-rules/correct-logger-context': 'error',
     'func-style': ['error', 'declaration'],
     '@typescript-eslint/no-unused-vars': [
       'warn',

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+'use strict';
+
+const loggerFunctions = ['error', 'log', 'warn', 'debug', 'verbose'];
+
+module.exports = {
+  'correct-logger-context': {
+    meta: {
+      fixable: 'code',
+      type: 'problem',
+      docs: {
+        recommended: true
+      },
+      schema: [],
+    },
+    create: function (context) {
+      return {
+        CallExpression: function (node) {
+          if (
+            node.callee.type === 'MemberExpression' &&
+            node.callee.object.type === 'MemberExpression' &&
+            node.callee.object.property.name === 'logger' &&
+            loggerFunctions.includes(node.callee.property.name) &&
+            !!node.arguments &&
+            node.arguments.length === 2
+          ) {
+            const usedContext = node.arguments[1].value;
+            let correctContext = 'undefined';
+            const ancestors = context.getAncestors();
+            for (let index = ancestors.length - 1; index >= 0; index--) {
+              if (ancestors[index].type === 'MethodDefinition') {
+                correctContext = ancestors[index].key.name;
+                break;
+              }
+            }
+            if (usedContext !== correctContext) {
+              context.report({
+                node: node,
+                message: `Used wrong context in log statement`,
+                fix: function (fixer) {
+                  return fixer.replaceText(
+                    node.arguments[1],
+                    `'${correctContext}'`,
+                  );
+                },
+              });
+            }
+          }
+        },
+      };
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cli-color": "2.0.0",
     "connect-typeorm": "1.1.4",
     "eslint-plugin-jest": "24.3.6",
+    "eslint-plugin-local-rules": "1.1.0",
     "file-type": "16.4.0",
     "joi": "17.4.0",
     "minio": "7.0.18",

--- a/src/api/private/media/media.controller.ts
+++ b/src/api/private/media/media.controller.ts
@@ -45,7 +45,7 @@ export class MediaController {
     const username = 'hardcoded';
     this.logger.debug(
       `Recieved filename '${file.originalname}' for note '${noteId}' from user '${username}'`,
-      'uploadImage',
+      'uploadMedia',
     );
     try {
       const url = await this.mediaService.saveFile(

--- a/src/api/public/media/media.controller.ts
+++ b/src/api/public/media/media.controller.ts
@@ -101,7 +101,7 @@ export class MediaController {
     const username = req.user.userName;
     this.logger.debug(
       `Recieved filename '${file.originalname}' for note '${noteId}' from user '${username}'`,
-      'uploadImage',
+      'uploadMedia',
     );
     try {
       const url = await this.mediaService.saveFile(
@@ -142,7 +142,7 @@ export class MediaController {
     try {
       this.logger.debug(
         `Deleting '${filename}' for user '${username}'`,
-        'deleteFile',
+        'deleteMedia',
       );
       const mediaUpload = await this.mediaService.findUploadByFilename(
         filename,
@@ -150,7 +150,7 @@ export class MediaController {
       if (mediaUpload.user.userName !== username) {
         this.logger.warn(
           `${username} tried to delete '${filename}', but is not the owner`,
-          'deleteFile',
+          'deleteMedia',
         );
         throw new PermissionError(
           `File '${filename}' is not owned by '${username}'`,

--- a/src/media/backends/imgur-backend.ts
+++ b/src/media/backends/imgur-backend.ts
@@ -78,7 +78,7 @@ export class ImgurBackend implements MediaBackend {
           headers: { Authorization: `Client-ID ${this.config.clientID}` },
         },
       ).then((res) => ImgurBackend.checkStatus(res));
-      this.logger.debug(`Response: ${result.toString()}`, 'saveFile');
+      this.logger.debug(`Response: ${result.toString()}`, 'deleteFile');
       this.logger.log(`Deleted ${fileName}`, 'deleteFile');
       return;
     } catch (e) {

--- a/src/media/backends/s3-backend.ts
+++ b/src/media/backends/s3-backend.ts
@@ -62,7 +62,7 @@ export class S3Backend implements MediaBackend {
     try {
       await this.client.removeObject(this.config.bucket, fileName);
       const url = this.getUrl(fileName);
-      this.logger.log(`Deleted ${url}`, 'saveFile');
+      this.logger.log(`Deleted ${url}`, 'deleteFile');
       return;
     } catch (e) {
       this.logger.error((e as Error).message, (e as Error).stack, 'saveFile');

--- a/src/media/backends/webdav-backend.ts
+++ b/src/media/backends/webdav-backend.ts
@@ -95,7 +95,7 @@ export class WebdavBackend implements MediaBackend {
         },
       }).then((res) => WebdavBackend.checkStatus(res));
       const url = this.getUrl(fileName);
-      this.logger.log(`Deleted ${url}`, 'saveFile');
+      this.logger.log(`Deleted ${url}`, 'deleteFile');
       return;
     } catch (e) {
       this.logger.error((e as Error).message, (e as Error).stack, 'saveFile');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2963,6 +2963,11 @@ eslint-plugin-jest@24.3.6:
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
+eslint-plugin-local-rules@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.1.0.tgz#5f934f685b08c96eed40b92aee7b02f03cf55f7b"
+  integrity sha512-FdPyzxakUKgZkeNM3x/vvRcB6nCjTNbui5gWALhvcaH1R6aCiD37fWtdesagcyBpEe9S9XRHAJ8CJ4rUJ3K9tQ==
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
This PR adds the custom rule 'correct-logger-context', which ensures, that the correct context is given in any logger statements.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
