### PR TITLE
Fix upgradeInsecureRequests CSP directive

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -85,9 +85,9 @@ function getCspNonce (req, res) {
 
 function addUpgradeUnsafeRequestsOptionTo (directives) {
   if (config.csp.upgradeInsecureRequests === 'auto' && config.useSSL) {
-    directives.upgradeInsecureRequests = true
+    directives.upgradeInsecureRequests = []
   } else if (config.csp.upgradeInsecureRequests === true) {
-    directives.upgradeInsecureRequests = true
+    directives.upgradeInsecureRequests = []
   }
 }
 


### PR DESCRIPTION
### Component/Part
csp.js

### Description
The `upgradeInsecureRequests` option of Helmets CSP middleware
was a boolean in Helmet 3, but with Helmet 4,
everything changed to lists.
This PR adjusts the addUpgradeUnsafeRequestsOptionTo
function accordingly.

Closes #1221

See also https://github.com/helmetjs/helmet/tree/v4.6.0/middlewares/content-security-policy

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#1221 
