### PR TITLE
Fix(logger): Ignore docker health check requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,8 +63,14 @@ if (!config.useSSL && config.protocolUseSSL) {
   app.set('trust proxy', 1)
 }
 
+// check if the request is from container healthcheck
+function isContainerHealthCheck (req, _) {
+  return req.headers['user-agent'] === 'hedgedoc-container-healthcheck/1.0' && req.ip === '127.0.0.1'
+}
+
 // logger
 app.use(morgan('combined', {
+  skip: isContainerHealthCheck,
   stream: logger.stream
 }))
 


### PR DESCRIPTION
### Component/Part
logger

### Description
This patch disables logging of HTTP requests containing health-check UA from the local IP address. These logs can take up a lot of disk space but are of little use.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#1933
