### PR TITLE
Fix crash while getting current git commit

### DIFF
--- a/lib/config/utils.js
+++ b/lib/config/utils.js
@@ -25,16 +25,29 @@ exports.toIntegerConfig = function toIntegerConfig (configValue) {
 }
 
 exports.getGitCommit = function getGitCommit (repodir) {
-  if (!fs.existsSync(repodir + '/.git/HEAD')) {
-    return undefined
+  try {
+    // prefer using git to get the current ref, as poking in .git is very fragile
+    return require('child_process').execSync('git rev-parse HEAD')
+  } catch (e) {
+    // there was an error running git, try to parse refs ourselves
+    if (!fs.existsSync(repodir + '/.git/HEAD')) {
+      // there is no HEAD information
+      return undefined
+    }
+    let reference = fs.readFileSync(repodir + '/.git/HEAD', 'utf8')
+    if (reference.startsWith('ref: ')) {
+      // HEAD references another ref, try to get the commit SHA from .git/ref/heads
+      reference = reference.substr(5).replace('\n', '')
+      const refPath = path.resolve(repodir + '/.git', reference)
+      if (!fs.existsSync(refPath)) {
+        // ref does not exist in .git/ref/heads
+        return undefined
+      }
+      reference = fs.readFileSync(refPath, 'utf8')
+    }
+    reference = reference.replace('\n', '')
+    return reference
   }
-  let reference = fs.readFileSync(repodir + '/.git/HEAD', 'utf8')
-  if (reference.startsWith('ref: ')) {
-    reference = reference.substr(5).replace('\n', '')
-    reference = fs.readFileSync(path.resolve(repodir + '/.git', reference), 'utf8')
-  }
-  reference = reference.replace('\n', '')
-  return reference
 }
 
 exports.getGitHubURL = function getGitHubURL (repo, reference) {

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -6,6 +6,8 @@
   If you want to continue using Google Analytics or Disqus, you can re-enable them in the config.
   See [the docs](https://docs.hedgedoc.org/configuration/#web-security-aspects) for details.
   
+### Bugfixes
+- Fix crash when trying to read the current Git commit on startup 
 
 ## <i class="fa fa-tag"></i> 1.8.2 <i class="fa fa-calendar-o"></i> 2021-05-11
 


### PR DESCRIPTION
### Component/Part
git parsing in config utilities

### Description
HedgeDoc crashed with
`uncaughtException: ENOENT: no such file or directory`
on startup, when `.git/ref/heads` did not contain
a file for the current branch. This seems to happen
regularly with current Git versions.

This fixes the crash by first trying to use the `git` executable for
getting the current commit SHA (before running our own parsing code)
and introducing a separate check to prevent accessing a nonexistent
file in `.git/ref/heads`.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
