### PR TITLE
Remove unsafe-eval from default CSP

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -5,8 +5,7 @@ const CspStrategy = {}
 
 const defaultDirectives = {
   defaultSrc: ['\'self\''],
-  scriptSrc: ['\'self\'', 'vimeo.com', 'https://gist.github.com', 'www.slideshare.net', '\'unsafe-eval\''],
-  // ^ TODO: Remove unsafe-eval - webpack script-loader issues https://github.com/hackmdio/codimd/issues/594
+  scriptSrc: ['\'self\'', 'vimeo.com', 'https://gist.github.com', 'www.slideshare.net'],
   imgSrc: ['*'],
   styleSrc: ['\'self\'', '\'unsafe-inline\'', 'https://github.githubassets.com'], // unsafe-inline is required for some libs, plus used in views
   fontSrc: ['\'self\'', 'data:', 'https://public.slidesharecdn.com'],

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,9 +6,9 @@ module.exports = [
   // merge common config
   merge(common, {
     mode: 'development',
-    devtool: 'eval-cheap-module-source-map'
+    devtool: 'cheap-module-source-map'
   }),
   merge(htmlexport, {
     mode: 'development',
-    devtool: 'eval-cheap-module-source-map'
+    devtool: 'cheap-module-source-map'
   })]


### PR DESCRIPTION
### Component/Part
Content-Security-Policy

### Description
As our webpack config does not use `eval` anymore, after #1368 is merged, we can remove
`unsafe-eval` from our CSP config.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
