### PR TITLE
Run E2E tests concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config jest-e2e.json --runInBand",
-    "test:e2e:cov": "jest --config jest-e2e.json --coverage --runInBand",
+    "test:e2e": "jest --config jest-e2e.json",
+    "test:e2e:cov": "jest --config jest-e2e.json --coverage",
     "seed": "ts-node src/seed.ts"
   },
   "dependencies": {

--- a/src/config/mock/media.config.mock.ts
+++ b/src/config/mock/media.config.mock.ts
@@ -9,7 +9,8 @@ export default registerAs('mediaConfig', () => ({
   backend: {
     use: 'filesystem',
     filesystem: {
-      uploadPath: 'test_uploads',
+      uploadPath:
+        'test_uploads' + Math.floor(Math.random() * 100000).toString(),
     },
   },
 }));


### PR DESCRIPTION
### Component/Part
E2e tests

### Description
This PR implements a simple fix to allow the E2E tests to run concurrently.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #1644 
