### PR TITLE
Webpack: production source maps & split chunks

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -22,7 +22,8 @@ module.exports = [
       splitChunks: {
         chunks: 'all'
       }
-    }
+    },
+    devtool: 'source-map'
   }),
   merge(htmlexport, {
     mode: 'production',

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -18,7 +18,10 @@ module.exports = [
         new ESBuildMinifyPlugin({
           target: 'es2015'
         })
-      ]
+      ],
+      splitChunks: {
+        chunks: 'all'
+      }
     }
   }),
   merge(htmlexport, {


### PR DESCRIPTION
### Component/Part
Webpack config

### Description
This PR improves the Webpack config by enabling production source maps (only loaded when the client requests them) and the SplitChunksPlugin. This automatically splits duplicated imports across different entrypoints into their own chunks.

See also https://v4.webpack.js.org/guides/code-splitting/#prevent-duplication

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->