### PR TITLE
fix(s3): replace dash with dot for s3 endpoint

### DIFF
--- a/lib/web/imageRouter/s3.js
+++ b/lib/web/imageRouter/s3.js
@@ -46,7 +46,7 @@ exports.uploadImage = function (imagePath, callback) {
       if (config.s3.endpoint) {
         s3Endpoint = config.s3.endpoint
       } else if (config.s3.region && config.s3.region !== 'us-east-1') {
-        s3Endpoint = `s3-${config.s3.region}.amazonaws.com`
+        s3Endpoint = `s3.${config.s3.region}.amazonaws.com`
       }
       callback(null, `https://${s3Endpoint}/${config.s3bucket}/${params.Key}`)
     })


### PR DESCRIPTION
### Component/Part
s3 endpoint

### Description
According to the AWS documentation there is no situation that there is a dash in `s3-<region>.amazonaws.com`, the correct way is with a dot `s3.<region>.amazonaws.com`
Source: https://docs.aws.amazon.com/general/latest/gr/s3.html

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

P.S.: Small change, big headache to debug.