### PR TITLE
Add new API to purge note history

### DIFF
--- a/src/revisions/revisions.service.ts
+++ b/src/revisions/revisions.service.ts
@@ -34,6 +34,27 @@ export class RevisionsService {
     });
   }
 
+  /**
+   * @async
+   * Purge revision history of a note.
+   * @param {Note} note - the note to purge the history
+   * @return {Revision[]} an array of purged revisions
+   */
+  async purgeRevisions(note: Note): Promise<Revision[]> {
+    const revisions = await this.revisionRepository.find({
+      where: {
+        note: note,
+      },
+    });
+    const latestRevison = await this.getLatestRevision(note);
+    // get all revisions except the latest
+    const oldRevisions = revisions.filter(
+      (item) => item.id !== latestRevison.id,
+    );
+    // delete the old revisions
+    return await this.revisionRepository.remove(oldRevisions);
+  }
+
   async getRevision(note: Note, revisionId: number): Promise<Revision> {
     const revision = await this.revisionRepository.findOne({
       where: {

--- a/test/private-api/notes.e2e-spec.ts
+++ b/test/private-api/notes.e2e-spec.ts
@@ -231,6 +231,40 @@ describe('Notes', () => {
     });
   });
 
+  describe('DELETE /notes/{note}/revisions', () => {
+    it('works with an existing alias', async () => {
+      const noteId = 'test8';
+      const note = await notesService.createNote(content, noteId, user);
+      await notesService.updateNote(note, 'update');
+      const responseBeforeDeleting = await request(app.getHttpServer())
+        .get('/notes/test8/revisions')
+        .expect('Content-Type', /json/)
+        .expect(200);
+      expect(responseBeforeDeleting.body).toHaveLength(2);
+      await request(app.getHttpServer())
+        .delete(`/notes/${noteId}/revisions`)
+        .set('Content-Type', 'application/json')
+        .expect(204);
+      const responseAfterDeleting = await request(app.getHttpServer())
+        .get('/notes/test8/revisions')
+        .expect('Content-Type', /json/)
+        .expect(200);
+      expect(responseAfterDeleting.body).toHaveLength(1);
+    });
+    it('fails with a forbidden alias', async () => {
+      await request(app.getHttpServer())
+        .delete(`/notes/${forbiddenNoteId}/revisions`)
+        .expect(400);
+    });
+    it('fails with non-existing alias', async () => {
+      // check if a missing note correctly returns 404
+      await request(app.getHttpServer())
+        .delete('/notes/i_dont_exist/revisions')
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+  });
+
   describe('GET /notes/{note}/revisions/{revision-id}', () => {
     it('works with an existing alias', async () => {
       const note = await notesService.createNote(content, 'test5', user);


### PR DESCRIPTION
Signed-off-by: Abhilasha Sinha <abhisinha662000@gmail.com>

### Component/Part
<!-- e.g database -->
Backend

### Description
This PR adds a new API to purge the history of a note. 
The API deletes all the revisions of a note except the latest one.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
#1064 
