### PR TITLE
Automatically enable protocolUseSSL when useSSL is set

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,4 +1,3 @@
-
 'use strict'
 
 const crypto = require('crypto')
@@ -31,7 +30,7 @@ const packageConfig = {
 }
 
 const configFilePath = path.resolve(appRootPath, process.env.CMD_CONFIG_FILE ||
-'config.json')
+  'config.json')
 const fileConfig = fs.existsSync(configFilePath) ? require(configFilePath)[env] : undefined
 
 let config = require('./default')
@@ -87,6 +86,14 @@ config.isStandardHTTPsPort = (function isStandardHTTPsPort () {
 config.isStandardHTTPPort = (function isStandardHTTPPort () {
   return !config.useSSL && config.port === 80
 })()
+
+// Use HTTPS protocol if the internal TLS server is enabled
+if (config.useSSL === true) {
+  if (config.protocolUseSSL === false) {
+    logger.warn('Overriding protocolUseSSL to \'true\' as useSSL is enabled.')
+  }
+  config.protocolUseSSL = true
+}
 
 // cache serverURL
 config.serverURL = (function getserverurl () {
@@ -147,8 +154,8 @@ for (let i = keys.length; i--;) {
   // and the config with uppercase is not set
   // we set the new config using the old key.
   if (uppercase.test(keys[i]) &&
-  config[lowercaseKey] !== undefined &&
-  fileConfig[keys[i]] === undefined) {
+    config[lowercaseKey] !== undefined &&
+    fileConfig[keys[i]] === undefined) {
     logger.warn('config.json contains deprecated lowercase setting for ' + keys[i] + '. Please change your config.json file to replace ' + lowercaseKey + ' with ' + keys[i])
     config[keys[i]] = config[lowercaseKey]
   }


### PR DESCRIPTION
### Component/Part
config

### Description
 This makes the behavior consistent with the docs and
 saves the user from having to both set
 `useSSL` and `protocolUseSSL`.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
