### PR TITLE
Update RenovateBot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
     "group:test",
     ":gitSignOff",
     ":prHourlyLimitNone",
-    ":dependencyDashboard",
     ":rebaseStalePrs",
     ":maintainLockFilesWeekly",
     ":automergePatch"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
+    "schedule:weekends",
     "group:definitelyTyped",
     "group:socketio",
     "group:linters",

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
     ":prHourlyLimitNone",
     ":rebaseStalePrs",
     ":maintainLockFilesWeekly",
-    ":automergePatch"
+    ":automergePatch",
+    ":separateMajorReleases"
   ],
   "baseBranches": [
     "master",


### PR DESCRIPTION
### Component/Part
renovate config

### Description
This PR changes the Renovate config:
- renovate only runs on weekends
- renovate creates separate PRs for major updates

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
