### PR TITLE
Docs: Use Postgres 13 in Docker example

### DIFF
--- a/docs/content/setup/docker.md
+++ b/docs/content/setup/docker.md
@@ -18,7 +18,7 @@ The easiest way to get started with HedgeDoc and Docker is to use the following 
 version: '3'
 services:
   database:
-    image: postgres:9.6-alpine
+    image: postgres:13.4-alpine
     environment:
       - POSTGRES_USER=hedgedoc
       - POSTGRES_PASSWORD=password


### PR DESCRIPTION
### Component/Part
Docs

### Description
After https://github.com/hedgedoc/container/pull/181 has been merged,
we should now also use PG 13 in the example snippet.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
