### PR TITLE
Fix(logger): Ignore docker health check requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ const errors = require('./lib/errors')
 const models = require('./lib/models')
 const csp = require('./lib/csp')
 const metrics = require('./lib/prometheus')
-const { useUnless } = require('./lib/utils')
+const { useUnless, isLocalhostAddress } = require('./lib/utils')
 
 const supportedLocalesList = Object.keys(require('./locales/_supported.json'))
 
@@ -65,6 +65,7 @@ if (!config.useSSL && config.protocolUseSSL) {
 
 // logger
 app.use(morgan('combined', {
+  skip: (req, _) => req.headers['user-agent'] == 'hedgedoc-container-healthcheck/1.0' && isLocalhostAddress(req),
   stream: logger.stream
 }))
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,3 +34,27 @@ exports.useUnless = function excludeRoute (paths, middleware) {
     return middleware(req, res, next)
   }
 }
+
+exports.isLocalhostAddress = function isLocalhostAddress(req) {
+  const regexRange0To255 = /^([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$/;
+  const clientIP = req.headers['x-forwarded-for'] ||
+    req.connection.remoteAddress ||
+    req.socket.remoteAddress ||
+    req.connection.socket.remoteAddress;
+  const testString = String(clientIP);
+  if (testString === 'localhost' ||
+    testString === '::1') {
+    return true;
+  }
+  if (!testString.startsWith('127.') ||
+    testString === '127.255.255.255' ||
+    testString === '127.0.0.0') {
+    return false;
+  }
+  const splits = testString.split('.');
+  return splits.length === 4 &&
+    splits[0] === '127' &&
+    regexRange0To255.test(splits[1]) &&
+    regexRange0To255.test(splits[2]) &&
+    regexRange0To255.test(splits[3]);
+};


### PR DESCRIPTION
### Component/Part
v1.x logger

### Description
This patch disables logging of HTTP requests containing health-check UA from the local IP address. These logs can take up a lot of disk space but are of little use.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` 

### Related Issue(s)
See #1933
