### PR TITLE
Various CI updates

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,10 +18,10 @@ jobs:
           - sudo apt install -y jq && yarn run jsonlint
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: yarn
       - run: yarn --frozen-lockfile --prefer-offline
       - run: ${{matrix.command}}
@@ -56,7 +56,7 @@ jobs:
       - run: yarn --frozen-lockfile --prefer-offline
       - run: yarn run build
       - uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/master' && matrix.node-version == '14.x'
+        if: github.ref == 'refs/heads/master' && matrix.node-version == '16.x'
         with:
           name: Prebuild with Node.js ${{ matrix.node-version }}
           path: |

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,16 +22,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
       - run: yarn --frozen-lockfile --prefer-offline
       - run: ${{matrix.command}}
   dynamic-tests:
@@ -46,16 +37,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
       - run: yarn --frozen-lockfile --prefer-offline
       - run: yarn run mocha-suite
   production-build:
@@ -70,16 +52,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
       - run: yarn --frozen-lockfile --prefer-offline
       - run: yarn run build
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12, 14, 16]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12, 14, 16]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -56,7 +56,7 @@ jobs:
       - run: yarn --frozen-lockfile --prefer-offline
       - run: yarn run build
       - uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/master' && matrix.node-version == '16.x'
+        if: github.ref == 'refs/heads/master' && matrix.node-version == '16'
         with:
           name: Prebuild with Node.js ${{ matrix.node-version }}
           path: |

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
### Component/Part
CI config

### Description
This PR is best reviewed commit-by-commit.
- It removes Node 15 (EOL)
- Migrates the cache feature to the one integrated into `actions/setup-node`
- Switches to Node 16 for non-matrix jobs

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
