### PR TITLE
Clarify docs

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -50,7 +50,10 @@ echo "Installing packages..."
 yarn install --production=true --pure-lockfile
 
 cat << EOF
-If you want to build the frontend yourself, you need to run 'yarn install' before 'yarn build' to install the devDependencies for the build process.
+##########
+If you have pulled HedgeDoc via git (or have changed the frontend files) then you need to run 'yarn install' and then 'yarn build' to install the necessary dependencies and build the frontend.
+This step is mandatory if you use git and can be skipped if you use the release tarball or the docker container.
+##########
 
 Edit the following config file to setup HedgeDoc server and client.
 Read more info at https://docs.hedgedoc.org/configuration/

--- a/docs/content/setup/manual-setup.md
+++ b/docs/content/setup/manual-setup.md
@@ -33,8 +33,8 @@
    ```
    It's also possible to use environment variables.
    For details, have a look at [the configuration documentation](../configuration.md).
-5. *:octicons-light-bulb-16: If you use the release tarball for 1.7.0 or newer, this step can be skipped.*  
-   Build the frontend bundle by running `yarn install` and then `yarn build`. The extra `yarn install` is necessary as `bin/setup` does not install the build dependencies.
+5. *:octicons-light-bulb-16: If you use the release tarball for 1.7.0 or newer, this step can be skipped. If you use git then this step is mandatory!*  
+   Build the frontend bundle by running `yarn install` and then `yarn build`. The extra `yarn install` is necessary because `bin/setup` doesn't install the build dependencies for the frontend.
 6. It is recommended to start your server manually once:  
    ```shell
    NODE_ENV=production yarn start


### PR DESCRIPTION
### Component/Part
Manual installation docs and bin/setup

### Description
This PR adds a hint that you MUST build the frontend if you use git.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
