### PR TITLE
Fix usage of "HFM" in table headers

### DIFF
--- a/docs/content/references/hfm.md
+++ b/docs/content/references/hfm.md
@@ -90,7 +90,7 @@ Instead of this uncommon syntax, HFM2 uses just plain links to external content 
 ## HTML
 Besides the basic HTML typography elements (`<p>`, `<a>`, `<b>`, `<ins>`, `<del>`) the following more special HTML elements are supported by some specification.
 
-|    Feature    | HedgeDocMark 1 | HedgeDocMark 2 | CommonMark | GFM |
+|    Feature    | HFM 1 | HFM 2 | CommonMark | GFM |
 |:-------------:|:--------------:|:--------------:|:----------:|:---:|
 |   `<title>`   |                |                | :ballot_box_with_check:          |     |
 |  `<textarea>` |                | :ballot_box_with_check:              | :ballot_box_with_check:          |     |


### PR DESCRIPTION
### Component/Part
HFM Documentation

### Description
This PR replaces "HedgeDocMark" in some table headers with "HFM" to match the other tables.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #1608
