### PR TITLE
Fix unescaped line break in `git` output

### DIFF
--- a/lib/config/utils.js
+++ b/lib/config/utils.js
@@ -27,7 +27,7 @@ exports.toIntegerConfig = function toIntegerConfig (configValue) {
 exports.getGitCommit = function getGitCommit (repodir) {
   try {
     // prefer using git to get the current ref, as poking in .git is very fragile
-    return require('child_process').execSync('git rev-parse HEAD')
+    return require('child_process').execSync('git rev-parse HEAD').replace('\n', '')
   } catch (e) {
     // there was an error running git, try to parse refs ourselves
     if (!fs.existsSync(repodir + '/.git/HEAD')) {


### PR DESCRIPTION
### Component/Part
Git parsing

### Description
The command output contains a line break at the end, which confuses the browser.
This removes that linebreak.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
