### PR TITLE
Fix link in openapi doc

### DIFF
--- a/docs/content/dev/openapi.yml
+++ b/docs/content/dev/openapi.yml
@@ -12,7 +12,7 @@ info:
     url: https://github.com/hedgedoc/hedgedoc/blob/master/LICENSE
 
 externalDocs:
-  url: https://github.com/hedgedoc/hedgedoc/blob/master/docs/dev/api.md
+  url: https://docs.hedgedoc.org/dev/api/
 
 
 paths:


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
This PR fixes the link for more documentation in the OpenAPI spec file.
The old link points to a location in our GitHub repo that doesn't exist anymore.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
