### PR TITLE
Correctly check for missing session

### DIFF
--- a/src/identity/session.guard.ts
+++ b/src/identity/session.guard.ts
@@ -27,7 +27,7 @@ export class SessionGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request: Request & { session?: { user: string }; user?: User } =
       context.switchToHttp().getRequest();
-    if (!request.session) {
+    if (!request.session?.user) {
       this.logger.debug('The user has no session.');
       throw new UnauthorizedException("You're not logged in");
     }


### PR DESCRIPTION
### Component/Part
SessionGuard

### Description
express-session always creates an `request.session` object, so only
checking if that exists is not sufficient.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
