### PR TITLE
fix(publicId): generate 128-bit instead of 128-byte value

### DIFF
--- a/src/notes/utils.spec.ts
+++ b/src/notes/utils.spec.ts
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { randomBytes } from 'crypto';
+import { generatePublicId } from './utils';
+jest.mock('crypto');
+
+it('generatePublicId', () => {
+  const random128bitBuffer = Buffer.from([
+    0xe1, 0x75, 0x86, 0xb7, 0xc3, 0xfb, 0x03, 0xa9, 0x26, 0x9f, 0xc9, 0xd6,
+    0x8c, 0x2d, 0x7b, 0x7b,
+  ]);
+  const mockRandomBytes = randomBytes as jest.MockedFunction<
+    typeof randomBytes
+  >;
+  mockRandomBytes.mockImplementationOnce((_) => random128bitBuffer);
+
+  expect(generatePublicId()).toEqual('w5trddy3zc1tj9mzs7b8rbbvfc');
+});

--- a/src/notes/utils.ts
+++ b/src/notes/utils.ts
@@ -12,6 +12,6 @@ import { randomBytes } from 'crypto';
  * This is a randomly generated 128-bit value encoded with base32-encode using the crockford variant and converted to lowercase.
  */
 export function generatePublicId(): string {
-  const randomId = randomBytes(128);
+  const randomId = randomBytes(16);
   return base32Encode(randomId, 'Crockford').toLowerCase();
 }


### PR DESCRIPTION
### Component/Part
public id

### Description
This PR fixes the generation of publicIds. It uses 128-bit instead of 128-byte values now.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fix #1386 
