### PR TITLE
Fix insertOnStartOfLines behaviour

### DIFF
--- a/public/js/lib/editor/utils.js
+++ b/public/js/lib/editor/utils.js
@@ -1,4 +1,5 @@
 const wrapSymbols = ['*', '_', '~', '^', '+', '=']
+
 export function wrapTextWith (editor, cm, symbol) {
   if (!cm.getSelection()) {
     return CodeMirror.Pass
@@ -106,12 +107,14 @@ export function insertOnStartOfLines (cm, symbol) {
   for (let i = 0; i < ranges.length; i++) {
     const range = ranges[i]
     if (!range.empty()) {
-      const from = range.from()
-      const to = range.to()
-      let selection = cm.getRange({ line: from.line, ch: 0 }, to)
+      const cursorFrom = range.from()
+      const cursorTo = range.to()
+      const firstLineStart = { line: cursorFrom.line, ch: 0 }
+      const lastLineEnd = { line: cursorTo.line, ch: cm.getLine(cursorTo.line).length }
+      let selection = cm.getRange(firstLineStart, lastLineEnd)
       selection = selection.replace(/\n/g, '\n' + symbol)
       selection = symbol + selection
-      cm.replaceRange(selection, from, to)
+      cm.replaceRange(selection, firstLineStart, lastLineEnd)
     } else {
       cm.replaceRange(symbol, { line: cursor.line, ch: 0 }, { line: cursor.line, ch: 0 })
     }


### PR DESCRIPTION
### Component/Part
Editor

### Description
A bug in insertOnStartOfLines lead to duplicated text,
if the cursor was not at the start of a line.

This fixes the behaviour of insertOnStartOfLines to always use
the complete first and last line of the selection,
even if they were only partially selected.

Fixes #1231

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#1231
