### PR TITLE
Fix endless loop on shutdown when DB can't be reached

### DIFF
--- a/app.js
+++ b/app.js
@@ -309,9 +309,15 @@ process.on('uncaughtException', function (err) {
   process.exit(1)
 })
 
+let alreadyHandlingTermSignals = false
 // install exit handler
 function handleTermSignals () {
+  if (alreadyHandlingTermSignals) {
+    logger.info('Forcefully exiting.')
+    process.exit(1)
+  }
   logger.info('HedgeDoc has been killed by signal, try to exit gracefully...')
+  alreadyHandlingTermSignals = true
   realtime.maintenance = true
   // disconnect all socket.io clients
   Object.keys(io.sockets.sockets).forEach(function (key) {

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -11,6 +11,7 @@
 
 ### Bugfixes
 - Fix crash when trying to read the current Git commit on startup 
+- Fix endless loop on shutdown when HedgeDoc can't connect to the database
 
 ## <i class="fa fa-tag"></i> 1.8.2 <i class="fa fa-calendar-o"></i> 2021-05-11
 


### PR DESCRIPTION
### Component/Part
Shutdown handler

### Description
The shutdown handler calls `checkAllNotesRevision` on a 100 ms
interval. If the database connection is broken, this will return
an error. Previously, this error was effectively ignored and resulted
in an endless loop printing out the error message every 100 ms.

This improves the error handling by terminating the process with a
nonzero exit code when an error was encountered.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
