### PR TITLE
Revert passport back to ^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "morgan": "^1.7.0",
     "mysql2": "^2.0.0",
     "node-fetch": "^2.6.1",
-    "passport": "^0.5.0",
+    "passport": "^0.4.0",
     "passport-dropbox-oauth2": "^1.1.0",
     "passport-facebook": "^3.0.0",
     "passport-github": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8058,10 +8058,10 @@ passport.socketio@^3.7.0:
   dependencies:
     xtend "^4.0.0"
 
-passport@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/passport/-/passport-0.5.0.tgz#7914aaa55844f9dce8c3aa28f7d6b73647ee0169"
-  integrity sha512-ln+ue5YaNDS+fes6O5PCzXKSseY5u8MYhX9H5Co4s+HfYI5oqvnHKoOORLYDUPh+8tHvrxugF2GFcUA1Q1Gqfg==
+passport@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/passport/-/passport-0.4.1.tgz#941446a21cb92fc688d97a0861c38ce9f738f270"
+  integrity sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==
   dependencies:
     passport-strategy "1.x.x"
     pause "0.0.1"


### PR DESCRIPTION
### Component/Part
Passport

### Description
Seems like passport 0.5.0 is incompatible with our session handling. This PR reverts passport to 0.4.0 so we can release a hotfix.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes https://github.com/hedgedoc/container/issues/270