### PR TITLE
Update readme link to explanation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ the [github repository](https://github.com/hedgedoc/hedgedoc-logo).
 
 [poeditor-url]: https://poeditor.com/join/project/1OpGjF2Jir
 
-[hedgedoc-demo]: https://demo.hedgedoc.org
+[hedgedoc-demo]: https://hedgedoc.org/demo/
 
 [hedgedoc-demo-features]: https://demo.hedgedoc.org/features
 


### PR DESCRIPTION
### Component/Part
README

### Description
This PR updates the link to the demo instance to the page which explains the constraints of the demo (not for production use, cloudflare, ...).

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#1532 and hedgedoc/hedgedoc.github.io#149
