### PR TITLE
[1.x] Add help link and short explanation for failing migrations

### DIFF
--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -82,7 +82,10 @@ db.runMigrations = async function runMigrations () {
   // exit in case of unsuccessful migrations
   await umzug.up().catch(error => {
     logger.error(error)
-    logger.error('Database migration failed. Exiting…')
+    logger.error(`Database migration failed.
+This can be the result of upgrading from quite old versions and requires manual database intervention.
+See https://docs.hedgedoc.org/guides/migration-troubleshooting/ for help.
+Exiting…`)
     process.exit(1)
   })
   logger.info('All migrations performed successfully')


### PR DESCRIPTION
### Component/Part
migration runtime

### Description
This PR improves the error message on failed migrations to include a link to the troubleshooting guide.

### Steps
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Closes #1419 