### PR TITLE
Add Docs for getting started with 2.0

### DIFF
--- a/docs/content/dev/2.0.md
+++ b/docs/content/dev/2.0.md
@@ -23,12 +23,6 @@ The software provides two special groups which have no explicit users:
 - The owner of a note may delete all revisions. This effectively purges the edit
   history of a note.
 
-## Dev Setup
-- Clone backend and frontend in two folders.
-- Run `yarn install` in both projects
-- Start the backend server in watch mode using `yarn start:dev`. The backend is then accessible on port 3000.
-- Start the frontend dev server using `yarn start`. The frontend is now accessible on port 3001. 
-
 ## Entity `create` methods
 
 Because we need to have empty constructors in our entity classes for TypeORM to work, the actual constructor is a separate `create` method. These methods should adhere to these guidelines:

--- a/docs/content/dev/getting-started.md
+++ b/docs/content/dev/getting-started.md
@@ -45,3 +45,5 @@ to run both at the same time.
 
 - The backend will be available at `http://localhost:3000`.
 - The frontend will be available at `http://localhost:3001`.
+
+**Note:** The backend also proxies requests to the frontend, so you can point also your browser at the backend.

--- a/docs/content/dev/getting-started.md
+++ b/docs/content/dev/getting-started.md
@@ -1,0 +1,56 @@
+# Getting started
+
+## Preparing for running the backend code
+
+**ToDo:** Document how to setup development environment using docker.
+
+1. Clone the repository with `git clone https://github.com/hedgedoc/hedgedoc.git`
+   (cloning is the preferred way, but you can also download and unzip a release)
+
+2. Enter the directory and run `yarn install`.
+
+3. Run `cp .env.example .env` to use the example configuration.
+
+   Alternatively, set up a [.env](../config/index.md) or set up
+   [environment variables](../config/index.md) yourself.
+   
+4. Run `openssl rand -hex 16 | sed -E 's/(.*)/HD_SESSION_SECRET=\1/' >> .env` to generate a session secret if you have not set one manually before.
+ 
+ ## Preparing for running the frontend code
+
+**ToDo:** Document how to setup development environment using docker.
+
+1. Clone the repository with `git clone https://github.com/hedgedoc/react-client.git`
+   (cloning is the preferred way, but you can also download and unzip a release)
+
+2. Enter the directory and run `yarn install`.
+
+## Running the Code
+
+Now that everything is in place, we can start HedgeDoc:
+
+**ToDo:** Document how to build the frontend and backend or remove this paragraph entirely.
+
+## Running the Code with Auto-Reload
+
+The commands above are fine for production, but you're a developer and surely
+you want to change things. You would need to restart both commands whenever you
+change something. Luckily, you can run these commands that will automatically
+rebuild the backend andfrontend or restart the server if necessary.
+
+The commands will stay active in your terminal, so you will need multiple tabs
+to run both at the same time.
+
+1. Enter the `react-frontend` directory and use `yarn start` if you want webpack to continuously rebuild the frontend
+   code.
+   
+   **Note:** Currently, this will not result in the backend and frontend communicating with each other.
+   
+   **Note:** You can run `yarn start:for-real-backend` to start a frontend, which tries to connect to a local backend.
+
+2. To auto-reload the server, enter the `hedgedoc` directory and run `yarn start:dev`.
+
+## Testing
+
+- The backend will be available at `http://localhost:3000`.
+- The frontend will be available at `http://localhost:3001`.

--- a/docs/content/dev/getting-started.md
+++ b/docs/content/dev/getting-started.md
@@ -25,18 +25,9 @@
 
 2. Enter the directory and run `yarn install`.
 
-## Running the Code
+## Running Hedgedoc with auto-reload
 
-Now that everything is in place, we can start HedgeDoc:
-
-**ToDo:** Document how to build the frontend and backend or remove this paragraph entirely.
-
-## Running the Code with Auto-Reload
-
-The commands above are fine for production, but you're a developer and surely
-you want to change things. You would need to restart both commands whenever you
-change something. Luckily, you can run these commands that will automatically
-rebuild the backend andfrontend or restart the server if necessary.
+We will run Hedgedoc in development mode, which means the backend and frontend will automatically rebuild or restart when you make changes.
 
 The commands will stay active in your terminal, so you will need multiple tabs
 to run both at the same time.

--- a/docs/content/dev/getting-started.md
+++ b/docs/content/dev/getting-started.md
@@ -16,7 +16,7 @@
    
 4. Run `openssl rand -hex 16 | sed -E 's/(.*)/HD_SESSION_SECRET=\1/' >> .env` to generate a session secret if you have not set one manually before.
  
- ## Preparing for running the frontend code
+## Preparing for running the frontend code
 
 **ToDo:** Document how to setup development environment using docker.
 
@@ -32,14 +32,11 @@ We will run Hedgedoc in development mode, which means the backend and frontend w
 The commands will stay active in your terminal, so you will need multiple tabs
 to run both at the same time.
 
-1. Enter the `react-frontend` directory and use `yarn start` if you want webpack to continuously rebuild the frontend
-   code.
+1. Enter the `react-frontend` directory and use `yarn start:for-real-backend` if you want webpack to continuously rebuild the frontend code. The frontend will expect a running backend at port 3000.
    
-   **Note:** Currently, this will not result in the backend and frontend communicating with each other.
-   
-   **Note:** You can run `yarn start:for-real-backend` to start a frontend, which tries to connect to a local backend.
+   **Note:** You can run `yarn start` to start a frontend with an integrated, mocked API. This may support more features than the real backend.
 
-2. To auto-reload the server, enter the `hedgedoc` directory and run `yarn start:dev`.
+2. To start the server in auto-reload mode, enter the `hedgedoc` directory and run `env NODE_ENV=development yarn start:dev`.
 
 ## Testing
 

--- a/docs/content/dev/getting-started.md
+++ b/docs/content/dev/getting-started.md
@@ -46,4 +46,4 @@ to run both at the same time.
 - The backend will be available at `http://localhost:3000`.
 - The frontend will be available at `http://localhost:3001`.
 
-**Note:** The backend also proxies requests to the frontend, so you can point also your browser at the backend.
+**Note:** The backend proxies requests to the frontend, so you can also point your browser at the backend.

--- a/docs/content/dev/getting-started.md
+++ b/docs/content/dev/getting-started.md
@@ -40,7 +40,8 @@ to run both at the same time.
 
 ## Testing
 
-- The backend will be available at `http://localhost:3000`.
-- The frontend will be available at `http://localhost:3001`.
+- After starting both frontend and backend, Hedgedoc will be available at `http://localhost:3000`.
 
-**Note:** The backend proxies requests to the frontend, so you can also point your browser at the backend.
+**Note:** If you only started the frontend, it will be available at `http://localhost:3001`.
+
+**Note:** If you want to use Hedgedoc with the real backend, point your browser at `http://localhost:3000`, as the backend proxies requests to the frontend and you'll get CORS errors if you try to use the frontend directly.


### PR DESCRIPTION
### Component/Part
documentation

### Description
This PR adds documentation for how to set up HedgeDoc 2.0 for local development.

### Steps

- [x] Added  documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
- [x] My commits are signed-off to accept the DCO.
- [x] This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
  
