### PR TITLE
Set secure flag for non-session cookies

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -12,6 +12,7 @@
 ### Bugfixes
 - Fix crash when trying to read the current Git commit on startup 
 - Fix endless loop on shutdown when HedgeDoc can't connect to the database
+- Ensure that all cookies are set with the `secure` flag, if HedgeDoc is loaded via HTTPS
 
 ## <i class="fa fa-tag"></i> 1.8.2 <i class="fa fa-calendar-o"></i> 2021-05-11
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -2098,7 +2098,8 @@ function toggleNightMode () {
   } else {
     Cookies.set('nightMode', !isActive, {
       expires: 365,
-      sameSite: window.cookiePolicy
+      sameSite: window.cookiePolicy,
+      secure: window.location.protocol === 'https:'
     })
   }
 }

--- a/public/js/lib/common/login.js
+++ b/public/js/lib/common/login.js
@@ -20,15 +20,20 @@ export function resetCheckAuth () {
 export function setLoginState (bool, id) {
   Cookies.set('loginstate', bool, {
     expires: 365,
-    sameSite: window.cookiePolicy
+    sameSite: window.cookiePolicy,
+    secure: window.location.protocol === 'https:'
   })
   if (id) {
     Cookies.set('userid', id, {
       expires: 365,
-      sameSite: window.cookiePolicy
+      sameSite: window.cookiePolicy,
+      secure: window.location.protocol === 'https:'
     })
   } else {
-    Cookies.remove('userid')
+    Cookies.remove('userid', {
+      sameSite: window.cookiePolicy,
+      secure: window.location.protocol === 'https:'
+    })
   }
   lastLoginState = bool
   lastUserId = id

--- a/public/js/lib/editor/index.js
+++ b/public/js/lib/editor/index.js
@@ -343,13 +343,15 @@ export default class Editor {
       if (this.editor.getOption('indentWithTabs')) {
         Cookies.set('indent_type', 'tab', {
           expires: 365,
-          sameSite: window.cookiePolicy
+          sameSite: window.cookiePolicy,
+          secure: window.location.protocol === 'https:'
         })
         type.text('Tab Size:')
       } else {
         Cookies.set('indent_type', 'space', {
           expires: 365,
-          sameSite: window.cookiePolicy
+          sameSite: window.cookiePolicy,
+          secure: window.location.protocol === 'https:'
         })
         type.text('Spaces:')
       }
@@ -361,12 +363,14 @@ export default class Editor {
       if (this.editor.getOption('indentWithTabs')) {
         Cookies.set('tab_size', unit, {
           expires: 365,
-          sameSite: window.cookiePolicy
+          sameSite: window.cookiePolicy,
+          secure: window.location.protocol === 'https:'
         })
       } else {
         Cookies.set('space_units', unit, {
           expires: 365,
-          sameSite: window.cookiePolicy
+          sameSite: window.cookiePolicy,
+          secure: window.location.protocol === 'https:'
         })
       }
       widthLabel.text(unit)
@@ -435,7 +439,8 @@ export default class Editor {
       const keymap = this.editor.getOption('keyMap')
       Cookies.set('keymap', keymap, {
         expires: 365,
-        sameSite: window.cookiePolicy
+        sameSite: window.cookiePolicy,
+        secure: window.location.protocol === 'https:'
       })
       label.text(keymap)
       this.restoreOverrideEditorKeymap()
@@ -484,7 +489,8 @@ export default class Editor {
       this.editor.setOption('theme', theme)
       Cookies.set('theme', theme, {
         expires: 365,
-        sameSite: window.cookiePolicy
+        sameSite: window.cookiePolicy,
+        secure: window.location.protocol === 'https:'
       })
 
       checkTheme()
@@ -530,7 +536,8 @@ export default class Editor {
       }
       Cookies.set('spellcheck', mode === 'spell-checker', {
         expires: 365,
-        sameSite: window.cookiePolicy
+        sameSite: window.cookiePolicy,
+        secure: window.location.protocol === 'https:'
       })
 
       checkSpellcheck()
@@ -577,7 +584,8 @@ export default class Editor {
     if (overrideBrowserKeymap.is(':checked')) {
       Cookies.set('preferences-override-browser-keymap', true, {
         expires: 365,
-        sameSite: window.cookiePolicy
+        sameSite: window.cookiePolicy,
+        secure: window.location.protocol === 'https:'
       })
       this.restoreOverrideEditorKeymap()
     } else {

--- a/public/js/locale.js
+++ b/public/js/locale.js
@@ -34,7 +34,8 @@ if (localeSelector.length > 0) {
   localeSelector.change(function () {
     Cookies.set('locale', $(this).val(), {
       expires: 365,
-      sameSite: window.cookiePolicy
+      sameSite: window.cookiePolicy,
+      secure: window.location.protocol === 'https:'
     })
     window.location.reload()
   })


### PR DESCRIPTION
### Component/Part
Cookie handling in the frontend

### Description
This adds the secure flag to all cookies that are set
in the frontend for storing various settings.
If `SameSite=none` is set (like when embedding the instance is allowed),
 the `secure` flag is necessary to set any cookie.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
