### PR TITLE
Exclude /status, /metrics from session middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -175,7 +175,7 @@ app.use(flash())
 
 // passport
 app.use(passport.initialize())
-app.use(passport.session())
+app.use(useUnless(['/status', '/metrics'], passport.session()))
 
 // check uri is valid before going further
 app.use(require('./lib/web/middleware/checkURIValid'))

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## <i class="fa fa-tag"></i> Unreleased
+
+### Bugfixes
+
+- Fix error in the session handler when requesting `/metrics` or `/status`
+
 ## <i class="fa fa-tag"></i> 1.9.1 <i class="fa fa-calendar-o"></i> 2021-12-02
 
 This release increases the minimum required Node versions to `12.20.0`, `14.13.1` and `16`.


### PR DESCRIPTION
### Component/Part
session handling

### Description
Because of seemingly undocumented changes in passport 0.5.0,
passport now crashes on requests to paths without session data.

This removes the session middleware from /status and /metrics, which are
 excluded from sessions since 90c5ab08332cf57bc43022c90b0d93bd9c1a9cc7.

 Fixes https://github.com/hedgedoc/container/issues/270

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
