### PR TITLE
Fix click handler for numbered task lists

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -266,9 +266,9 @@ export function finishView (view) {
     li.innerHTML = html
     let disabled = 'disabled'
     if (typeof editor !== 'undefined' && window.havePermission()) { disabled = '' }
-    if (/^\s*\[[x ]\]\s*/.test(html)) {
-      li.innerHTML = html.replace(/^\s*\[ \]\s*/, `<input type="checkbox" class="task-list-item-checkbox "${disabled}><label></label>`)
-        .replace(/^\s*\[x\]\s*/, `<input type="checkbox" class="task-list-item-checkbox" checked ${disabled}><label></label>`)
+    if (/^\s*\[[xX ]]\s*/.test(html)) {
+      li.innerHTML = html.replace(/^\s*\[ ]\s*/, `<input type="checkbox" class="task-list-item-checkbox" ${disabled}><label></label>`)
+        .replace(/^\s*\[[xX]]\s*/, `<input type="checkbox" class="task-list-item-checkbox" checked ${disabled}><label></label>`)
       if (li.tagName.toLowerCase() !== 'li') {
         li.parentElement.setAttribute('class', 'task-list-item')
       } else {
@@ -705,11 +705,11 @@ $.fn.sortByDepth = function () {
 function toggleTodoEvent (e) {
   const startline = $(this).closest('li').attr('data-startline') - 1
   const line = window.editor.getLine(startline)
-  const matches = line.match(/^[>\s-]*[-+*]\s\[([x ])\]/)
+  const matches = line.match(/^[>\s-]*(?:[-+*]|\d+[.)])\s\[([xX ])]/)
   if (matches && matches.length >= 2) {
     let checked = null
-    if (matches[1] === 'x') { checked = true } else if (matches[1] === ' ') { checked = false }
-    const replacements = matches[0].match(/(^[>\s-]*[-+*]\s\[)([x ])(\])/)
+    if (matches[1].toLowerCase() === 'x') { checked = true } else if (matches[1] === ' ') { checked = false }
+    const replacements = matches[0].match(/(^[>\s-]*(?:[-+*]|\d+[.)])\s\[)([xX ])(])/)
     window.editor.replaceRange(checked ? ' ' : 'x', {
       line: startline,
       ch: replacements[1].length


### PR DESCRIPTION
### Component/Part
markdown renderer / editor

### Description
The regex for task lists in 1.x didn't include upper-case x/X letters nor ordered lists (`1. [ ] abc`).
This PR changes the regex to allow both.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Additional information
For testing, I took this content:
```markdown
- [ ] abc
- [x] def
- [X] ghi

* [ ] abc
* [x] def
* [X] ghi

+ [ ] abc
+ [x] def
+ [X] ghi

1. [ ] abc
2. [x] def
3. [X] ghi

1) [ ] abc
2) [x] def
3) [X] ghi
```

### Related Issue(s)
Fixes #1220 