### PR TITLE
Enforce consistent order of import statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
-    'prettier',
+    'plugin:prettier/recommended',
   ],
   root: true,
   env: {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "importOrder": ["^[./]"],
+  "importOrderSeparation": true
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.24.2",
+    "eslint-plugin-prettier": "^3.4.1",
     "jest": "27.1.0",
     "prettier": "2.3.2",
     "supertest": "6.1.6",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@nestjs/cli": "8.1.1",
     "@nestjs/schematics": "8.0.3",
     "@nestjs/testing": "8.0.6",
+    "@trivago/prettier-plugin-sort-imports": "^2.0.4",
     "@tsconfig/node12": "1.0.9",
     "@types/cli-color": "2.0.1",
     "@types/express": "4.17.13",

--- a/src/api/private/config/config.controller.spec.ts
+++ b/src/api/private/config/config.controller.spec.ts
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigController } from './config.controller';
-import { LoggerModule } from '../../../logger/logger.module';
-import { FrontendConfigModule } from '../../../frontend-config/frontend-config.module';
 import { ConfigModule } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+
 import appConfigMock from '../../../config/mock/app.config.mock';
 import authConfigMock from '../../../config/mock/auth.config.mock';
 import customizationConfigMock from '../../../config/mock/customization.config.mock';
 import externalConfigMock from '../../../config/mock/external-services.config.mock';
+import { FrontendConfigModule } from '../../../frontend-config/frontend-config.module';
+import { LoggerModule } from '../../../logger/logger.module';
+import { ConfigController } from './config.controller';
 
 describe('ConfigController', () => {
   let controller: ConfigController;

--- a/src/api/private/config/config.controller.ts
+++ b/src/api/private/config/config.controller.ts
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Controller, Get } from '@nestjs/common';
-import { ConsoleLoggerService } from '../../../logger/console-logger.service';
-import { FrontendConfigService } from '../../../frontend-config/frontend-config.service';
+
 import { FrontendConfigDto } from '../../../frontend-config/frontend-config.dto';
+import { FrontendConfigService } from '../../../frontend-config/frontend-config.service';
+import { ConsoleLoggerService } from '../../../logger/console-logger.service';
 
 @Controller('config')
 export class ConfigController {

--- a/src/api/private/me/history/history.controller.spec.ts
+++ b/src/api/private/me/history/history.controller.spec.ts
@@ -3,33 +3,33 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Author } from '../../../../authors/author.entity';
-import { Session } from '../../../../users/session.entity';
-import { HistoryController } from './history.controller';
-import { LoggerModule } from '../../../../logger/logger.module';
-import { UsersModule } from '../../../../users/users.module';
-import { HistoryModule } from '../../../../history/history.module';
-import { NotesModule } from '../../../../notes/notes.module';
 import {
   getConnectionToken,
   getRepositoryToken,
   TypeOrmModule,
 } from '@nestjs/typeorm';
-import { User } from '../../../../users/user.entity';
-import { Note } from '../../../../notes/note.entity';
+
 import { AuthToken } from '../../../../auth/auth-token.entity';
-import { Identity } from '../../../../users/identity.entity';
-import { Edit } from '../../../../revisions/edit.entity';
-import { Revision } from '../../../../revisions/revision.entity';
-import { Tag } from '../../../../notes/tag.entity';
+import { Author } from '../../../../authors/author.entity';
+import appConfigMock from '../../../../config/mock/app.config.mock';
+import { Group } from '../../../../groups/group.entity';
 import { HistoryEntry } from '../../../../history/history-entry.entity';
+import { HistoryModule } from '../../../../history/history.module';
+import { LoggerModule } from '../../../../logger/logger.module';
+import { Note } from '../../../../notes/note.entity';
+import { NotesModule } from '../../../../notes/notes.module';
+import { Tag } from '../../../../notes/tag.entity';
 import { NoteGroupPermission } from '../../../../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../../../../permissions/note-user-permission.entity';
-import { Group } from '../../../../groups/group.entity';
-import { ConfigModule } from '@nestjs/config';
-import appConfigMock from '../../../../config/mock/app.config.mock';
+import { Edit } from '../../../../revisions/edit.entity';
+import { Revision } from '../../../../revisions/revision.entity';
+import { Identity } from '../../../../users/identity.entity';
+import { Session } from '../../../../users/session.entity';
+import { User } from '../../../../users/user.entity';
+import { UsersModule } from '../../../../users/users.module';
+import { HistoryController } from './history.controller';
 
 describe('HistoryController', () => {
   let controller: HistoryController;

--- a/src/api/private/me/history/history.controller.ts
+++ b/src/api/private/me/history/history.controller.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   BadRequestException,
   Body,
@@ -16,13 +15,14 @@ import {
   Put,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { UsersService } from '../../../../users/users.service';
-import { HistoryEntryDto } from '../../../../history/history-entry.dto';
+
 import { ForbiddenIdError, NotInDBError } from '../../../../errors/errors';
 import { HistoryEntryImportDto } from '../../../../history/history-entry-import.dto';
 import { HistoryEntryUpdateDto } from '../../../../history/history-entry-update.dto';
-import { ConsoleLoggerService } from '../../../../logger/console-logger.service';
+import { HistoryEntryDto } from '../../../../history/history-entry.dto';
 import { HistoryService } from '../../../../history/history.service';
+import { ConsoleLoggerService } from '../../../../logger/console-logger.service';
+import { UsersService } from '../../../../users/users.service';
 
 @ApiTags('history')
 @Controller('/me/history')

--- a/src/api/private/me/me.controller.spec.ts
+++ b/src/api/private/me/me.controller.spec.ts
@@ -3,31 +3,31 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Author } from '../../../authors/author.entity';
-import { Session } from '../../../users/session.entity';
-import { MeController } from './me.controller';
-import { UsersModule } from '../../../users/users.module';
-import { LoggerModule } from '../../../logger/logger.module';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { User } from '../../../users/user.entity';
-import { Identity } from '../../../users/identity.entity';
+
+import { Author } from '../../../authors/author.entity';
+import appConfigMock from '../../../config/mock/app.config.mock';
+import authConfigMock from '../../../config/mock/auth.config.mock';
+import customizationConfigMock from '../../../config/mock/customization.config.mock';
+import externalServicesConfigMock from '../../../config/mock/external-services.config.mock';
+import mediaConfigMock from '../../../config/mock/media.config.mock';
+import { Group } from '../../../groups/group.entity';
+import { LoggerModule } from '../../../logger/logger.module';
+import { MediaUpload } from '../../../media/media-upload.entity';
 import { MediaModule } from '../../../media/media.module';
+import { Note } from '../../../notes/note.entity';
+import { Tag } from '../../../notes/tag.entity';
 import { NoteGroupPermission } from '../../../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
 import { Edit } from '../../../revisions/edit.entity';
-import { ConfigModule } from '@nestjs/config';
-import appConfigMock from '../../../config/mock/app.config.mock';
-import authConfigMock from '../../../config/mock/auth.config.mock';
-import mediaConfigMock from '../../../config/mock/media.config.mock';
-import customizationConfigMock from '../../../config/mock/customization.config.mock';
-import externalServicesConfigMock from '../../../config/mock/external-services.config.mock';
-import { MediaUpload } from '../../../media/media-upload.entity';
-import { Note } from '../../../notes/note.entity';
-import { Tag } from '../../../notes/tag.entity';
 import { Revision } from '../../../revisions/revision.entity';
-import { Group } from '../../../groups/group.entity';
+import { Identity } from '../../../users/identity.entity';
+import { Session } from '../../../users/session.entity';
+import { User } from '../../../users/user.entity';
+import { UsersModule } from '../../../users/users.module';
+import { MeController } from './me.controller';
 
 describe('MeController', () => {
   let controller: MeController;

--- a/src/api/private/me/me.controller.ts
+++ b/src/api/private/me/me.controller.ts
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Body, Controller, Delete, Get, HttpCode, Post } from '@nestjs/common';
-import { UserInfoDto } from '../../../users/user-info.dto';
+
 import { ConsoleLoggerService } from '../../../logger/console-logger.service';
-import { UsersService } from '../../../users/users.service';
-import { MediaService } from '../../../media/media.service';
 import { MediaUploadDto } from '../../../media/media-upload.dto';
+import { MediaService } from '../../../media/media.service';
+import { UserInfoDto } from '../../../users/user-info.dto';
+import { UsersService } from '../../../users/users.service';
 
 @Controller('me')
 export class MeController {

--- a/src/api/private/media/media.controller.spec.ts
+++ b/src/api/private/media/media.controller.spec.ts
@@ -3,33 +3,33 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { Test, TestingModule } from '@nestjs/testing';
-import { Author } from '../../../authors/author.entity';
-import { Session } from '../../../users/session.entity';
-import { UsersModule } from '../../../users/users.module';
-import { MediaController } from './media.controller';
-import { LoggerModule } from '../../../logger/logger.module';
 import { ConfigModule } from '@nestjs/config';
-import mediaConfigMock from '../../../config/mock/media.config.mock';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { AuthToken } from '../../../auth/auth-token.entity';
+import { Author } from '../../../authors/author.entity';
 import appConfigMock from '../../../config/mock/app.config.mock';
 import authConfigMock from '../../../config/mock/auth.config.mock';
 import customizationConfigMock from '../../../config/mock/customization.config.mock';
 import externalConfigMock from '../../../config/mock/external-services.config.mock';
-import { MediaModule } from '../../../media/media.module';
-import { NotesModule } from '../../../notes/notes.module';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { Edit } from '../../../revisions/edit.entity';
-import { AuthToken } from '../../../auth/auth-token.entity';
-import { Identity } from '../../../users/identity.entity';
+import mediaConfigMock from '../../../config/mock/media.config.mock';
+import { Group } from '../../../groups/group.entity';
+import { LoggerModule } from '../../../logger/logger.module';
 import { MediaUpload } from '../../../media/media-upload.entity';
+import { MediaModule } from '../../../media/media.module';
 import { Note } from '../../../notes/note.entity';
-import { Revision } from '../../../revisions/revision.entity';
-import { User } from '../../../users/user.entity';
+import { NotesModule } from '../../../notes/notes.module';
 import { Tag } from '../../../notes/tag.entity';
 import { NoteGroupPermission } from '../../../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
-import { Group } from '../../../groups/group.entity';
+import { Edit } from '../../../revisions/edit.entity';
+import { Revision } from '../../../revisions/revision.entity';
+import { Identity } from '../../../users/identity.entity';
+import { Session } from '../../../users/session.entity';
+import { User } from '../../../users/user.entity';
+import { UsersModule } from '../../../users/users.module';
+import { MediaController } from './media.controller';
 
 describe('MediaController', () => {
   let controller: MediaController;

--- a/src/api/private/media/media.controller.ts
+++ b/src/api/private/media/media.controller.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   BadRequestException,
   Controller,
@@ -14,16 +13,17 @@ import {
   UploadedFile,
   UseInterceptors,
 } from '@nestjs/common';
-import { ConsoleLoggerService } from '../../../logger/console-logger.service';
-import { MediaService } from '../../../media/media.service';
-import { MulterFile } from '../../../media/multer-file.interface';
-import { MediaUploadUrlDto } from '../../../media/media-upload-url.dto';
+import { FileInterceptor } from '@nestjs/platform-express';
+
 import {
   ClientError,
   MediaBackendError,
   NotInDBError,
 } from '../../../errors/errors';
-import { FileInterceptor } from '@nestjs/platform-express';
+import { ConsoleLoggerService } from '../../../logger/console-logger.service';
+import { MediaUploadUrlDto } from '../../../media/media-upload-url.dto';
+import { MediaService } from '../../../media/media.service';
+import { MulterFile } from '../../../media/multer-file.interface';
 
 @Controller('media')
 export class MediaController {

--- a/src/api/private/notes/notes.controller.spec.ts
+++ b/src/api/private/notes/notes.controller.spec.ts
@@ -3,39 +3,39 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Author } from '../../../authors/author.entity';
-import { Session } from '../../../users/session.entity';
-import { NotesController } from './notes.controller';
-import { NotesService } from '../../../notes/notes.service';
 import {
   getConnectionToken,
   getRepositoryToken,
   TypeOrmModule,
 } from '@nestjs/typeorm';
-import { Note } from '../../../notes/note.entity';
-import { Tag } from '../../../notes/tag.entity';
-import { RevisionsModule } from '../../../revisions/revisions.module';
-import { UsersModule } from '../../../users/users.module';
-import { GroupsModule } from '../../../groups/groups.module';
-import { LoggerModule } from '../../../logger/logger.module';
-import { PermissionsModule } from '../../../permissions/permissions.module';
-import { HistoryModule } from '../../../history/history.module';
-import { MediaModule } from '../../../media/media.module';
-import { ConfigModule } from '@nestjs/config';
+
+import { AuthToken } from '../../../auth/auth-token.entity';
+import { Author } from '../../../authors/author.entity';
 import appConfigMock from '../../../config/mock/app.config.mock';
 import mediaConfigMock from '../../../config/mock/media.config.mock';
-import { Revision } from '../../../revisions/revision.entity';
-import { Edit } from '../../../revisions/edit.entity';
-import { User } from '../../../users/user.entity';
-import { AuthToken } from '../../../auth/auth-token.entity';
-import { Identity } from '../../../users/identity.entity';
+import { Group } from '../../../groups/group.entity';
+import { GroupsModule } from '../../../groups/groups.module';
 import { HistoryEntry } from '../../../history/history-entry.entity';
+import { HistoryModule } from '../../../history/history.module';
+import { LoggerModule } from '../../../logger/logger.module';
+import { MediaUpload } from '../../../media/media-upload.entity';
+import { MediaModule } from '../../../media/media.module';
+import { Note } from '../../../notes/note.entity';
+import { NotesService } from '../../../notes/notes.service';
+import { Tag } from '../../../notes/tag.entity';
 import { NoteGroupPermission } from '../../../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
-import { Group } from '../../../groups/group.entity';
-import { MediaUpload } from '../../../media/media-upload.entity';
+import { PermissionsModule } from '../../../permissions/permissions.module';
+import { Edit } from '../../../revisions/edit.entity';
+import { Revision } from '../../../revisions/revision.entity';
+import { RevisionsModule } from '../../../revisions/revisions.module';
+import { Identity } from '../../../users/identity.entity';
+import { Session } from '../../../users/session.entity';
+import { User } from '../../../users/user.entity';
+import { UsersModule } from '../../../users/users.module';
+import { NotesController } from './notes.controller';
 
 describe('NotesController', () => {
   let controller: NotesController;

--- a/src/api/private/notes/notes.controller.ts
+++ b/src/api/private/notes/notes.controller.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   BadRequestException,
   Body,
@@ -16,25 +15,26 @@ import {
   Post,
   UnauthorizedException,
 } from '@nestjs/common';
-import { Note } from '../../../notes/note.entity';
+
 import {
   AlreadyInDBError,
   ForbiddenIdError,
   NotInDBError,
 } from '../../../errors/errors';
-import { NoteDto } from '../../../notes/note.dto';
-import { ConsoleLoggerService } from '../../../logger/console-logger.service';
-import { NotesService } from '../../../notes/notes.service';
-import { PermissionsService } from '../../../permissions/permissions.service';
 import { HistoryService } from '../../../history/history.service';
-import { UsersService } from '../../../users/users.service';
+import { ConsoleLoggerService } from '../../../logger/console-logger.service';
 import { MediaUploadDto } from '../../../media/media-upload.dto';
 import { MediaService } from '../../../media/media.service';
+import { NoteDto } from '../../../notes/note.dto';
+import { Note } from '../../../notes/note.entity';
+import { NoteMediaDeletionDto } from '../../../notes/note.media-deletion.dto';
+import { NotesService } from '../../../notes/notes.service';
+import { PermissionsService } from '../../../permissions/permissions.service';
 import { RevisionMetadataDto } from '../../../revisions/revision-metadata.dto';
 import { RevisionDto } from '../../../revisions/revision.dto';
 import { RevisionsService } from '../../../revisions/revisions.service';
+import { UsersService } from '../../../users/users.service';
 import { MarkdownBody } from '../../utils/markdownbody-decorator';
-import { NoteMediaDeletionDto } from '../../../notes/note.media-deletion.dto';
 
 @Controller('notes')
 export class NotesController {

--- a/src/api/private/private-api.module.ts
+++ b/src/api/private/private-api.module.ts
@@ -3,23 +3,23 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
-import { TokensController } from './tokens/tokens.controller';
-import { LoggerModule } from '../../logger/logger.module';
-import { UsersModule } from '../../users/users.module';
+
 import { AuthModule } from '../../auth/auth.module';
-import { MeController } from './me/me.controller';
-import { ConfigController } from './config/config.controller';
 import { FrontendConfigModule } from '../../frontend-config/frontend-config.module';
-import { HistoryController } from './me/history/history.controller';
 import { HistoryModule } from '../../history/history.module';
-import { NotesModule } from '../../notes/notes.module';
+import { LoggerModule } from '../../logger/logger.module';
 import { MediaModule } from '../../media/media.module';
-import { MediaController } from './media/media.controller';
-import { NotesController } from './notes/notes.controller';
+import { NotesModule } from '../../notes/notes.module';
 import { PermissionsModule } from '../../permissions/permissions.module';
 import { RevisionsModule } from '../../revisions/revisions.module';
+import { UsersModule } from '../../users/users.module';
+import { ConfigController } from './config/config.controller';
+import { HistoryController } from './me/history/history.controller';
+import { MeController } from './me/me.controller';
+import { MediaController } from './media/media.controller';
+import { NotesController } from './notes/notes.controller';
+import { TokensController } from './tokens/tokens.controller';
 
 @Module({
   imports: [

--- a/src/api/private/tokens/tokens.controller.spec.ts
+++ b/src/api/private/tokens/tokens.controller.spec.ts
@@ -3,18 +3,18 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Session } from '../../../users/session.entity';
-import { TokensController } from './tokens.controller';
-import { LoggerModule } from '../../../logger/logger.module';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Identity } from '../../../users/identity.entity';
-import { User } from '../../../users/user.entity';
+
 import { AuthToken } from '../../../auth/auth-token.entity';
 import { AuthModule } from '../../../auth/auth.module';
-import { ConfigModule } from '@nestjs/config';
 import appConfigMock from '../../../config/mock/app.config.mock';
+import { LoggerModule } from '../../../logger/logger.module';
+import { Identity } from '../../../users/identity.entity';
+import { Session } from '../../../users/session.entity';
+import { User } from '../../../users/user.entity';
+import { TokensController } from './tokens.controller';
 
 describe('TokensController', () => {
   let controller: TokensController;

--- a/src/api/private/tokens/tokens.controller.ts
+++ b/src/api/private/tokens/tokens.controller.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   Body,
   Controller,
@@ -13,12 +12,13 @@ import {
   Param,
   Post,
 } from '@nestjs/common';
-import { ConsoleLoggerService } from '../../../logger/console-logger.service';
-import { AuthService } from '../../../auth/auth.service';
-import { TimestampMillis } from '../../../utils/timestamp';
-import { AuthTokenDto } from '../../../auth/auth-token.dto';
-import { AuthTokenWithSecretDto } from '../../../auth/auth-token-with-secret.dto';
 import { ApiTags } from '@nestjs/swagger';
+
+import { AuthTokenWithSecretDto } from '../../../auth/auth-token-with-secret.dto';
+import { AuthTokenDto } from '../../../auth/auth-token.dto';
+import { AuthService } from '../../../auth/auth.service';
+import { ConsoleLoggerService } from '../../../logger/console-logger.service';
+import { TimestampMillis } from '../../../utils/timestamp';
 
 @ApiTags('tokens')
 @Controller('tokens')

--- a/src/api/public/me/me.controller.spec.ts
+++ b/src/api/public/me/me.controller.spec.ts
@@ -3,36 +3,36 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   getConnectionToken,
   getRepositoryToken,
   TypeOrmModule,
 } from '@nestjs/typeorm';
+
+import { AuthToken } from '../../../auth/auth-token.entity';
 import { Author } from '../../../authors/author.entity';
+import appConfigMock from '../../../config/mock/app.config.mock';
+import mediaConfigMock from '../../../config/mock/media.config.mock';
+import { Group } from '../../../groups/group.entity';
+import { HistoryEntry } from '../../../history/history-entry.entity';
 import { HistoryModule } from '../../../history/history.module';
 import { LoggerModule } from '../../../logger/logger.module';
+import { MediaUpload } from '../../../media/media-upload.entity';
+import { MediaModule } from '../../../media/media.module';
 import { Note } from '../../../notes/note.entity';
 import { NotesModule } from '../../../notes/notes.module';
 import { Tag } from '../../../notes/tag.entity';
+import { NoteGroupPermission } from '../../../permissions/note-group-permission.entity';
+import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
 import { Edit } from '../../../revisions/edit.entity';
 import { Revision } from '../../../revisions/revision.entity';
-import { AuthToken } from '../../../auth/auth-token.entity';
 import { Identity } from '../../../users/identity.entity';
 import { Session } from '../../../users/session.entity';
 import { User } from '../../../users/user.entity';
 import { UsersModule } from '../../../users/users.module';
 import { MeController } from './me.controller';
-import { HistoryEntry } from '../../../history/history-entry.entity';
-import { NoteGroupPermission } from '../../../permissions/note-group-permission.entity';
-import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
-import { Group } from '../../../groups/group.entity';
-import { MediaModule } from '../../../media/media.module';
-import { MediaUpload } from '../../../media/media-upload.entity';
-import { ConfigModule } from '@nestjs/config';
-import mediaConfigMock from '../../../config/mock/media.config.mock';
-import appConfigMock from '../../../config/mock/app.config.mock';
 
 describe('Me Controller', () => {
   let controller: MeController;

--- a/src/api/public/me/me.controller.ts
+++ b/src/api/public/me/me.controller.ts
@@ -9,12 +9,12 @@ import {
   Delete,
   Get,
   HttpCode,
+  InternalServerErrorException,
   NotFoundException,
   Param,
   Put,
-  UseGuards,
   Req,
-  InternalServerErrorException,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiNoContentResponse,

--- a/src/api/public/me/me.controller.ts
+++ b/src/api/public/me/me.controller.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   Body,
   Controller,
@@ -17,13 +16,6 @@ import {
   Req,
   InternalServerErrorException,
 } from '@nestjs/common';
-import { HistoryEntryUpdateDto } from '../../../history/history-entry-update.dto';
-import { HistoryService } from '../../../history/history.service';
-import { ConsoleLoggerService } from '../../../logger/console-logger.service';
-import { NoteMetadataDto } from '../../../notes/note-metadata.dto';
-import { NotesService } from '../../../notes/notes.service';
-import { UsersService } from '../../../users/users.service';
-import { TokenAuthGuard } from '../../../auth/token-auth.guard';
 import {
   ApiNoContentResponse,
   ApiNotFoundResponse,
@@ -32,12 +24,20 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { HistoryEntryDto } from '../../../history/history-entry.dto';
-import { UserInfoDto } from '../../../users/user-info.dto';
-import { NotInDBError } from '../../../errors/errors';
 import { Request } from 'express';
-import { MediaService } from '../../../media/media.service';
+
+import { TokenAuthGuard } from '../../../auth/token-auth.guard';
+import { NotInDBError } from '../../../errors/errors';
+import { HistoryEntryUpdateDto } from '../../../history/history-entry-update.dto';
+import { HistoryEntryDto } from '../../../history/history-entry.dto';
+import { HistoryService } from '../../../history/history.service';
+import { ConsoleLoggerService } from '../../../logger/console-logger.service';
 import { MediaUploadDto } from '../../../media/media-upload.dto';
+import { MediaService } from '../../../media/media.service';
+import { NoteMetadataDto } from '../../../notes/note-metadata.dto';
+import { NotesService } from '../../../notes/notes.service';
+import { UserInfoDto } from '../../../users/user-info.dto';
+import { UsersService } from '../../../users/users.service';
 import {
   notFoundDescription,
   successfullyDeletedDescription,

--- a/src/api/public/media/media.controller.spec.ts
+++ b/src/api/public/media/media.controller.spec.ts
@@ -3,29 +3,29 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { AuthToken } from '../../../auth/auth-token.entity';
 import { Author } from '../../../authors/author.entity';
 import appConfigMock from '../../../config/mock/app.config.mock';
 import mediaConfigMock from '../../../config/mock/media.config.mock';
+import { Group } from '../../../groups/group.entity';
 import { LoggerModule } from '../../../logger/logger.module';
 import { MediaUpload } from '../../../media/media-upload.entity';
 import { MediaModule } from '../../../media/media.module';
 import { Note } from '../../../notes/note.entity';
 import { NotesModule } from '../../../notes/notes.module';
 import { Tag } from '../../../notes/tag.entity';
+import { NoteGroupPermission } from '../../../permissions/note-group-permission.entity';
+import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
 import { Edit } from '../../../revisions/edit.entity';
 import { Revision } from '../../../revisions/revision.entity';
-import { AuthToken } from '../../../auth/auth-token.entity';
 import { Identity } from '../../../users/identity.entity';
 import { Session } from '../../../users/session.entity';
 import { User } from '../../../users/user.entity';
 import { MediaController } from './media.controller';
-import { NoteGroupPermission } from '../../../permissions/note-group-permission.entity';
-import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
-import { Group } from '../../../groups/group.entity';
 
 describe('Media Controller', () => {
   let controller: MediaController;

--- a/src/api/public/media/media.controller.ts
+++ b/src/api/public/media/media.controller.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   BadRequestException,
   Controller,
@@ -21,17 +20,6 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { Request } from 'express';
-import {
-  ClientError,
-  MediaBackendError,
-  NotInDBError,
-  PermissionError,
-} from '../../../errors/errors';
-import { ConsoleLoggerService } from '../../../logger/console-logger.service';
-import { MediaService } from '../../../media/media.service';
-import { MulterFile } from '../../../media/multer-file.interface';
-import { TokenAuthGuard } from '../../../auth/token-auth.guard';
 import {
   ApiBody,
   ApiConsumes,
@@ -43,7 +31,19 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { Request } from 'express';
+
+import { TokenAuthGuard } from '../../../auth/token-auth.guard';
+import {
+  ClientError,
+  MediaBackendError,
+  NotInDBError,
+  PermissionError,
+} from '../../../errors/errors';
+import { ConsoleLoggerService } from '../../../logger/console-logger.service';
 import { MediaUploadUrlDto } from '../../../media/media-upload-url.dto';
+import { MediaService } from '../../../media/media.service';
+import { MulterFile } from '../../../media/multer-file.interface';
 import {
   forbiddenDescription,
   successfullyDeletedDescription,

--- a/src/api/public/monitoring/monitoring.controller.spec.ts
+++ b/src/api/public/monitoring/monitoring.controller.spec.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Test, TestingModule } from '@nestjs/testing';
+
 import { MonitoringService } from '../../../monitoring/monitoring.service';
 import { MonitoringController } from './monitoring.controller';
 

--- a/src/api/public/monitoring/monitoring.controller.ts
+++ b/src/api/public/monitoring/monitoring.controller.ts
@@ -3,10 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Controller, Get, UseGuards } from '@nestjs/common';
-import { MonitoringService } from '../../../monitoring/monitoring.service';
-import { TokenAuthGuard } from '../../../auth/token-auth.guard';
 import {
   ApiForbiddenResponse,
   ApiOkResponse,
@@ -15,6 +12,9 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+
+import { TokenAuthGuard } from '../../../auth/token-auth.guard';
+import { MonitoringService } from '../../../monitoring/monitoring.service';
 import { ServerStatusDto } from '../../../monitoring/server-status.dto';
 import {
   forbiddenDescription,

--- a/src/api/public/notes/notes.controller.spec.ts
+++ b/src/api/public/notes/notes.controller.spec.ts
@@ -3,39 +3,39 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   getConnectionToken,
   getRepositoryToken,
   TypeOrmModule,
 } from '@nestjs/typeorm';
+
+import { AuthToken } from '../../../auth/auth-token.entity';
 import { Author } from '../../../authors/author.entity';
+import appConfigMock from '../../../config/mock/app.config.mock';
+import mediaConfigMock from '../../../config/mock/media.config.mock';
+import { Group } from '../../../groups/group.entity';
+import { GroupsModule } from '../../../groups/groups.module';
+import { HistoryEntry } from '../../../history/history-entry.entity';
+import { HistoryModule } from '../../../history/history.module';
 import { LoggerModule } from '../../../logger/logger.module';
+import { MediaUpload } from '../../../media/media-upload.entity';
+import { MediaModule } from '../../../media/media.module';
 import { Note } from '../../../notes/note.entity';
 import { NotesService } from '../../../notes/notes.service';
 import { Tag } from '../../../notes/tag.entity';
+import { NoteGroupPermission } from '../../../permissions/note-group-permission.entity';
+import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
+import { PermissionsModule } from '../../../permissions/permissions.module';
 import { Edit } from '../../../revisions/edit.entity';
 import { Revision } from '../../../revisions/revision.entity';
 import { RevisionsModule } from '../../../revisions/revisions.module';
-import { AuthToken } from '../../../auth/auth-token.entity';
 import { Identity } from '../../../users/identity.entity';
 import { Session } from '../../../users/session.entity';
 import { User } from '../../../users/user.entity';
 import { UsersModule } from '../../../users/users.module';
 import { NotesController } from './notes.controller';
-import { PermissionsModule } from '../../../permissions/permissions.module';
-import { HistoryModule } from '../../../history/history.module';
-import { HistoryEntry } from '../../../history/history-entry.entity';
-import { NoteGroupPermission } from '../../../permissions/note-group-permission.entity';
-import { NoteUserPermission } from '../../../permissions/note-user-permission.entity';
-import { Group } from '../../../groups/group.entity';
-import { GroupsModule } from '../../../groups/groups.module';
-import { ConfigModule } from '@nestjs/config';
-import { MediaModule } from '../../../media/media.module';
-import { MediaUpload } from '../../../media/media-upload.entity';
-import appConfigMock from '../../../config/mock/app.config.mock';
-import mediaConfigMock from '../../../config/mock/media.config.mock';
 
 describe('Notes Controller', () => {
   let controller: NotesController;

--- a/src/api/public/notes/notes.controller.ts
+++ b/src/api/public/notes/notes.controller.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   BadRequestException,
   Body,
@@ -22,22 +21,6 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import {
-  AlreadyInDBError,
-  ForbiddenIdError,
-  NotInDBError,
-  PermissionsUpdateInconsistentError,
-} from '../../../errors/errors';
-import { ConsoleLoggerService } from '../../../logger/console-logger.service';
-import {
-  NotePermissionsDto,
-  NotePermissionsUpdateDto,
-} from '../../../notes/note-permissions.dto';
-import { NotesService } from '../../../notes/notes.service';
-import { RevisionsService } from '../../../revisions/revisions.service';
-import { FullApi } from '../../utils/fullapi-decorator';
-import { MarkdownBody } from '../../utils/markdownbody-decorator';
-import { TokenAuthGuard } from '../../../auth/token-auth.guard';
-import {
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiNoContentResponse,
@@ -47,22 +30,39 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { Request } from 'express';
+
+import { TokenAuthGuard } from '../../../auth/token-auth.guard';
+import {
+  AlreadyInDBError,
+  ForbiddenIdError,
+  NotInDBError,
+  PermissionsUpdateInconsistentError,
+} from '../../../errors/errors';
 import { HistoryService } from '../../../history/history.service';
-import { NoteDto } from '../../../notes/note.dto';
+import { ConsoleLoggerService } from '../../../logger/console-logger.service';
+import { MediaUploadDto } from '../../../media/media-upload.dto';
+import { MediaService } from '../../../media/media.service';
 import { NoteMetadataDto } from '../../../notes/note-metadata.dto';
+import {
+  NotePermissionsDto,
+  NotePermissionsUpdateDto,
+} from '../../../notes/note-permissions.dto';
+import { NoteDto } from '../../../notes/note.dto';
+import { Note } from '../../../notes/note.entity';
+import { NoteMediaDeletionDto } from '../../../notes/note.media-deletion.dto';
+import { NotesService } from '../../../notes/notes.service';
+import { PermissionsService } from '../../../permissions/permissions.service';
 import { RevisionMetadataDto } from '../../../revisions/revision-metadata.dto';
 import { RevisionDto } from '../../../revisions/revision.dto';
-import { PermissionsService } from '../../../permissions/permissions.service';
-import { Note } from '../../../notes/note.entity';
-import { Request } from 'express';
+import { RevisionsService } from '../../../revisions/revisions.service';
 import {
   forbiddenDescription,
   successfullyDeletedDescription,
   unauthorizedDescription,
 } from '../../utils/descriptions';
-import { MediaUploadDto } from '../../../media/media-upload.dto';
-import { MediaService } from '../../../media/media.service';
-import { NoteMediaDeletionDto } from '../../../notes/note.media-deletion.dto';
+import { FullApi } from '../../utils/fullapi-decorator';
+import { MarkdownBody } from '../../utils/markdownbody-decorator';
 
 @ApiTags('notes')
 @ApiSecurity('token')

--- a/src/api/public/public-api.module.ts
+++ b/src/api/public/public-api.module.ts
@@ -3,20 +3,20 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
+
 import { HistoryModule } from '../../history/history.module';
 import { LoggerModule } from '../../logger/logger.module';
 import { MediaModule } from '../../media/media.module';
 import { MonitoringModule } from '../../monitoring/monitoring.module';
 import { NotesModule } from '../../notes/notes.module';
+import { PermissionsModule } from '../../permissions/permissions.module';
 import { RevisionsModule } from '../../revisions/revisions.module';
 import { UsersModule } from '../../users/users.module';
 import { MeController } from './me/me.controller';
-import { NotesController } from './notes/notes.controller';
 import { MediaController } from './media/media.controller';
 import { MonitoringController } from './monitoring/monitoring.controller';
-import { PermissionsModule } from '../../permissions/permissions.module';
+import { NotesController } from './notes/notes.controller';
 
 @Module({
   imports: [

--- a/src/api/utils/fullapi-decorator.ts
+++ b/src/api/utils/fullapi-decorator.ts
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { applyDecorators } from '@nestjs/common';
 import {
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+
 import { forbiddenDescription, notFoundDescription } from './descriptions';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/api/utils/markdownbody-decorator.ts
+++ b/src/api/utils/markdownbody-decorator.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   BadRequestException,
   createParamDecorator,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,12 +3,26 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { RouterModule, Routes } from 'nest-router';
+
+import { PrivateApiModule } from './api/private/private-api.module';
 import { PublicApiModule } from './api/public/public-api.module';
+import { AuthModule } from './auth/auth.module';
 import { AuthorsModule } from './authors/authors.module';
+import appConfig from './config/app.config';
+import authConfig from './config/auth.config';
+import cspConfig from './config/csp.config';
+import customizationConfig from './config/customization.config';
+import databaseConfig from './config/database.config';
+import externalConfig from './config/external-services.config';
+import hstsConfig from './config/hsts.config';
+import mediaConfig from './config/media.config';
+import { FrontendConfigModule } from './frontend-config/frontend-config.module';
+import { FrontendConfigService } from './frontend-config/frontend-config.service';
 import { GroupsModule } from './groups/groups.module';
 import { HistoryModule } from './history/history.module';
 import { LoggerModule } from './logger/logger.module';
@@ -18,20 +32,6 @@ import { NotesModule } from './notes/notes.module';
 import { PermissionsModule } from './permissions/permissions.module';
 import { RevisionsModule } from './revisions/revisions.module';
 import { UsersModule } from './users/users.module';
-import { AuthModule } from './auth/auth.module';
-import appConfig from './config/app.config';
-import mediaConfig from './config/media.config';
-import hstsConfig from './config/hsts.config';
-import cspConfig from './config/csp.config';
-import databaseConfig from './config/database.config';
-import authConfig from './config/auth.config';
-import customizationConfig from './config/customization.config';
-import externalConfig from './config/external-services.config';
-import { PrivateApiModule } from './api/private/private-api.module';
-import { ScheduleModule } from '@nestjs/schedule';
-import { RouterModule, Routes } from 'nest-router';
-import { FrontendConfigService } from './frontend-config/frontend-config.service';
-import { FrontendConfigModule } from './frontend-config/frontend-config.module';
 
 const routes: Routes = [
   {

--- a/src/auth/auth-token-with-secret.dto.ts
+++ b/src/auth/auth-token-with-secret.dto.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { IsString } from 'class-validator';
+
 import { AuthTokenDto } from './auth-token.dto';
 
 export class AuthTokenWithSecretDto extends AuthTokenDto {

--- a/src/auth/auth-token.dto.ts
+++ b/src/auth/auth-token.dto.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { IsDate, IsOptional, IsString } from 'class-validator';
 
 export class AuthTokenDto {

--- a/src/auth/auth-token.entity.ts
+++ b/src/auth/auth-token.entity.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   Column,
   CreateDateColumn,
@@ -11,6 +10,7 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+
 import { User } from '../users/user.entity';
 
 @Entity()

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,15 +3,15 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
-import { AuthService } from './auth.service';
-import { UsersModule } from '../users/users.module';
 import { PassportModule } from '@nestjs/passport';
-import { TokenStrategy } from './token.strategy';
-import { LoggerModule } from '../logger/logger.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { LoggerModule } from '../logger/logger.module';
+import { UsersModule } from '../users/users.module';
 import { AuthToken } from './auth-token.entity';
+import { AuthService } from './auth.service';
+import { TokenStrategy } from './token.strategy';
 
 @Module({
   imports: [

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -3,22 +3,22 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { Test, TestingModule } from '@nestjs/testing';
-import { Session } from '../users/session.entity';
-import { AuthService } from './auth.service';
+import { ConfigModule } from '@nestjs/config';
 import { PassportModule } from '@nestjs/passport';
+import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { randomBytes } from 'crypto';
+import { Repository } from 'typeorm';
+
+import appConfigMock from '../config/mock/app.config.mock';
+import { NotInDBError, TokenNotValidError } from '../errors/errors';
+import { LoggerModule } from '../logger/logger.module';
+import { Identity } from '../users/identity.entity';
+import { Session } from '../users/session.entity';
 import { User } from '../users/user.entity';
 import { UsersModule } from '../users/users.module';
-import { Identity } from '../users/identity.entity';
-import { LoggerModule } from '../logger/logger.module';
 import { AuthToken } from './auth-token.entity';
-import { NotInDBError, TokenNotValidError } from '../errors/errors';
-import { Repository } from 'typeorm';
-import { ConfigModule } from '@nestjs/config';
-import appConfigMock from '../config/mock/app.config.mock';
-import { randomBytes } from 'crypto';
+import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
   let service: AuthService;

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,25 +3,25 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Injectable } from '@nestjs/common';
-import { UsersService } from '../users/users.service';
-import { User } from '../users/user.entity';
-import { AuthToken } from './auth-token.entity';
-import { AuthTokenDto } from './auth-token.dto';
-import { AuthTokenWithSecretDto } from './auth-token-with-secret.dto';
+import { Cron, Timeout } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
 import { compare, hash } from 'bcrypt';
+import { randomBytes } from 'crypto';
+import { Repository } from 'typeorm';
+
 import {
   NotInDBError,
   TokenNotValidError,
   TooManyTokensError,
 } from '../errors/errors';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
+import { User } from '../users/user.entity';
+import { UsersService } from '../users/users.service';
 import { TimestampMillis } from '../utils/timestamp';
-import { Cron, Timeout } from '@nestjs/schedule';
-import { randomBytes } from 'crypto';
+import { AuthTokenWithSecretDto } from './auth-token-with-secret.dto';
+import { AuthTokenDto } from './auth-token.dto';
+import { AuthToken } from './auth-token.entity';
 
 @Injectable()
 export class AuthService {

--- a/src/auth/mock-auth.guard.ts
+++ b/src/auth/mock-auth.guard.ts
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { ExecutionContext, Injectable } from '@nestjs/common';
-import { UsersService } from '../users/users.service';
-import { User } from '../users/user.entity';
 import { Request } from 'express';
+
+import { User } from '../users/user.entity';
+import { UsersService } from '../users/users.service';
 
 @Injectable()
 export class MockAuthGuard {

--- a/src/auth/mock-auth.guard.ts
+++ b/src/auth/mock-auth.guard.ts
@@ -12,6 +12,7 @@ import { UsersService } from '../users/users.service';
 @Injectable()
 export class MockAuthGuard {
   private user: User;
+
   constructor(private usersService: UsersService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {

--- a/src/auth/token-auth.guard.ts
+++ b/src/auth/token-auth.guard.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 

--- a/src/auth/token.strategy.ts
+++ b/src/auth/token.strategy.ts
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { Strategy } from 'passport-http-bearer';
-import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { AuthService } from './auth.service';
-import { User } from '../users/user.entity';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-http-bearer';
+
 import { NotInDBError, TokenNotValidError } from '../errors/errors';
+import { User } from '../users/user.entity';
+import { AuthService } from './auth.service';
 
 @Injectable()
 export class TokenStrategy extends PassportStrategy(Strategy, 'token') {

--- a/src/authors/author.entity.ts
+++ b/src/authors/author.entity.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   Column,
   Entity,
@@ -11,6 +10,7 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+
 import { Edit } from '../revisions/edit.entity';
 import { Session } from '../users/session.entity';
 import { User } from '../users/user.entity';

--- a/src/authors/authors.module.ts
+++ b/src/authors/authors.module.ts
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { Author } from './author.entity';
 
 @Module({

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { registerAs } from '@nestjs/config';
 import * as Joi from 'joi';
+
 import { Loglevel } from './loglevel.enum';
 import { buildErrorMessage, parseOptionalInt, toArrayConfig } from './utils';
 

--- a/src/config/auth.config.ts
+++ b/src/config/auth.config.ts
@@ -3,15 +3,15 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { registerAs } from '@nestjs/config';
 import * as Joi from 'joi';
+
 import { GitlabScope, GitlabVersion } from './gitlab.enum';
 import {
   buildErrorMessage,
   replaceAuthErrorsWithEnvironmentVariables,
   toArrayConfig,
 } from './utils';
-import { registerAs } from '@nestjs/config';
 
 export interface AuthConfig {
   email: {

--- a/src/config/csp.config.ts
+++ b/src/config/csp.config.ts
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import * as Joi from 'joi';
 import { registerAs } from '@nestjs/config';
+import * as Joi from 'joi';
+
 import { buildErrorMessage } from './utils';
 
 export interface CspConfig {

--- a/src/config/customization.config.ts
+++ b/src/config/customization.config.ts
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { registerAs } from '@nestjs/config';
 import * as Joi from 'joi';
+
 import { buildErrorMessage } from './utils';
 
 export interface CustomizationConfig {

--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import * as Joi from 'joi';
-import { DatabaseDialect } from './database-dialect.enum';
 import { registerAs } from '@nestjs/config';
+import * as Joi from 'joi';
+
+import { DatabaseDialect } from './database-dialect.enum';
 import { buildErrorMessage, parseOptionalInt } from './utils';
 
 export interface DatabaseConfig {

--- a/src/config/external-services.config.ts
+++ b/src/config/external-services.config.ts
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { registerAs } from '@nestjs/config';
 import * as Joi from 'joi';
+
 import { buildErrorMessage } from './utils';
 
 export interface ExternalServicesConfig {

--- a/src/config/hsts.config.ts
+++ b/src/config/hsts.config.ts
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import * as Joi from 'joi';
 import { registerAs } from '@nestjs/config';
+import * as Joi from 'joi';
+
 import { buildErrorMessage, parseOptionalInt } from './utils';
 
 export interface HstsConfig {

--- a/src/config/media.config.ts
+++ b/src/config/media.config.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import * as Joi from 'joi';
-import { BackendType } from '../media/backends/backend-type.enum';
 import { registerAs } from '@nestjs/config';
+import * as Joi from 'joi';
+
+import { BackendType } from '../media/backends/backend-type.enum';
 import { buildErrorMessage } from './utils';
 
 export interface MediaConfig {

--- a/src/config/mock/app.config.mock.ts
+++ b/src/config/mock/app.config.mock.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { registerAs } from '@nestjs/config';
+
 import { Loglevel } from '../loglevel.enum';
 
 export default registerAs('appConfig', () => ({

--- a/src/config/mock/auth.config.mock.ts
+++ b/src/config/mock/auth.config.mock.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { registerAs } from '@nestjs/config';
 
 export default registerAs('authConfig', () => ({

--- a/src/config/mock/customization.config.mock.ts
+++ b/src/config/mock/customization.config.mock.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { registerAs } from '@nestjs/config';
 
 export default registerAs('customizationConfig', () => ({

--- a/src/config/mock/external-services.config.mock.ts
+++ b/src/config/mock/external-services.config.mock.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { registerAs } from '@nestjs/config';
 
 export default registerAs('externalServicesConfig', () => ({

--- a/src/config/mock/media.config.mock.ts
+++ b/src/config/mock/media.config.mock.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { registerAs } from '@nestjs/config';
 
 export default registerAs('mediaConfig', () => ({

--- a/src/config/utils.spec.ts
+++ b/src/config/utils.spec.ts
@@ -3,14 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { Loglevel } from './loglevel.enum';
 import {
   needToLog,
   parseOptionalInt,
   replaceAuthErrorsWithEnvironmentVariables,
   toArrayConfig,
 } from './utils';
-import { Loglevel } from './loglevel.enum';
 
 describe('config utils', () => {
   describe('toArrayConfig', () => {

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Loglevel } from './loglevel.enum';
 
 export function toArrayConfig(configValue?: string, separator = ','): string[] {

--- a/src/frontend-config/frontend-config.dto.ts
+++ b/src/frontend-config/frontend-config.dto.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   IsArray,
   IsBoolean,
@@ -13,6 +12,7 @@ import {
   IsUrl,
   ValidateNested,
 } from 'class-validator';
+
 import { ServerVersion } from '../monitoring/server-status.dto';
 
 export class AuthProviders {

--- a/src/frontend-config/frontend-config.module.ts
+++ b/src/frontend-config/frontend-config.module.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
-import { LoggerModule } from '../logger/logger.module';
 import { ConfigModule } from '@nestjs/config';
+
+import { LoggerModule } from '../logger/logger.module';
 import { FrontendConfigService } from './frontend-config.service';
 
 @Module({

--- a/src/frontend-config/frontend-config.service.spec.ts
+++ b/src/frontend-config/frontend-config.service.spec.ts
@@ -3,18 +3,18 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { Test, TestingModule } from '@nestjs/testing';
-import { FrontendConfigService } from './frontend-config.service';
 import { ConfigModule, registerAs } from '@nestjs/config';
-import { LoggerModule } from '../logger/logger.module';
-import { AuthConfig } from '../config/auth.config';
-import { GitlabScope, GitlabVersion } from '../config/gitlab.enum';
-import { getServerVersionFromPackageJson } from '../utils/serverVersion';
-import { CustomizationConfig } from '../config/customization.config';
+import { Test, TestingModule } from '@nestjs/testing';
+
 import { AppConfig } from '../config/app.config';
+import { AuthConfig } from '../config/auth.config';
+import { CustomizationConfig } from '../config/customization.config';
 import { ExternalServicesConfig } from '../config/external-services.config';
+import { GitlabScope, GitlabVersion } from '../config/gitlab.enum';
 import { Loglevel } from '../config/loglevel.enum';
+import { LoggerModule } from '../logger/logger.module';
+import { getServerVersionFromPackageJson } from '../utils/serverVersion';
+import { FrontendConfigService } from './frontend-config.service';
 
 /* eslint-disable
  jest/no-conditional-expect

--- a/src/frontend-config/frontend-config.service.ts
+++ b/src/frontend-config/frontend-config.service.ts
@@ -3,9 +3,18 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Inject, Injectable } from '@nestjs/common';
+
+import appConfiguration, { AppConfig } from '../config/app.config';
+import authConfiguration, { AuthConfig } from '../config/auth.config';
+import customizationConfiguration, {
+  CustomizationConfig,
+} from '../config/customization.config';
+import externalServicesConfiguration, {
+  ExternalServicesConfig,
+} from '../config/external-services.config';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
+import { getServerVersionFromPackageJson } from '../utils/serverVersion';
 import {
   AuthProviders,
   BrandingDto,
@@ -14,15 +23,6 @@ import {
   IframeCommunicationDto,
   SpecialUrlsDto,
 } from './frontend-config.dto';
-import authConfiguration, { AuthConfig } from '../config/auth.config';
-import customizationConfiguration, {
-  CustomizationConfig,
-} from '../config/customization.config';
-import appConfiguration, { AppConfig } from '../config/app.config';
-import externalServicesConfiguration, {
-  ExternalServicesConfig,
-} from '../config/external-services.config';
-import { getServerVersionFromPackageJson } from '../utils/serverVersion';
 
 @Injectable()
 export class FrontendConfigService {

--- a/src/groups/group-info.dto.ts
+++ b/src/groups/group-info.dto.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { IsBoolean, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsString } from 'class-validator';
 
 export class GroupInfoDto {
   /**

--- a/src/groups/group.entity.ts
+++ b/src/groups/group.entity.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   Column,
   Entity,
@@ -11,6 +10,7 @@ import {
   ManyToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+
 import { User } from '../users/user.entity';
 
 @Entity()

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -3,12 +3,12 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { LoggerModule } from '../logger/logger.module';
 import { Group } from './group.entity';
 import { GroupsService } from './groups.service';
-import { LoggerModule } from '../logger/logger.module';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Group]), LoggerModule],

--- a/src/groups/groups.service.spec.ts
+++ b/src/groups/groups.service.spec.ts
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import { GroupsService } from './groups.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Group } from './group.entity';
+
+import appConfigMock from '../config/mock/app.config.mock';
 import { NotInDBError } from '../errors/errors';
 import { LoggerModule } from '../logger/logger.module';
-import { ConfigModule } from '@nestjs/config';
-import appConfigMock from '../config/mock/app.config.mock';
+import { Group } from './group.entity';
+import { GroupsService } from './groups.service';
 
 describe('GroupsService', () => {
   let service: GroupsService;

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -3,14 +3,14 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Injectable } from '@nestjs/common';
-import { ConsoleLoggerService } from '../logger/console-logger.service';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Group } from './group.entity';
+
 import { NotInDBError } from '../errors/errors';
+import { ConsoleLoggerService } from '../logger/console-logger.service';
 import { GroupInfoDto } from './group-info.dto';
+import { Group } from './group.entity';
 
 @Injectable()
 export class GroupsService {

--- a/src/history/history-entry-import.dto.ts
+++ b/src/history/history-entry-import.dto.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { IsBoolean, IsDate, IsString } from 'class-validator';
 
 export class HistoryEntryImportDto {

--- a/src/history/history-entry-update.dto.ts
+++ b/src/history/history-entry-update.dto.ts
@@ -3,9 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { IsBoolean } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
 
 export class HistoryEntryUpdateDto {
   /**

--- a/src/history/history-entry.dto.ts
+++ b/src/history/history-entry.dto.ts
@@ -3,9 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { IsArray, IsBoolean, IsDate, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsBoolean, IsDate, IsString } from 'class-validator';
 
 export class HistoryEntryDto {
   /**

--- a/src/history/history-entry.entity.ts
+++ b/src/history/history-entry.entity.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Column, Entity, ManyToOne, UpdateDateColumn } from 'typeorm';
-import { User } from '../users/user.entity';
+
 import { Note } from '../notes/note.entity';
+import { User } from '../users/user.entity';
 
 @Entity()
 export class HistoryEntry {

--- a/src/history/history.module.ts
+++ b/src/history/history.module.ts
@@ -3,15 +3,15 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
-import { LoggerModule } from '../logger/logger.module';
-import { HistoryService } from './history.service';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { HistoryEntry } from './history-entry.entity';
-import { UsersModule } from '../users/users.module';
-import { NotesModule } from '../notes/notes.module';
 import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { LoggerModule } from '../logger/logger.module';
+import { NotesModule } from '../notes/notes.module';
+import { UsersModule } from '../users/users.module';
+import { HistoryEntry } from './history-entry.entity';
+import { HistoryService } from './history.service';
 
 @Module({
   providers: [HistoryService],

--- a/src/history/history.service.spec.ts
+++ b/src/history/history.service.spec.ts
@@ -3,31 +3,31 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Author } from '../authors/author.entity';
-import { LoggerModule } from '../logger/logger.module';
-import { Session } from '../users/session.entity';
-import { HistoryService } from './history.service';
-import { UsersModule } from '../users/users.module';
-import { NotesModule } from '../notes/notes.module';
 import { getConnectionToken, getRepositoryToken } from '@nestjs/typeorm';
-import { Identity } from '../users/identity.entity';
-import { User } from '../users/user.entity';
-import { Edit } from '../revisions/edit.entity';
-import { HistoryEntry } from './history-entry.entity';
-import { Note } from '../notes/note.entity';
-import { Tag } from '../notes/tag.entity';
-import { AuthToken } from '../auth/auth-token.entity';
-import { Revision } from '../revisions/revision.entity';
 import { Connection, Repository } from 'typeorm';
+
+import { AuthToken } from '../auth/auth-token.entity';
+import { Author } from '../authors/author.entity';
+import appConfigMock from '../config/mock/app.config.mock';
 import { NotInDBError } from '../errors/errors';
+import { Group } from '../groups/group.entity';
+import { LoggerModule } from '../logger/logger.module';
+import { Note } from '../notes/note.entity';
+import { NotesModule } from '../notes/notes.module';
+import { Tag } from '../notes/tag.entity';
 import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../permissions/note-user-permission.entity';
-import { Group } from '../groups/group.entity';
-import { ConfigModule } from '@nestjs/config';
-import appConfigMock from '../config/mock/app.config.mock';
+import { Edit } from '../revisions/edit.entity';
+import { Revision } from '../revisions/revision.entity';
+import { Identity } from '../users/identity.entity';
+import { Session } from '../users/session.entity';
+import { User } from '../users/user.entity';
+import { UsersModule } from '../users/users.module';
 import { HistoryEntryImportDto } from './history-entry-import.dto';
+import { HistoryEntry } from './history-entry.entity';
+import { HistoryService } from './history.service';
 
 describe('HistoryService', () => {
   let service: HistoryService;

--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -3,20 +3,20 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Injectable } from '@nestjs/common';
-import { ConsoleLoggerService } from '../logger/console-logger.service';
-import { HistoryEntryUpdateDto } from './history-entry-update.dto';
-import { HistoryEntryDto } from './history-entry.dto';
 import { InjectConnection, InjectRepository } from '@nestjs/typeorm';
 import { Connection, Repository } from 'typeorm';
-import { HistoryEntry } from './history-entry.entity';
-import { UsersService } from '../users/users.service';
+
+import { NotInDBError } from '../errors/errors';
+import { ConsoleLoggerService } from '../logger/console-logger.service';
+import { Note } from '../notes/note.entity';
 import { NotesService } from '../notes/notes.service';
 import { User } from '../users/user.entity';
-import { Note } from '../notes/note.entity';
-import { NotInDBError } from '../errors/errors';
+import { UsersService } from '../users/users.service';
 import { HistoryEntryImportDto } from './history-entry-import.dto';
+import { HistoryEntryUpdateDto } from './history-entry-update.dto';
+import { HistoryEntryDto } from './history-entry.dto';
+import { HistoryEntry } from './history-entry.entity';
 
 @Injectable()
 export class HistoryService {

--- a/src/logger/console-logger.service.ts
+++ b/src/logger/console-logger.service.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   Inject,
   Injectable,
@@ -12,11 +11,13 @@ import {
   Scope,
 } from '@nestjs/common';
 import { isObject } from '@nestjs/common/utils/shared.utils';
-import clc = require('cli-color');
-import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
+
 import appConfiguration, { AppConfig } from '../config/app.config';
 import { Loglevel } from '../config/loglevel.enum';
 import { needToLog } from '../config/utils';
+
+import clc = require('cli-color');
+import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
 
 @Injectable({ scope: Scope.TRANSIENT })
 export class ConsoleLoggerService implements LoggerService {

--- a/src/logger/logger.module.ts
+++ b/src/logger/logger.module.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
+
 import { ConsoleLoggerService } from './console-logger.service';
 
 @Module({

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,17 +3,17 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { LogLevel, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
+
 import { AppModule } from './app.module';
 import { AppConfig } from './config/app.config';
 import { MediaConfig } from './config/media.config';
-import { setupPrivateApiDocs, setupPublicApiDocs } from './utils/swagger';
-import { BackendType } from './media/backends/backend-type.enum';
 import { ConsoleLoggerService } from './logger/console-logger.service';
+import { BackendType } from './media/backends/backend-type.enum';
+import { setupPrivateApiDocs, setupPublicApiDocs } from './utils/swagger';
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {

--- a/src/media/backends/azure-backend.ts
+++ b/src/media/backends/azure-backend.ts
@@ -3,19 +3,19 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { Inject, Injectable } from '@nestjs/common';
-import mediaConfiguration, { MediaConfig } from '../../config/media.config';
-import { ConsoleLoggerService } from '../../logger/console-logger.service';
-import { MediaBackend } from '../media-backend.interface';
-import { BackendData } from '../media-upload.entity';
 import {
   BlobServiceClient,
   BlockBlobClient,
   ContainerClient,
 } from '@azure/storage-blob';
-import { BackendType } from './backend-type.enum';
+import { Inject, Injectable } from '@nestjs/common';
+
+import mediaConfiguration, { MediaConfig } from '../../config/media.config';
 import { MediaBackendError } from '../../errors/errors';
+import { ConsoleLoggerService } from '../../logger/console-logger.service';
+import { MediaBackend } from '../media-backend.interface';
+import { BackendData } from '../media-upload.entity';
+import { BackendType } from './backend-type.enum';
 
 @Injectable()
 export class AzureBackend implements MediaBackend {

--- a/src/media/backends/filesystem-backend.ts
+++ b/src/media/backends/filesystem-backend.ts
@@ -7,8 +7,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 
-import mediaConfiguration from '../../config/media.config';
-import { MediaConfig } from '../../config/media.config';
+import mediaConfiguration, { MediaConfig } from '../../config/media.config';
 import { MediaBackendError } from '../../errors/errors';
 import { ConsoleLoggerService } from '../../logger/console-logger.service';
 import { MediaBackend } from '../media-backend.interface';

--- a/src/media/backends/filesystem-backend.ts
+++ b/src/media/backends/filesystem-backend.ts
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Inject, Injectable } from '@nestjs/common';
 import { promises as fs } from 'fs';
 import { join } from 'path';
+
 import mediaConfiguration from '../../config/media.config';
+import { MediaConfig } from '../../config/media.config';
+import { MediaBackendError } from '../../errors/errors';
 import { ConsoleLoggerService } from '../../logger/console-logger.service';
 import { MediaBackend } from '../media-backend.interface';
 import { BackendData } from '../media-upload.entity';
-import { MediaConfig } from '../../config/media.config';
-import { MediaBackendError } from '../../errors/errors';
 
 @Injectable()
 export class FilesystemBackend implements MediaBackend {

--- a/src/media/backends/imgur-backend.ts
+++ b/src/media/backends/imgur-backend.ts
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Inject, Injectable } from '@nestjs/common';
+import fetch, { Response } from 'node-fetch';
+import { URLSearchParams } from 'url';
+
 import mediaConfiguration from '../../config/media.config';
+import { MediaConfig } from '../../config/media.config';
+import { MediaBackendError } from '../../errors/errors';
 import { ConsoleLoggerService } from '../../logger/console-logger.service';
 import { MediaBackend } from '../media-backend.interface';
 import { BackendData } from '../media-upload.entity';
-import { MediaConfig } from '../../config/media.config';
-import fetch, { Response } from 'node-fetch';
-import { URLSearchParams } from 'url';
-import { MediaBackendError } from '../../errors/errors';
 
 type UploadResult = {
   data: {

--- a/src/media/backends/imgur-backend.ts
+++ b/src/media/backends/imgur-backend.ts
@@ -7,8 +7,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import fetch, { Response } from 'node-fetch';
 import { URLSearchParams } from 'url';
 
-import mediaConfiguration from '../../config/media.config';
-import { MediaConfig } from '../../config/media.config';
+import mediaConfiguration, { MediaConfig } from '../../config/media.config';
 import { MediaBackendError } from '../../errors/errors';
 import { ConsoleLoggerService } from '../../logger/console-logger.service';
 import { MediaBackend } from '../media-backend.interface';

--- a/src/media/backends/s3-backend.ts
+++ b/src/media/backends/s3-backend.ts
@@ -6,8 +6,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Client } from 'minio';
 
-import mediaConfiguration from '../../config/media.config';
-import { MediaConfig } from '../../config/media.config';
+import mediaConfiguration, { MediaConfig } from '../../config/media.config';
 import { MediaBackendError } from '../../errors/errors';
 import { ConsoleLoggerService } from '../../logger/console-logger.service';
 import { MediaBackend } from '../media-backend.interface';

--- a/src/media/backends/s3-backend.ts
+++ b/src/media/backends/s3-backend.ts
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Inject, Injectable } from '@nestjs/common';
+import { Client } from 'minio';
+
 import mediaConfiguration from '../../config/media.config';
+import { MediaConfig } from '../../config/media.config';
+import { MediaBackendError } from '../../errors/errors';
 import { ConsoleLoggerService } from '../../logger/console-logger.service';
 import { MediaBackend } from '../media-backend.interface';
 import { BackendData } from '../media-upload.entity';
-import { MediaConfig } from '../../config/media.config';
-import { Client } from 'minio';
 import { BackendType } from './backend-type.enum';
-import { MediaBackendError } from '../../errors/errors';
 
 @Injectable()
 export class S3Backend implements MediaBackend {

--- a/src/media/backends/webdav-backend.ts
+++ b/src/media/backends/webdav-backend.ts
@@ -6,8 +6,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import fetch, { Response } from 'node-fetch';
 
-import mediaConfiguration from '../../config/media.config';
-import { MediaConfig } from '../../config/media.config';
+import mediaConfiguration, { MediaConfig } from '../../config/media.config';
 import { MediaBackendError } from '../../errors/errors';
 import { ConsoleLoggerService } from '../../logger/console-logger.service';
 import { MediaBackend } from '../media-backend.interface';

--- a/src/media/backends/webdav-backend.ts
+++ b/src/media/backends/webdav-backend.ts
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Inject, Injectable } from '@nestjs/common';
+import fetch, { Response } from 'node-fetch';
+
 import mediaConfiguration from '../../config/media.config';
+import { MediaConfig } from '../../config/media.config';
+import { MediaBackendError } from '../../errors/errors';
 import { ConsoleLoggerService } from '../../logger/console-logger.service';
 import { MediaBackend } from '../media-backend.interface';
 import { BackendData } from '../media-upload.entity';
-import { MediaConfig } from '../../config/media.config';
-import { MediaBackendError } from '../../errors/errors';
 import { BackendType } from './backend-type.enum';
-import fetch, { Response } from 'node-fetch';
 
 @Injectable()
 export class WebdavBackend implements MediaBackend {

--- a/src/media/media-backend.interface.ts
+++ b/src/media/media-backend.interface.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { BackendData } from './media-upload.entity';
 
 export interface MediaBackend {

--- a/src/media/media-upload-url.dto.ts
+++ b/src/media/media-upload-url.dto.ts
@@ -3,9 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
 
 export class MediaUploadUrlDto {
   @IsString()

--- a/src/media/media-upload.dto.ts
+++ b/src/media/media-upload.dto.ts
@@ -3,9 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { IsDate, IsOptional, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsOptional, IsString } from 'class-validator';
 
 export class MediaUploadDto {
   /**

--- a/src/media/media-upload.entity.ts
+++ b/src/media/media-upload.entity.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import * as crypto from 'crypto';
 import {
   Column,
@@ -12,6 +11,7 @@ import {
   ManyToOne,
   PrimaryColumn,
 } from 'typeorm';
+
 import { Note } from '../notes/note.entity';
 import { User } from '../users/user.entity';
 import { BackendType } from './backends/backend-type.enum';

--- a/src/media/media.module.ts
+++ b/src/media/media.module.ts
@@ -3,20 +3,20 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { LoggerModule } from '../logger/logger.module';
 import { NotesModule } from '../notes/notes.module';
 import { UsersModule } from '../users/users.module';
+import { AzureBackend } from './backends/azure-backend';
 import { FilesystemBackend } from './backends/filesystem-backend';
+import { ImgurBackend } from './backends/imgur-backend';
+import { S3Backend } from './backends/s3-backend';
+import { WebdavBackend } from './backends/webdav-backend';
 import { MediaUpload } from './media-upload.entity';
 import { MediaService } from './media.service';
-import { S3Backend } from './backends/s3-backend';
-import { ImgurBackend } from './backends/imgur-backend';
-import { AzureBackend } from './backends/azure-backend';
-import { WebdavBackend } from './backends/webdav-backend';
 
 @Module({
   imports: [

--- a/src/media/media.service.spec.ts
+++ b/src/media/media.service.spec.ts
@@ -3,19 +3,26 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { promises as fs } from 'fs';
+import { Repository } from 'typeorm';
+
+import appConfigMock from '../../src/config/mock/app.config.mock';
+import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
 import mediaConfigMock from '../config/mock/media.config.mock';
+import { ClientError, NotInDBError } from '../errors/errors';
+import { Group } from '../groups/group.entity';
 import { LoggerModule } from '../logger/logger.module';
 import { Note } from '../notes/note.entity';
 import { NotesModule } from '../notes/notes.module';
 import { Tag } from '../notes/tag.entity';
+import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
+import { NoteUserPermission } from '../permissions/note-user-permission.entity';
 import { Edit } from '../revisions/edit.entity';
 import { Revision } from '../revisions/revision.entity';
-import { AuthToken } from '../auth/auth-token.entity';
 import { Identity } from '../users/identity.entity';
 import { Session } from '../users/session.entity';
 import { User } from '../users/user.entity';
@@ -23,13 +30,6 @@ import { UsersModule } from '../users/users.module';
 import { FilesystemBackend } from './backends/filesystem-backend';
 import { BackendData, MediaUpload } from './media-upload.entity';
 import { MediaService } from './media.service';
-import { Repository } from 'typeorm';
-import { promises as fs } from 'fs';
-import { ClientError, NotInDBError } from '../errors/errors';
-import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
-import { NoteUserPermission } from '../permissions/note-user-permission.entity';
-import { Group } from '../groups/group.entity';
-import appConfigMock from '../../src/config/mock/app.config.mock';
 
 describe('MediaService', () => {
   let service: MediaService;

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -3,29 +3,29 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Inject, Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as FileType from 'file-type';
 import { Repository } from 'typeorm';
+
 import mediaConfiguration, { MediaConfig } from '../config/media.config';
 import { ClientError, NotInDBError } from '../errors/errors';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
+import { Note } from '../notes/note.entity';
 import { NotesService } from '../notes/notes.service';
+import { User } from '../users/user.entity';
 import { UsersService } from '../users/users.service';
+import { AzureBackend } from './backends/azure-backend';
 import { BackendType } from './backends/backend-type.enum';
 import { FilesystemBackend } from './backends/filesystem-backend';
-import { MediaBackend } from './media-backend.interface';
-import { MediaUpload } from './media-upload.entity';
-import { MediaUploadUrlDto } from './media-upload-url.dto';
-import { S3Backend } from './backends/s3-backend';
-import { AzureBackend } from './backends/azure-backend';
 import { ImgurBackend } from './backends/imgur-backend';
-import { User } from '../users/user.entity';
-import { MediaUploadDto } from './media-upload.dto';
-import { Note } from '../notes/note.entity';
+import { S3Backend } from './backends/s3-backend';
 import { WebdavBackend } from './backends/webdav-backend';
+import { MediaBackend } from './media-backend.interface';
+import { MediaUploadUrlDto } from './media-upload-url.dto';
+import { MediaUploadDto } from './media-upload.dto';
+import { MediaUpload } from './media-upload.entity';
 
 @Injectable()
 export class MediaService {

--- a/src/media/multer-file.interface.ts
+++ b/src/media/multer-file.interface.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Readable } from 'stream';
 
 // Type from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/multer/index.d.ts

--- a/src/monitoring/monitoring.module.ts
+++ b/src/monitoring/monitoring.module.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
+
 import { LoggerModule } from '../logger/logger.module';
 import { MonitoringService } from './monitoring.service';
 

--- a/src/monitoring/monitoring.service.spec.ts
+++ b/src/monitoring/monitoring.service.spec.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Test, TestingModule } from '@nestjs/testing';
+
 import { MonitoringService } from './monitoring.service';
 
 describe('MonitoringService', () => {

--- a/src/monitoring/monitoring.service.ts
+++ b/src/monitoring/monitoring.service.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Injectable } from '@nestjs/common';
-import { ServerStatusDto } from './server-status.dto';
+
 import { getServerVersionFromPackageJson } from '../utils/serverVersion';
+import { ServerStatusDto } from './server-status.dto';
 
 @Injectable()
 export class MonitoringService {

--- a/src/monitoring/server-status.dto.ts
+++ b/src/monitoring/server-status.dto.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { ApiProperty } from '@nestjs/swagger';
 
 export class ServerVersion {

--- a/src/notes/note-metadata.dto.ts
+++ b/src/notes/note-metadata.dto.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsArray,
   IsDate,
@@ -12,9 +12,9 @@ import {
   IsString,
   ValidateNested,
 } from 'class-validator';
+
 import { UserInfoDto } from '../users/user-info.dto';
 import { NotePermissionsDto } from './note-permissions.dto';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class NoteMetadataDto {
   /**

--- a/src/notes/note-permissions.dto.ts
+++ b/src/notes/note-permissions.dto.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsArray,
   IsBoolean,
@@ -11,9 +11,9 @@ import {
   IsString,
   ValidateNested,
 } from 'class-validator';
-import { UserInfoDto } from '../users/user-info.dto';
+
 import { GroupInfoDto } from '../groups/group-info.dto';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { UserInfoDto } from '../users/user-info.dto';
 
 export class NoteUserPermissionEntryDto {
   /**

--- a/src/notes/note.dto.ts
+++ b/src/notes/note.dto.ts
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsString, ValidateNested } from 'class-validator';
+
 import { EditDto } from '../revisions/edit.dto';
 import { NoteMetadataDto } from './note-metadata.dto';
-import { ApiProperty } from '@nestjs/swagger';
 
 export class NoteDto {
   /**

--- a/src/notes/note.entity.ts
+++ b/src/notes/note.entity.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   Column,
   Entity,
@@ -13,13 +12,14 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+
+import { HistoryEntry } from '../history/history-entry.entity';
+import { MediaUpload } from '../media/media-upload.entity';
 import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../permissions/note-user-permission.entity';
 import { Revision } from '../revisions/revision.entity';
 import { User } from '../users/user.entity';
 import { Tag } from './tag.entity';
-import { HistoryEntry } from '../history/history-entry.entity';
-import { MediaUpload } from '../media/media-upload.entity';
 import { generatePublicId } from './utils';
 
 @Entity()

--- a/src/notes/note.media-deletion.dto.ts
+++ b/src/notes/note.media-deletion.dto.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { IsBoolean } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
 
 export class NoteMediaDeletionDto {
   /**

--- a/src/notes/notes.module.ts
+++ b/src/notes/notes.module.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { forwardRef, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { GroupsModule } from '../groups/groups.module';
 import { LoggerModule } from '../logger/logger.module';
 import { NoteGroupPermission } from '../permissions/note-group-permission.entity';

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -3,39 +3,39 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Author } from '../authors/author.entity';
-import { LoggerModule } from '../logger/logger.module';
-import { Edit } from '../revisions/edit.entity';
-import { Revision } from '../revisions/revision.entity';
-import { RevisionsModule } from '../revisions/revisions.module';
-import { AuthToken } from '../auth/auth-token.entity';
-import { Identity } from '../users/identity.entity';
-import { Session } from '../users/session.entity';
-import { User } from '../users/user.entity';
-import { UsersModule } from '../users/users.module';
-import { Note } from './note.entity';
-import { NotesService } from './notes.service';
 import { Repository } from 'typeorm';
-import { Tag } from './tag.entity';
+
+import { AuthToken } from '../auth/auth-token.entity';
+import { Author } from '../authors/author.entity';
+import appConfigMock from '../config/mock/app.config.mock';
 import {
   AlreadyInDBError,
   ForbiddenIdError,
   NotInDBError,
   PermissionsUpdateInconsistentError,
 } from '../errors/errors';
+import { Group } from '../groups/group.entity';
+import { GroupsModule } from '../groups/groups.module';
+import { LoggerModule } from '../logger/logger.module';
+import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
+import { NoteUserPermission } from '../permissions/note-user-permission.entity';
+import { Edit } from '../revisions/edit.entity';
+import { Revision } from '../revisions/revision.entity';
+import { RevisionsModule } from '../revisions/revisions.module';
+import { Identity } from '../users/identity.entity';
+import { Session } from '../users/session.entity';
+import { User } from '../users/user.entity';
+import { UsersModule } from '../users/users.module';
 import {
   NoteGroupPermissionUpdateDto,
   NoteUserPermissionUpdateDto,
 } from './note-permissions.dto';
-import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
-import { NoteUserPermission } from '../permissions/note-user-permission.entity';
-import { GroupsModule } from '../groups/groups.module';
-import { Group } from '../groups/group.entity';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import appConfigMock from '../config/mock/app.config.mock';
+import { Note } from './note.entity';
+import { NotesService } from './notes.service';
+import { Tag } from './tag.entity';
 
 describe('NotesService', () => {
   let service: NotesService;

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -5,8 +5,6 @@
  */
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import base32Encode from 'base32-encode';
-import { randomBytes } from 'crypto';
 import { Repository } from 'typeorm';
 
 import appConfiguration, { AppConfig } from '../config/app.config';

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -3,21 +3,29 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import base32Encode from 'base32-encode';
+import { randomBytes } from 'crypto';
 import { Repository } from 'typeorm';
+
+import appConfiguration, { AppConfig } from '../config/app.config';
 import {
   AlreadyInDBError,
   ForbiddenIdError,
   NotInDBError,
   PermissionsUpdateInconsistentError,
 } from '../errors/errors';
+import { GroupsService } from '../groups/groups.service';
+import { HistoryEntry } from '../history/history-entry.entity';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
+import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
+import { NoteUserPermission } from '../permissions/note-user-permission.entity';
 import { Revision } from '../revisions/revision.entity';
 import { RevisionsService } from '../revisions/revisions.service';
 import { User } from '../users/user.entity';
 import { UsersService } from '../users/users.service';
+import { checkArrayForDuplicates } from '../utils/arrayDuplicatCheck';
 import { NoteMetadataDto } from './note-metadata.dto';
 import {
   NotePermissionsDto,
@@ -26,14 +34,6 @@ import {
 import { NoteDto } from './note.dto';
 import { Note } from './note.entity';
 import { Tag } from './tag.entity';
-import { HistoryEntry } from '../history/history-entry.entity';
-import { NoteUserPermission } from '../permissions/note-user-permission.entity';
-import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
-import { GroupsService } from '../groups/groups.service';
-import { checkArrayForDuplicates } from '../utils/arrayDuplicatCheck';
-import appConfiguration, { AppConfig } from '../config/app.config';
-import base32Encode from 'base32-encode';
-import { randomBytes } from 'crypto';
 
 @Injectable()
 export class NotesService {

--- a/src/notes/tag.entity.ts
+++ b/src/notes/tag.entity.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
+
 import { Note } from './note.entity';
 
 @Entity()

--- a/src/notes/utils.spec.ts
+++ b/src/notes/utils.spec.ts
@@ -3,9 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { randomBytes } from 'crypto';
+
 import { generatePublicId } from './utils';
+
 jest.mock('crypto');
 
 it('generatePublicId', () => {

--- a/src/notes/utils.ts
+++ b/src/notes/utils.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import base32Encode from 'base32-encode';
 import { randomBytes } from 'crypto';
 

--- a/src/permissions/note-group-permission.entity.ts
+++ b/src/permissions/note-group-permission.entity.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Column, Entity, ManyToOne } from 'typeorm';
+
 import { Group } from '../groups/group.entity';
 import { Note } from '../notes/note.entity';
 

--- a/src/permissions/note-user-permission.entity.ts
+++ b/src/permissions/note-user-permission.entity.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Column, Entity, ManyToOne } from 'typeorm';
+
 import { Note } from '../notes/note.entity';
 import { User } from '../users/user.entity';
 

--- a/src/permissions/permissions.module.ts
+++ b/src/permissions/permissions.module.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
+
 import { PermissionsService } from './permissions.service';
 
 @Module({

--- a/src/permissions/permissions.service.spec.ts
+++ b/src/permissions/permissions.service.spec.ts
@@ -3,11 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
+import appConfigMock from '../config/mock/app.config.mock';
 import { Group } from '../groups/group.entity';
 import { LoggerModule } from '../logger/logger.module';
 import { Note } from '../notes/note.entity';
@@ -23,8 +25,6 @@ import { NoteGroupPermission } from './note-group-permission.entity';
 import { NoteUserPermission } from './note-user-permission.entity';
 import { PermissionsModule } from './permissions.module';
 import { GuestPermission, PermissionsService } from './permissions.service';
-import { ConfigModule } from '@nestjs/config';
-import appConfigMock from '../config/mock/app.config.mock';
 
 describe('PermissionsService', () => {
   let permissionsService: PermissionsService;

--- a/src/permissions/permissions.service.ts
+++ b/src/permissions/permissions.service.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Injectable } from '@nestjs/common';
-import { User } from '../users/user.entity';
+
 import { Note } from '../notes/note.entity';
+import { User } from '../users/user.entity';
 
 // TODO move to config or remove
 export enum GuestPermission {

--- a/src/revisions/edit.dto.ts
+++ b/src/revisions/edit.dto.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { IsDate, IsNumber, IsOptional, IsString, Min } from 'class-validator';
-import { UserInfoDto } from '../users/user-info.dto';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDate, IsNumber, IsOptional, IsString, Min } from 'class-validator';
+
+import { UserInfoDto } from '../users/user-info.dto';
 
 export class EditDto {
   /**

--- a/src/revisions/edit.entity.ts
+++ b/src/revisions/edit.entity.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   Column,
   CreateDateColumn,
@@ -13,6 +12,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+
 import { Author } from '../authors/author.entity';
 import { Revision } from './revision.entity';
 

--- a/src/revisions/revision-metadata.dto.ts
+++ b/src/revisions/revision-metadata.dto.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { IsDate, IsNumber } from 'class-validator';
-import { Revision } from './revision.entity';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsNumber } from 'class-validator';
+
+import { Revision } from './revision.entity';
 
 export class RevisionMetadataDto {
   /**

--- a/src/revisions/revision.dto.ts
+++ b/src/revisions/revision.dto.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { IsDate, IsNumber, IsString } from 'class-validator';
-import { Revision } from './revision.entity';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsNumber, IsString } from 'class-validator';
+
+import { Revision } from './revision.entity';
 
 export class RevisionDto {
   /**

--- a/src/revisions/revision.entity.ts
+++ b/src/revisions/revision.entity.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   Column,
   CreateDateColumn,
@@ -12,6 +11,7 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { JoinTable, ManyToMany } from 'typeorm';
+
 import { Note } from '../notes/note.entity';
 import { Edit } from './edit.entity';
 

--- a/src/revisions/revision.entity.ts
+++ b/src/revisions/revision.entity.ts
@@ -7,10 +7,11 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinTable,
+  ManyToMany,
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { JoinTable, ManyToMany } from 'typeorm';
 
 import { Note } from '../notes/note.entity';
 import { Edit } from './edit.entity';

--- a/src/revisions/revisions.module.ts
+++ b/src/revisions/revisions.module.ts
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { forwardRef, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { AuthorsModule } from '../authors/authors.module';
 import { LoggerModule } from '../logger/logger.module';
 import { NotesModule } from '../notes/notes.module';
 import { Edit } from './edit.entity';
 import { Revision } from './revision.entity';
 import { RevisionsService } from './revisions.service';
-import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [

--- a/src/revisions/revisions.service.spec.ts
+++ b/src/revisions/revisions.service.spec.ts
@@ -10,7 +10,6 @@ import { Repository } from 'typeorm';
 
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
-import { AuthorsModule } from '../authors/authors.module';
 import appConfigMock from '../config/mock/app.config.mock';
 import { NotInDBError } from '../errors/errors';
 import { Group } from '../groups/group.entity';

--- a/src/revisions/revisions.service.spec.ts
+++ b/src/revisions/revisions.service.spec.ts
@@ -3,29 +3,29 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+
+import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
 import { AuthorsModule } from '../authors/authors.module';
+import appConfigMock from '../config/mock/app.config.mock';
 import { NotInDBError } from '../errors/errors';
+import { Group } from '../groups/group.entity';
 import { LoggerModule } from '../logger/logger.module';
 import { Note } from '../notes/note.entity';
 import { NotesModule } from '../notes/notes.module';
-import { AuthToken } from '../auth/auth-token.entity';
+import { Tag } from '../notes/tag.entity';
+import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
+import { NoteUserPermission } from '../permissions/note-user-permission.entity';
 import { Identity } from '../users/identity.entity';
 import { Session } from '../users/session.entity';
 import { User } from '../users/user.entity';
 import { Edit } from './edit.entity';
 import { Revision } from './revision.entity';
 import { RevisionsService } from './revisions.service';
-import { Tag } from '../notes/tag.entity';
-import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
-import { NoteUserPermission } from '../permissions/note-user-permission.entity';
-import { Group } from '../groups/group.entity';
-import { ConfigModule } from '@nestjs/config';
-import appConfigMock from '../config/mock/app.config.mock';
 
 describe('RevisionsService', () => {
   let service: RevisionsService;

--- a/src/revisions/revisions.service.ts
+++ b/src/revisions/revisions.service.ts
@@ -3,17 +3,17 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+
+import { NotInDBError } from '../errors/errors';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
+import { Note } from '../notes/note.entity';
 import { NotesService } from '../notes/notes.service';
 import { RevisionMetadataDto } from './revision-metadata.dto';
 import { RevisionDto } from './revision.dto';
 import { Revision } from './revision.entity';
-import { Note } from '../notes/note.entity';
-import { NotInDBError } from '../errors/errors';
 
 @Injectable()
 export class RevisionsService {

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -3,22 +3,22 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { createConnection } from 'typeorm';
+
+import { AuthToken } from './auth/auth-token.entity';
 import { Author } from './authors/author.entity';
-import { Session } from './users/session.entity';
-import { User } from './users/user.entity';
-import { Note } from './notes/note.entity';
-import { Revision } from './revisions/revision.entity';
-import { Edit } from './revisions/edit.entity';
-import { NoteGroupPermission } from './permissions/note-group-permission.entity';
-import { NoteUserPermission } from './permissions/note-user-permission.entity';
 import { Group } from './groups/group.entity';
 import { HistoryEntry } from './history/history-entry.entity';
 import { MediaUpload } from './media/media-upload.entity';
+import { Note } from './notes/note.entity';
 import { Tag } from './notes/tag.entity';
-import { AuthToken } from './auth/auth-token.entity';
+import { NoteGroupPermission } from './permissions/note-group-permission.entity';
+import { NoteUserPermission } from './permissions/note-user-permission.entity';
+import { Edit } from './revisions/edit.entity';
+import { Revision } from './revisions/revision.entity';
 import { Identity } from './users/identity.entity';
+import { Session } from './users/session.entity';
+import { User } from './users/user.entity';
 
 /**
  * This function creates and populates a sqlite db for manual testing

--- a/src/users/identity.entity.ts
+++ b/src/users/identity.entity.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   Column,
   CreateDateColumn,
@@ -12,6 +11,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+
 import { User } from './user.entity';
 
 @Entity()

--- a/src/users/session.entity.ts
+++ b/src/users/session.entity.ts
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { ISession } from 'connect-typeorm';
 import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
+
 import { Author } from '../authors/author.entity';
 
 @Entity()

--- a/src/users/user-info.dto.ts
+++ b/src/users/user-info.dto.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
 

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import {
+  Column,
   CreateDateColumn,
   Entity,
   ManyToMany,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import { Column, OneToMany } from 'typeorm';
 
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import {
   CreateDateColumn,
   Entity,
@@ -12,13 +11,14 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { Column, OneToMany } from 'typeorm';
-import { Author } from '../authors/author.entity';
-import { Note } from '../notes/note.entity';
+
 import { AuthToken } from '../auth/auth-token.entity';
-import { Identity } from './identity.entity';
+import { Author } from '../authors/author.entity';
 import { Group } from '../groups/group.entity';
 import { HistoryEntry } from '../history/history-entry.entity';
 import { MediaUpload } from '../media/media-upload.entity';
+import { Note } from '../notes/note.entity';
+import { Identity } from './identity.entity';
 
 @Entity()
 export class User {

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { LoggerModule } from '../logger/logger.module';
 import { Identity } from './identity.entity';
 import { Session } from './session.entity';

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import appConfigMock from '../config/mock/app.config.mock';
+import { AlreadyInDBError, NotInDBError } from '../errors/errors';
 import { LoggerModule } from '../logger/logger.module';
 import { User } from './user.entity';
 import { UsersService } from './users.service';
-import { Repository } from 'typeorm';
-import { AlreadyInDBError, NotInDBError } from '../errors/errors';
-import { ConfigModule } from '@nestjs/config';
-import appConfigMock from '../config/mock/app.config.mock';
 
 describe('UsersService', () => {
   let service: UsersService;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+
 import { AlreadyInDBError, NotInDBError } from '../errors/errors';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
 import { UserInfoDto } from './user-info.dto';

--- a/src/utils/serverVersion.spec.ts
+++ b/src/utils/serverVersion.spec.ts
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { promises as fs } from 'fs';
+
 import { getServerVersionFromPackageJson } from './serverVersion';
 
 it('getServerVersionFromPackageJson works', async () => {

--- a/src/utils/serverVersion.ts
+++ b/src/utils/serverVersion.ts
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-import { ServerVersion } from '../monitoring/server-status.dto';
 import { promises as fs } from 'fs';
 import { join as joinPath } from 'path';
+
+import { ServerVersion } from '../monitoring/server-status.dto';
 
 let versionCache: ServerVersion;
 

--- a/src/utils/swagger.ts
+++ b/src/utils/swagger.ts
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { INestApplication } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
 import { PrivateApiModule } from '../api/private/private-api.module';
 import { PublicApiModule } from '../api/public/public-api.module';
 

--- a/test/private-api/history.e2e-spec.ts
+++ b/test/private-api/history.e2e-spec.ts
@@ -3,31 +3,31 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { INestApplication } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import request from 'supertest';
-import mediaConfigMock from '../../src/config/mock/media.config.mock';
+
+import { PrivateApiModule } from '../../src/api/private/private-api.module';
+import { AuthModule } from '../../src/auth/auth.module';
 import appConfigMock from '../../src/config/mock/app.config.mock';
 import authConfigMock from '../../src/config/mock/auth.config.mock';
 import customizationConfigMock from '../../src/config/mock/customization.config.mock';
 import externalServicesConfigMock from '../../src/config/mock/external-services.config.mock';
+import mediaConfigMock from '../../src/config/mock/media.config.mock';
 import { GroupsModule } from '../../src/groups/groups.module';
+import { HistoryEntryImportDto } from '../../src/history/history-entry-import.dto';
+import { HistoryEntry } from '../../src/history/history-entry.entity';
+import { HistoryService } from '../../src/history/history.service';
 import { LoggerModule } from '../../src/logger/logger.module';
+import { Note } from '../../src/notes/note.entity';
 import { NotesModule } from '../../src/notes/notes.module';
 import { NotesService } from '../../src/notes/notes.service';
 import { PermissionsModule } from '../../src/permissions/permissions.module';
-import { AuthModule } from '../../src/auth/auth.module';
-import { UsersService } from '../../src/users/users.service';
 import { User } from '../../src/users/user.entity';
 import { UsersModule } from '../../src/users/users.module';
-import { PrivateApiModule } from '../../src/api/private/private-api.module';
-import { HistoryService } from '../../src/history/history.service';
-import { Note } from '../../src/notes/note.entity';
-import { HistoryEntryImportDto } from '../../src/history/history-entry-import.dto';
-import { HistoryEntry } from '../../src/history/history-entry.entity';
+import { UsersService } from '../../src/users/users.service';
 
 describe('History', () => {
   let app: INestApplication;

--- a/test/private-api/me.e2e-spec.ts
+++ b/test/private-api/me.e2e-spec.ts
@@ -8,34 +8,34 @@
 @typescript-eslint/no-unsafe-assignment,
 @typescript-eslint/no-unsafe-member-access
 */
-
 import { INestApplication } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { promises as fs } from 'fs';
 import request from 'supertest';
+
+import { PrivateApiModule } from '../../src/api/private/private-api.module';
+import { AuthModule } from '../../src/auth/auth.module';
 import appConfigMock from '../../src/config/mock/app.config.mock';
 import authConfigMock from '../../src/config/mock/auth.config.mock';
-import mediaConfigMock from '../../src/config/mock/media.config.mock';
 import customizationConfigMock from '../../src/config/mock/customization.config.mock';
 import externalServicesConfigMock from '../../src/config/mock/external-services.config.mock';
+import mediaConfigMock from '../../src/config/mock/media.config.mock';
+import { NotInDBError } from '../../src/errors/errors';
 import { GroupsModule } from '../../src/groups/groups.module';
+import { HistoryModule } from '../../src/history/history.module';
 import { LoggerModule } from '../../src/logger/logger.module';
+import { MediaModule } from '../../src/media/media.module';
+import { MediaService } from '../../src/media/media.service';
+import { Note } from '../../src/notes/note.entity';
 import { NotesModule } from '../../src/notes/notes.module';
+import { NotesService } from '../../src/notes/notes.service';
 import { PermissionsModule } from '../../src/permissions/permissions.module';
-import { AuthModule } from '../../src/auth/auth.module';
-import { UsersService } from '../../src/users/users.service';
+import { UserInfoDto } from '../../src/users/user-info.dto';
 import { User } from '../../src/users/user.entity';
 import { UsersModule } from '../../src/users/users.module';
-import { PrivateApiModule } from '../../src/api/private/private-api.module';
-import { UserInfoDto } from '../../src/users/user-info.dto';
-import { MediaModule } from '../../src/media/media.module';
-import { HistoryModule } from '../../src/history/history.module';
-import { NotInDBError } from '../../src/errors/errors';
-import { promises as fs } from 'fs';
-import { Note } from '../../src/notes/note.entity';
-import { NotesService } from '../../src/notes/notes.service';
-import { MediaService } from '../../src/media/media.service';
+import { UsersService } from '../../src/users/users.service';
 
 describe('Me', () => {
   let app: INestApplication;

--- a/test/private-api/media.e2e-spec.ts
+++ b/test/private-api/media.e2e-spec.ts
@@ -3,29 +3,29 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { promises as fs } from 'fs';
+import { join } from 'path';
 import request from 'supertest';
-import mediaConfigMock from '../../src/config/mock/media.config.mock';
+
+import { PrivateApiModule } from '../../src/api/private/private-api.module';
+import { AuthModule } from '../../src/auth/auth.module';
 import appConfigMock from '../../src/config/mock/app.config.mock';
 import authConfigMock from '../../src/config/mock/auth.config.mock';
 import customizationConfigMock from '../../src/config/mock/customization.config.mock';
 import externalConfigMock from '../../src/config/mock/external-services.config.mock';
+import mediaConfigMock from '../../src/config/mock/media.config.mock';
 import { GroupsModule } from '../../src/groups/groups.module';
+import { ConsoleLoggerService } from '../../src/logger/console-logger.service';
 import { LoggerModule } from '../../src/logger/logger.module';
 import { MediaModule } from '../../src/media/media.module';
 import { NotesModule } from '../../src/notes/notes.module';
 import { NotesService } from '../../src/notes/notes.service';
 import { PermissionsModule } from '../../src/permissions/permissions.module';
-import { AuthModule } from '../../src/auth/auth.module';
-import { join } from 'path';
-import { PrivateApiModule } from '../../src/api/private/private-api.module';
 import { UsersService } from '../../src/users/users.service';
-import { ConsoleLoggerService } from '../../src/logger/console-logger.service';
 import { ensureDeleted } from '../utils';
 
 describe('Media', () => {

--- a/test/private-api/notes.e2e-spec.ts
+++ b/test/private-api/notes.e2e-spec.ts
@@ -3,31 +3,31 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { INestApplication } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { promises as fs } from 'fs';
+import { join } from 'path';
 import request from 'supertest';
-import mediaConfigMock from '../../src/config/mock/media.config.mock';
+
+import { PrivateApiModule } from '../../src/api/private/private-api.module';
+import { AuthModule } from '../../src/auth/auth.module';
 import appConfigMock from '../../src/config/mock/app.config.mock';
 import authConfigMock from '../../src/config/mock/auth.config.mock';
 import customizationConfigMock from '../../src/config/mock/customization.config.mock';
 import externalConfigMock from '../../src/config/mock/external-services.config.mock';
+import mediaConfigMock from '../../src/config/mock/media.config.mock';
 import { NotInDBError } from '../../src/errors/errors';
 import { GroupsModule } from '../../src/groups/groups.module';
 import { LoggerModule } from '../../src/logger/logger.module';
+import { MediaService } from '../../src/media/media.service';
 import { NotesModule } from '../../src/notes/notes.module';
 import { NotesService } from '../../src/notes/notes.service';
 import { PermissionsModule } from '../../src/permissions/permissions.module';
-import { AuthModule } from '../../src/auth/auth.module';
-import { UsersService } from '../../src/users/users.service';
 import { User } from '../../src/users/user.entity';
 import { UsersModule } from '../../src/users/users.module';
-import { promises as fs } from 'fs';
-import { MediaService } from '../../src/media/media.service';
-import { PrivateApiModule } from '../../src/api/private/private-api.module';
-import { join } from 'path';
+import { UsersService } from '../../src/users/users.service';
 
 describe('Notes', () => {
   let app: INestApplication;

--- a/test/public-api/me.e2e-spec.ts
+++ b/test/public-api/me.e2e-spec.ts
@@ -3,36 +3,36 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { INestApplication } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { promises as fs } from 'fs';
+import { join } from 'path';
 import request from 'supertest';
-import { HistoryService } from '../../src/history/history.service';
-import { NotesService } from '../../src/notes/notes.service';
+
+import { PublicApiModule } from '../../src/api/public/public-api.module';
+import { AuthModule } from '../../src/auth/auth.module';
+import { MockAuthGuard } from '../../src/auth/mock-auth.guard';
+import { TokenAuthGuard } from '../../src/auth/token-auth.guard';
+import appConfigMock from '../../src/config/mock/app.config.mock';
+import mediaConfigMock from '../../src/config/mock/media.config.mock';
+import { GroupsModule } from '../../src/groups/groups.module';
 import { HistoryEntryUpdateDto } from '../../src/history/history-entry-update.dto';
 import { HistoryEntryDto } from '../../src/history/history-entry.dto';
 import { HistoryEntry } from '../../src/history/history-entry.entity';
-import { UsersService } from '../../src/users/users.service';
-import { TokenAuthGuard } from '../../src/auth/token-auth.guard';
-import { MockAuthGuard } from '../../src/auth/mock-auth.guard';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { PublicApiModule } from '../../src/api/public/public-api.module';
-import { NotesModule } from '../../src/notes/notes.module';
-import { PermissionsModule } from '../../src/permissions/permissions.module';
-import { GroupsModule } from '../../src/groups/groups.module';
-import { LoggerModule } from '../../src/logger/logger.module';
-import { AuthModule } from '../../src/auth/auth.module';
-import { UsersModule } from '../../src/users/users.module';
 import { HistoryModule } from '../../src/history/history.module';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import mediaConfigMock from '../../src/config/mock/media.config.mock';
-import appConfigMock from '../../src/config/mock/app.config.mock';
-import { User } from '../../src/users/user.entity';
-import { MediaService } from '../../src/media/media.service';
+import { HistoryService } from '../../src/history/history.service';
+import { LoggerModule } from '../../src/logger/logger.module';
 import { MediaModule } from '../../src/media/media.module';
-import { promises as fs } from 'fs';
+import { MediaService } from '../../src/media/media.service';
 import { NoteMetadataDto } from '../../src/notes/note-metadata.dto';
-import { join } from 'path';
+import { NotesModule } from '../../src/notes/notes.module';
+import { NotesService } from '../../src/notes/notes.service';
+import { PermissionsModule } from '../../src/permissions/permissions.module';
+import { User } from '../../src/users/user.entity';
+import { UsersModule } from '../../src/users/users.module';
+import { UsersService } from '../../src/users/users.service';
 
 // TODO Tests have to be reworked using UserService functions
 
@@ -104,7 +104,7 @@ describe('Me', () => {
       .get('/me/history')
       .expect('Content-Type', /json/)
       .expect(200);
-    const history = <HistoryEntryDto[]>response.body;
+    const history: HistoryEntryDto[] = response.body;
     expect(history.length).toEqual(1);
     const historyDto = historyService.toHistoryEntryDto(createdHistoryEntry);
     for (const historyEntry of history) {
@@ -128,7 +128,7 @@ describe('Me', () => {
         .get(`/me/history/${noteName}`)
         .expect('Content-Type', /json/)
         .expect(200);
-      const historyEntry = <HistoryEntryDto>response.body;
+      const historyEntry: HistoryEntryDto = response.body;
       const historyEntryDto =
         historyService.toHistoryEntryDto(createdHistoryEntry);
       expect(historyEntry.identifier).toEqual(historyEntryDto.identifier);

--- a/test/public-api/media.e2e-spec.ts
+++ b/test/public-api/media.e2e-spec.ts
@@ -3,28 +3,28 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { promises as fs } from 'fs';
+import { join } from 'path';
 import request from 'supertest';
+
 import { PublicApiModule } from '../../src/api/public/public-api.module';
-import mediaConfigMock from '../../src/config/mock/media.config.mock';
+import { AuthModule } from '../../src/auth/auth.module';
+import { MockAuthGuard } from '../../src/auth/mock-auth.guard';
+import { TokenAuthGuard } from '../../src/auth/token-auth.guard';
 import appConfigMock from '../../src/config/mock/app.config.mock';
+import mediaConfigMock from '../../src/config/mock/media.config.mock';
 import { GroupsModule } from '../../src/groups/groups.module';
+import { ConsoleLoggerService } from '../../src/logger/console-logger.service';
 import { LoggerModule } from '../../src/logger/logger.module';
 import { MediaModule } from '../../src/media/media.module';
 import { MediaService } from '../../src/media/media.service';
 import { NotesModule } from '../../src/notes/notes.module';
 import { NotesService } from '../../src/notes/notes.service';
 import { PermissionsModule } from '../../src/permissions/permissions.module';
-import { AuthModule } from '../../src/auth/auth.module';
-import { TokenAuthGuard } from '../../src/auth/token-auth.guard';
-import { MockAuthGuard } from '../../src/auth/mock-auth.guard';
-import { join } from 'path';
-import { ConsoleLoggerService } from '../../src/logger/console-logger.service';
 import { ensureDeleted } from '../utils';
 
 describe('Media', () => {

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -3,31 +3,31 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { INestApplication } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { promises as fs } from 'fs';
+import { join } from 'path';
 import request from 'supertest';
+
 import { PublicApiModule } from '../../src/api/public/public-api.module';
-import mediaConfigMock from '../../src/config/mock/media.config.mock';
+import { AuthModule } from '../../src/auth/auth.module';
+import { MockAuthGuard } from '../../src/auth/mock-auth.guard';
+import { TokenAuthGuard } from '../../src/auth/token-auth.guard';
 import appConfigMock from '../../src/config/mock/app.config.mock';
+import mediaConfigMock from '../../src/config/mock/media.config.mock';
 import { NotInDBError } from '../../src/errors/errors';
 import { GroupsModule } from '../../src/groups/groups.module';
 import { LoggerModule } from '../../src/logger/logger.module';
+import { MediaService } from '../../src/media/media.service';
+import { NotePermissionsUpdateDto } from '../../src/notes/note-permissions.dto';
 import { NotesModule } from '../../src/notes/notes.module';
 import { NotesService } from '../../src/notes/notes.service';
 import { PermissionsModule } from '../../src/permissions/permissions.module';
-import { AuthModule } from '../../src/auth/auth.module';
-import { TokenAuthGuard } from '../../src/auth/token-auth.guard';
-import { MockAuthGuard } from '../../src/auth/mock-auth.guard';
-import { UsersService } from '../../src/users/users.service';
 import { User } from '../../src/users/user.entity';
 import { UsersModule } from '../../src/users/users.module';
-import { promises as fs } from 'fs';
-import { MediaService } from '../../src/media/media.service';
-import { NotePermissionsUpdateDto } from '../../src/notes/note-permissions.dto';
-import { join } from 'path';
+import { UsersService } from '../../src/users/users.service';
 
 describe('Notes', () => {
   let app: INestApplication;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { promises as fs } from 'fs';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2970,6 +2970,13 @@ eslint-plugin-local-rules@1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.1.0.tgz#5f934f685b08c96eed40b92aee7b02f03cf55f7b"
   integrity sha512-FdPyzxakUKgZkeNM3x/vvRcB6nCjTNbui5gWALhvcaH1R6aCiD37fWtdesagcyBpEe9S9XRHAJ8CJ4rUJ3K9tQ==
 
+eslint-plugin-prettier@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz#e9ddb200efb6f3d05ffe83b1665a716af4a387e5"
+  integrity sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -3241,6 +3248,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
   version "3.2.7"
@@ -5686,6 +5698,13 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier@2.3.2:
   version "2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,6 +162,28 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.15.0.tgz#2dbaf8b85334796cafbb0f5793a90a2fc010b176"
   integrity sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==
 
+"@babel/core@7.13.10":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.10.tgz#07de050bbd8193fcd8a3c27918c0890613a94559"
+  integrity sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.13.9"
+    "@babel/helper-compilation-targets" "^7.13.10"
+    "@babel/helper-module-transforms" "^7.13.0"
+    "@babel/helpers" "^7.13.10"
+    "@babel/parser" "^7.13.10"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.13.0"
+    "@babel/types" "^7.13.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
 "@babel/core@^7.1.0", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.0.tgz#749e57c68778b73ad8082775561f67f5196aafa8"
@@ -183,7 +205,16 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.15.0", "@babel/generator@^7.7.2":
+"@babel/generator@7.13.9":
+  version "7.13.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39"
+  integrity sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
+  dependencies:
+    "@babel/types" "^7.13.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.13.0", "@babel/generator@^7.13.9", "@babel/generator@^7.15.0", "@babel/generator@^7.7.2":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.0.tgz#a7d0c172e0d814974bad5aa77ace543b97917f15"
   integrity sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==
@@ -192,7 +223,7 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-compilation-targets@^7.15.0":
+"@babel/helper-compilation-targets@^7.13.10", "@babel/helper-compilation-targets@^7.15.0":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz#973df8cbd025515f3ff25db0c05efc704fa79818"
   integrity sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==
@@ -202,7 +233,7 @@
     browserslist "^4.16.6"
     semver "^6.3.0"
 
-"@babel/helper-function-name@^7.14.5":
+"@babel/helper-function-name@^7.12.13", "@babel/helper-function-name@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
   integrity sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
@@ -239,7 +270,7 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-module-transforms@^7.15.0":
+"@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.15.0":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz#679275581ea056373eddbe360e1419ef23783b08"
   integrity sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==
@@ -282,14 +313,14 @@
   dependencies:
     "@babel/types" "^7.14.8"
 
-"@babel/helper-split-export-declaration@^7.14.5":
+"@babel/helper-split-export-declaration@^7.12.13", "@babel/helper-split-export-declaration@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz#22b23a54ef51c2b7605d851930c1976dd0bc693a"
   integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
+"@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
   version "7.14.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
   integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
@@ -299,7 +330,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
-"@babel/helpers@^7.14.8":
+"@babel/helpers@^7.13.10", "@babel/helpers@^7.14.8":
   version "7.15.3"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.15.3.tgz#c96838b752b95dcd525b4e741ed40bb1dc2a1357"
   integrity sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==
@@ -317,7 +348,12 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.15.0", "@babel/parser@^7.7.2":
+"@babel/parser@7.13.10":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.10.tgz#8f8f9bf7b3afa3eabd061f7a5bcdf4fec3c48409"
+  integrity sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.13.0", "@babel/parser@^7.13.10", "@babel/parser@^7.14.5", "@babel/parser@^7.15.0", "@babel/parser@^7.7.2":
   version "7.15.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.3.tgz#3416d9bea748052cfcb63dbcc27368105b1ed862"
   integrity sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==
@@ -413,7 +449,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/template@^7.14.5", "@babel/template@^7.3.3":
+"@babel/template@^7.12.13", "@babel/template@^7.14.5", "@babel/template@^7.3.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
   integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
@@ -422,7 +458,22 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.15.0", "@babel/traverse@^7.7.2":
+"@babel/traverse@7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.0.tgz#6d95752475f86ee7ded06536de309a65fc8966cc"
+  integrity sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.13.0"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/parser" "^7.13.0"
+    "@babel/types" "^7.13.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.15.0", "@babel/traverse@^7.7.2":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.0.tgz#4cca838fd1b2a03283c1f38e141f639d60b3fc98"
   integrity sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==
@@ -437,7 +488,16 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.14.8", "@babel/types@^7.15.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
+"@babel/types@7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.0.tgz#74424d2816f0171b4100f0ab34e9a374efdf7f80"
+  integrity sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.0.0", "@babel/types@^7.13.0", "@babel/types@^7.14.5", "@babel/types@^7.14.8", "@babel/types@^7.15.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.0.tgz#61af11f2286c4e9c69ca8deb5f4375a73c72dcbd"
   integrity sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==
@@ -933,6 +993,20 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@trivago/prettier-plugin-sort-imports@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-2.0.4.tgz#2e5bbf80bd87e919202f791008a2fbcdbb2a566f"
+  integrity sha512-SCVUhQdbjn/Z4AY7b9JO00fZCeXxiVuarVxYP0n6cX2ijiQkE5HmGrOk32n0u385OebzQ9bZcrc51lAGLjXnFQ==
+  dependencies:
+    "@babel/core" "7.13.10"
+    "@babel/generator" "7.13.9"
+    "@babel/parser" "7.13.10"
+    "@babel/traverse" "7.13.0"
+    "@babel/types" "7.13.0"
+    "@types/lodash" "4.14.168"
+    javascript-natural-sort "0.7.1"
+    lodash "4.17.21"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -1179,6 +1253,11 @@
     "@types/keygrip" "*"
     "@types/koa-compose" "*"
     "@types/node" "*"
+
+"@types/lodash@4.14.168":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
 "@types/mime@^1":
   version "1.3.2"
@@ -4053,6 +4132,11 @@ iterare@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/iterare/-/iterare-1.2.1.tgz#139c400ff7363690e33abffa33cbba8920f00042"
   integrity sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==
+
+javascript-natural-sort@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
+  integrity sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=
 
 jest-changed-files@^27.1.0:
   version "27.1.0"


### PR DESCRIPTION
### Component/Part
linting

### Description
This PR adds a Prettier plugin that enforces a consistent order of `import` statements.
It also fixes all corresponding errors and ensures that format errors can be easily fixed in the future by running Prettier as part of ESLint.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
