### PR TITLE
Codecov: Wait for 2 builds to be submitted

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-License-Identifier: CC0-1.0
+
+codecov:
+  notify:
+    # We currently have integration tests and E2E tests. Codecov should wait until both are done.
+    after_n_builds: 2


### PR DESCRIPTION
### Component/Part
Codecov config

### Description
This should stop Codecov from complaining about low
coverage after only half the tests have finished.

See https://docs.codecov.com/docs/notifications#section-preventing-notifications-until-after-n-builds

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
