### PR TITLE
Refactor(note): Remove shortid from note

### DIFF
--- a/docs/content/dev/db-schema.plantuml
+++ b/docs/content/dev/db-schema.plantuml
@@ -5,7 +5,6 @@ skinparam nodesep 60
 entity "note" {
   *id : uuid <<generated>>
   --
-  *shortid : text
   alias : text
   *viewCount : number
   *ownerId : uuid <<FK user>>

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "reflect-metadata": "0.1.13",
     "rimraf": "3.0.2",
     "rxjs": "7.0.0",
-    "shortid": "2.2.16",
     "sqlite3": "5.0.2",
     "swagger-ui-express": "4.1.6",
     "typeorm": "0.2.32"
@@ -71,7 +70,6 @@
     "@types/express": "4.17.11",
     "@types/jest": "26.0.23",
     "@types/node": "13.13.51",
-    "@types/shortid": "0.0.29",
     "@types/supertest": "2.0.11",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",

--- a/src/notes/note.entity.ts
+++ b/src/notes/note.entity.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { generate as shortIdGenerate } from 'shortid';
 import {
   Column,
   Entity,
@@ -27,11 +26,6 @@ import { MediaUpload } from '../media/media-upload.entity';
 export class Note {
   @PrimaryGeneratedColumn('uuid')
   id: string;
-  @Column({
-    nullable: false,
-    unique: true,
-  })
-  shortid: string;
   @Column({
     unique: true,
     nullable: true,
@@ -87,12 +81,8 @@ export class Note {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   private constructor() {}
 
-  public static create(owner?: User, alias?: string, shortid?: string): Note {
-    if (!shortid) {
-      shortid = shortIdGenerate();
-    }
+  public static create(owner?: User, alias?: string): Note {
     const newNote = new Note();
-    newNote.shortid = shortid;
     newNote.alias = alias ?? null;
     newNote.viewCount = 0;
     newNote.owner = owner ?? null;

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -45,7 +45,7 @@ createConnection({
 })
   .then(async (connection) => {
     const user = User.create('hardcoded', 'Test User');
-    const note = Note.create(undefined, 'test', 'abc');
+    const note = Note.create(undefined, 'test');
     const revision = Revision.create(
       'This is a test note',
       'This is a test note',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,11 +1239,6 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/shortid@0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
-  integrity sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=
-
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
@@ -5203,11 +5198,6 @@ mz@^2.4.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^2.1.0:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -6491,13 +6481,6 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-
-shortid@2.2.16:
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
-  integrity sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==
-  dependencies:
-    nanoid "^2.1.0"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
### Component/Part
note

### Description
This PR removes the shortid form the note.

This is a 1.x relict and isn't used anymore in 2.x. All 1.x shortids will be converted to aliases on migration of 1.x to 2.x.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #1268 
