### PR TITLE
 docs: fix typos 

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -8,7 +8,7 @@ it by visiting our [HedgeDoc demo server][hedgedoc-demo].
 
 It is inspired by Hackpad, Etherpad and similar collaborative editors. This
 project originated with the team at [HackMD](https://hackmd.io) and now forked
-into its own organisation. [A longer writeup can be read in the history doc](history.md) or [you can have a look at an explanitory graph over at our website][hedgedoc-history].
+into its own organization. [A longer write-up can be read in the history doc](history.md) or [you can have a look at an explanatory graph over at our website][hedgedoc-history].
 
 If you have any questions that aren't answered here, feel free to ask us on [Matrix][matrix.org-url], stop by our [community forums][hedgedoc-community] or have a look at our [FAQ][hedgedoc-faq].
 


### PR DESCRIPTION
### Component/Part
docs

### Description
This PR fixes some typos in the docs that geeked pointed out in the forum

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
https://community.hedgedoc.org/t/couple-spelling-errors-on-your-docs-home-page/453
