### PR TITLE
[1.x] Exclude /metrics and /status routes from session initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ const errors = require('./lib/errors')
 const models = require('./lib/models')
 const csp = require('./lib/csp')
 const metrics = require('./lib/prometheus')
+const { useUnless } = require('./lib/utils')
 
 const supportedLocalesList = Object.keys(require('./locales/_supported.json'))
 
@@ -147,7 +148,7 @@ app.use('/uploads', express.static(path.resolve(__dirname, config.uploadsPath), 
 app.use('/default.md', express.static(path.resolve(__dirname, config.defaultNotePath), { maxAge: config.staticCacheTime }))
 
 // session
-app.use(session({
+app.use(useUnless(['/status', '/metrics'], session({
   name: config.sessionName,
   secret: config.sessionSecret,
   resave: false, // don't save session if unmodified
@@ -159,7 +160,7 @@ app.use(session({
     secure: config.useSSL || config.protocolUseSSL || false
   },
   store: sessionStore
-}))
+})))
 
 // session resumption
 const tlsSessionStore = {}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,3 +25,12 @@ exports.getImageMimeType = function getImageMimeType (imagePath) {
       return undefined
   }
 }
+
+exports.useUnless = function excludeRoute (paths, middleware) {
+  return function (req, res, next) {
+    if (paths.includes(req.path)) {
+      return next()
+    }
+    return middleware(req, res, next)
+  }
+}


### PR DESCRIPTION
### Component/Part
express middlewares

### Description
This PR fixes the problem that sessions were created for requests to `/metrics` and `/status`. This is caused by the express-session middleware which is applied to every request going through HedgeDoc.
As the express-session middleware does not have any option to disable session initialization for specific routes, I created a helper middleware that accepts a list of blocked routes and another middleware. If a request matches one of the blocked routes, nothing happens. Otherwise the other middleware is applied to the request.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #1446 
