### PR TITLE
Add missing null in type in permissions service

### DIFF
--- a/src/permissions/permissions.service.ts
+++ b/src/permissions/permissions.service.ts
@@ -21,7 +21,7 @@ export enum GuestPermission {
 @Injectable()
 export class PermissionsService {
   public guestPermission: GuestPermission; // TODO change to configOption
-  mayRead(user: User, note: Note): boolean {
+  mayRead(user: User | null, note: Note): boolean {
     if (this.isOwner(user, note)) return true;
 
     if (this.hasPermissionUser(user, note, false)) return true;
@@ -32,7 +32,7 @@ export class PermissionsService {
     return false;
   }
 
-  mayWrite(user: User, note: Note): boolean {
+  mayWrite(user: User | null, note: Note): boolean {
     if (this.isOwner(user, note)) return true;
 
     if (this.hasPermissionUser(user, note, true)) return true;
@@ -43,7 +43,7 @@ export class PermissionsService {
     return false;
   }
 
-  mayCreate(user: User): boolean {
+  mayCreate(user: User | null): boolean {
     if (user) {
       return true;
     } else {
@@ -58,14 +58,14 @@ export class PermissionsService {
     return false;
   }
 
-  isOwner(user: User, note: Note): boolean {
+  isOwner(user: User | null, note: Note): boolean {
     if (!user) return false;
     if (!note.owner) return false;
     return note.owner.id === user.id;
   }
 
   private hasPermissionUser(
-    user: User,
+    user: User | null,
     note: Note,
     wantEdit: boolean,
   ): boolean {
@@ -84,7 +84,7 @@ export class PermissionsService {
   }
 
   private hasPermissionGroup(
-    user: User,
+    user: User | null,
     note: Note,
     wantEdit: boolean,
   ): boolean {


### PR DESCRIPTION
### Component/Part
Permissions Service

### Description
The parameters of the permission checking methods were missing a null value for not set user. This is the case if user is not logged in and operating as guest.


### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
