### PR TITLE
[Docs] Add Mattermost guide to navigation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
           - GitHub: guides/auth/github.md
           - GitLab: guides/auth/gitlab-self-hosted.md
           - Keycloak: guides/auth/keycloak.md
+          - Mattermost: guides/auth/mattermost-self-hosted.md
           - Nextcloud: guides/auth/nextcloud.md
           - Twitter: guides/auth/twitter.md
       - Media Backend:


### PR DESCRIPTION
### Component/Part
Docs

### Description
This PR adds the mattermost guide to the navbar, so that it can be found without using the search xD

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
