### PR TITLE
Move publicId creation to Note.create

### DIFF
--- a/src/notes/note.entity.ts
+++ b/src/notes/note.entity.ts
@@ -21,6 +21,7 @@ import { AuthorColor } from './author-color.entity';
 import { Tag } from './tag.entity';
 import { HistoryEntry } from '../history/history-entry.entity';
 import { MediaUpload } from '../media/media-upload.entity';
+import { generatePublicId } from './utils';
 
 @Entity()
 export class Note {
@@ -85,6 +86,7 @@ export class Note {
 
   public static create(owner?: User, alias?: string): Note {
     const newNote = new Note();
+    newNote.publicId = generatePublicId();
     newNote.alias = alias ?? null;
     newNote.viewCount = 0;
     newNote.owner = owner ?? null;

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -94,7 +94,6 @@ export class NotesService {
     newNote.revisions = Promise.resolve([
       Revision.create(noteContent, noteContent),
     ]);
-    newNote.publicId = this.generatePublicId();
     if (alias) {
       newNote.alias = alias;
       this.checkNoteIdOrAlias(alias);
@@ -211,15 +210,6 @@ export class NotesService {
         `A note with the alias '${noteIdOrAlias}' is forbidden by the administrator.`,
       );
     }
-  }
-
-  /**
-   * Generate publicId for a note.
-   * This is a randomly generated 128-bit value encoded with base32-encode using the crockford variant and converted to lowercase.
-   */
-  generatePublicId(): string {
-    const randomId = randomBytes(128);
-    return base32Encode(randomId, 'Crockford').toLowerCase();
   }
 
   /**

--- a/src/notes/utils.ts
+++ b/src/notes/utils.ts
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import base32Encode from 'base32-encode';
+import { randomBytes } from 'crypto';
+
+/**
+ * Generate publicId for a note.
+ * This is a randomly generated 128-bit value encoded with base32-encode using the crockford variant and converted to lowercase.
+ */
+export function generatePublicId(): string {
+  const randomId = randomBytes(128);
+  return base32Encode(randomId, 'Crockford').toLowerCase();
+}


### PR DESCRIPTION
### Component/Part
Note entity

### Description
Before this PR, `Note.create()` did not return a complete object,
as the `publicId` property was missing.
This adds the generation of the property to the `create` method and moves the
actual generation code from the `NotesService` to a utility method.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ ] Added implementation
- [ ] Added / updated tests
- [ ] Added / updated documentation
- [ ] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
