### PR TITLE
docs: add documentation on private api authentication

### DIFF
--- a/docs/content/dev/private-api-auth.md
+++ b/docs/content/dev/private-api-auth.md
@@ -1,0 +1,18 @@
+# Private API Auth
+
+## Supported kinds of authentication
+
+- Username & Password (`local`)
+- LDAP 
+- SAML
+- OAuth2
+- GitLab
+- GitHub
+- Facebook
+- Twitter
+- Dropbox
+- Google
+
+## How the authentication works
+
+The backend is called directly from the frontend. The different routes that handle different kinds of authentication perform any kind of verification needed and then create a session cookie. This session cookie is than provided with each subsequent call to the private api by the frontend (until it expires or the user logs out). The SessionGuard, which is added to each other (appropriate) controller method of the private api, checks if the provided session is still valid and provides the controller method with the correct user.


### PR DESCRIPTION
### Component/Part
docs

### Description
This PR adds documentation on private api authentication

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

