### PR TITLE
Ignore Postgres SSL errors on Heroku

### DIFF
--- a/bin/heroku
+++ b/bin/heroku
@@ -6,6 +6,16 @@ cat << EOF > config.json
 
 {
   "production": {
+    "db": {
+      "dialect": "postgres",
+      "protocol": "postgres",
+      "dialectOptions": {
+        "ssl": {
+           "require": true,
+           "rejectUnauthorized": false
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Component/Part
Heroku setup script

### Description
The connection to Heroku's Postgres instances must use SSL,
but not check the certificate.

This adds the necessary configuration to the Heroku setup script.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #1245
