### PR TITLE
AuthTokenEntity: Make validUntil not nullable

### DIFF
--- a/src/auth/auth-token.dto.ts
+++ b/src/auth/auth-token.dto.ts
@@ -14,8 +14,7 @@ export class AuthTokenDto {
   @IsDate()
   createdAt: Date;
   @IsDate()
-  @IsOptional()
-  validUntil: Date | null;
+  validUntil: Date;
   @IsDate()
   @IsOptional()
   lastUsed: Date | null;

--- a/src/auth/auth-token.entity.ts
+++ b/src/auth/auth-token.entity.ts
@@ -35,11 +35,8 @@ export class AuthToken {
   @Column({ unique: true })
   accessTokenHash: string;
 
-  @Column({
-    nullable: true,
-    type: 'date',
-  })
-  validUntil: Date | null;
+  @Column()
+  validUntil: Date;
 
   @Column({
     nullable: true,

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -309,11 +309,14 @@ describe('AuthService', () => {
       authToken.keyId = 'testKeyId';
       authToken.label = 'testLabel';
       authToken.createdAt = new Date();
+      authToken.validUntil = new Date();
       const tokenDto = service.toAuthTokenDto(authToken);
       expect(tokenDto.keyId).toEqual(authToken.keyId);
       expect(tokenDto.lastUsed).toBeNull();
       expect(tokenDto.label).toEqual(authToken.label);
-      expect(tokenDto.validUntil).toBeNull();
+      expect(tokenDto.validUntil.getTime()).toEqual(
+        authToken.createdAt.getTime(),
+      );
       expect(tokenDto.createdAt.getTime()).toEqual(
         authToken.createdAt.getTime(),
       );

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -184,13 +184,9 @@ export class AuthService {
       label: authToken.label,
       keyId: authToken.keyId,
       createdAt: authToken.createdAt,
-      validUntil: null,
+      validUntil: authToken.validUntil,
       lastUsed: null,
     };
-
-    if (authToken.validUntil) {
-      tokenDto.validUntil = new Date(authToken.validUntil);
-    }
 
     if (authToken.lastUsed) {
       tokenDto.lastUsed = new Date(authToken.lastUsed);


### PR DESCRIPTION
### Component/Part
AuthToken entity/DTO

### Description
As all tokens are valid for a maximum of 2 years, the
validUntil attribute is always populated.

This updates the database schema and the DTO to reflect that.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#1256 
