### PR TITLE
Remove explicit title from cloudflare warning

### DIFF
--- a/docs/content/guides/reverse-proxy.md
+++ b/docs/content/guides/reverse-proxy.md
@@ -6,7 +6,7 @@ configs that you'll have to do.
 This documentation will cover HTTPS setup, with comments for HTTP setup.
 
 ## Cloudflare
-!!! warning "Requirements on your server"
+!!! warning
     If you use Cloudflare as reverse proxy then you **MUST** disable the minify features for HTML, CSS and JS, or your HedgeDoc instance may be broken.
     For more information please read the [Cloudflare documentation](https://support.cloudflare.com/hc/en-us/articles/200168196-How-do-I-minify-HTML-CSS-and-JavaScript-to-optimize-my-site-).
 


### PR DESCRIPTION
### Component/Part
Reverse Proxy Documentation

### Description
The Cloudflare warning has "Requirements on your server" as it's title which is wrong.
This PR removes the explicit title so the theme falls back to "Warning"

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
