### PR TITLE
test: fix test name in alias.e2e-spec.ts

### DIFF
--- a/test/public-api/alias.e2e-spec.ts
+++ b/test/public-api/alias.e2e-spec.ts
@@ -10,7 +10,7 @@ import { AliasUpdateDto } from '../../src/notes/alias-update.dto';
 import { User } from '../../src/users/user.entity';
 import { TestSetup } from '../test-setup';
 
-describe('Notes', () => {
+describe('Alias', () => {
   let testSetup: TestSetup;
 
   let user: User;


### PR DESCRIPTION
### Component/Part
alias e2e test

### Description
This PR fixes a typo in the alias e2e test

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
