### PR TITLE
Automatically retry DB connection on startup

### DIFF
--- a/app.js
+++ b/app.js
@@ -272,21 +272,38 @@ function startListen () {
   }
 }
 
-// sync db then start listen
-models.sequelize.authenticate().then(function () {
-  models.runMigrations().then(() => {
-    sessionStore.sync()
-    // check if realtime is ready
-    if (realtime.isReady()) {
-      models.Revision.checkAllNotesRevision(function (err, notes) {
-        if (err) throw new Error(err)
-        if (!notes || notes.length <= 0) return startListen()
-      })
+const maxDBTries = 30
+let currentDBTry = 1
+function syncAndListen () {
+  // sync db then start listen
+  models.sequelize.authenticate().then(function () {
+    models.runMigrations().then(() => {
+      sessionStore.sync()
+      // check if realtime is ready
+      if (realtime.isReady()) {
+        models.Revision.checkAllNotesRevision(function (err, notes) {
+          if (err) throw new Error(err)
+          if (!notes || notes.length <= 0) return startListen()
+        })
+      } else {
+        logger.error('server still not ready after db synced')
+        process.exit(1)
+      }
+    })
+  }).catch(() => {
+    if (currentDBTry < maxDBTries) {
+      logger.warn(`Database cannot be reached. Try ${currentDBTry} of ${maxDBTries}.`)
+      currentDBTry++
+      setTimeout(function () {
+        syncAndListen()
+      }, 1000)
     } else {
-      throw new Error('server still not ready after db synced')
+      logger.error('Cannot reach database! Exiting.')
+      process.exit(1)
     }
   })
-})
+}
+syncAndListen()
 
 // log uncaught exception
 process.on('uncaughtException', function (err) {

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -5,7 +5,10 @@
   they were repeatedly used to exploit security vulnerabilities.  
   If you want to continue using Google Analytics or Disqus, you can re-enable them in the config.
   See [the docs](https://docs.hedgedoc.org/configuration/#web-security-aspects) for details.
-  
+
+### Features
+- HedgeDoc now automatically retries connecting to the database up to 30 times on startup.
+
 ### Bugfixes
 - Fix crash when trying to read the current Git commit on startup 
 


### PR DESCRIPTION
### Component/Part
DB handling

### Description
This is a cherry-pick from https://github.com/hedgedoc/hedgedoc/pull/1228 and needed by https://github.com/hedgedoc/container/pull/186.

This adds retry logic to the initial DB connection on startup.
HedgeDoc now tries connecting to the database up to 30 times, waiting
one second after each try.
This gives a database that was simultaneously started (e.g. via
docker-compose) enough time to get ready to accept connections.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
