### PR TITLE
Update manual-setup.md

### DIFF
--- a/docs/content/setup/manual-setup.md
+++ b/docs/content/setup/manual-setup.md
@@ -34,7 +34,7 @@
    It's also possible to use environment variables.
    For details, have a look at [the configuration documentation](../configuration.md).
 5. *:octicons-light-bulb-16: If you use the release tarball for 1.7.0 or newer, this step can be skipped.*  
-   Build the frontend bundle by running `yarn install` and then `yarn build`. The extra `yarn install` is necessary as `bin/setup` does not install the build dependencies.
+   Build the frontend bundle by running `yarn install --prod=false` and then `yarn build`. The extra `yarn install` is necessary as `bin/setup` does not install the build dependencies. The `--prod=false` overrides the NODE_ENV variable so the development dependencies are installed.
 6. It is recommended to start your server manually once:  
    ```shell
    NODE_ENV=production yarn start


### PR DESCRIPTION
Added "--prod=false" to yarn install so the NODE_ENV variable is overridden, and the development dependencies are installed.

### Component/Part
Documentation


### Description
This PR Adds "--prod=false" to "yarn install" in the manual installation documentation so the NODE_ENV variable is overridden, and the development dependencies are installed.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [X] Added / updated documentation
- [X] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
