### PR TITLE
Replace vimeo meta data api

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -294,14 +294,14 @@ export function finishView (view) {
       imgPlayiframe(this, '//player.vimeo.com/video/')
     })
     .each((key, value) => {
+      const vimeoLink = `https://vimeo.com/${$(value).attr('data-videoid')}`
       $.ajax({
         type: 'GET',
-        url: `//vimeo.com/api/v2/video/${$(value).attr('data-videoid')}.json`,
+        url: `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(vimeoLink)}`,
         jsonp: 'callback',
         dataType: 'jsonp',
         success (data) {
-          const thumbnailSrc = data[0].thumbnail_large
-          const image = `<img src="${thumbnailSrc}" />`
+          const image = `<img src="${data.thumbnail_url}" />`
           $(value).prepend(image)
           if (window.viewAjaxCallback) window.viewAjaxCallback()
         }


### PR DESCRIPTION
### Component/Part
Vimeo embedding

### Description
Vimeo deprecated the v2 api and recommends to use https://developer.vimeo.com/api/oembed/videos
This PR replaces the used API.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #1281