### PR TITLE
fix(image-upload): Fix swallowing of errors for filesystem

### DIFF
--- a/lib/web/imageRouter/filesystem.js
+++ b/lib/web/imageRouter/filesystem.js
@@ -22,7 +22,7 @@ exports.uploadImage = function (imagePath, callback) {
   try {
     fs.copyFileSync(imagePath, path.join(config.uploadsPath, fileName))
   } catch (e) {
-    callback(new Error('Error while moving file'), null)
+    callback(new Error(`Error while moving file: ${e.message}`), null)
     return
   }
   callback(null, (new URL(fileName, config.serverURL + '/uploads/')).href)


### PR DESCRIPTION
### Component/Part
image-upload/filesystem

### Description
This patch fixes the swallowing of the actual error message that appears
when a file fails to move, after being uploaded to Hedgedoc on an
instance that is using the upload-method `filesystem` active.

This became apparent when the error messages provided by some users,
where less than helpful.

As a solution the error message of the copy command was added to the
error that is output to the console.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
https://community.hedgedoc.org/t/image-upload-fail-docker/439
