### PR TITLE
[1.x] Set node engines field to LTS versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "**/request": "^2.88.0"
   },
   "engines": {
-    "node": ">=12"
+    "node": "12.x || 14.x || 16.x"
   },
   "bugs": "https://github.com/hedgedoc/hedgedoc/issues",
   "keywords": [


### PR DESCRIPTION
### Component/Part
package.json

### Description
This sets the `engines.node` field to the current three LTS versions, so Heroku does not try to use Node 17, which HedgeDoc apparently is not compatible with.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #1761
