### PR TITLE
Add missing title property to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Create a report to help us improve HedgeDoc.
-title: ""
+title: "type a short title of your bug report here"
 labels: ["type: bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/enhancement_request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.yml
@@ -1,6 +1,6 @@
 name: Enhancement request
 description: Suggest an enhancement of an existing feature.
-title: ""
+title: "type a short title of your enhancement request here"
 labels: ["type: enhancement"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest a new feature for this project, which isn't existing yet.
-title: ""
+title: "type a short title of your feature request here"
 labels: ["type: feature"]
 body:
   - type: markdown


### PR DESCRIPTION
### Component/Part
issue templates

### Description
This PR fixes the issue templates by adding a title to each template

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
