### PR TITLE
Change error types in checkLocalPassword and updateLocalPassword

### DIFF
--- a/src/api/private/auth/auth.controller.ts
+++ b/src/api/private/auth/auth.controller.ts
@@ -17,7 +17,11 @@ import {
 } from '@nestjs/common';
 import { Session } from 'express-session';
 
-import { AlreadyInDBError, NotInDBError } from '../../../errors/errors';
+import {
+  AlreadyInDBError,
+  InvalidCredentialsError,
+  NoLocalIdentityError,
+} from '../../../errors/errors';
 import { IdentityService } from '../../../identity/identity.service';
 import { LocalAuthGuard } from '../../../identity/local/local.strategy';
 import { LoginDto } from '../../../identity/local/login.dto';
@@ -80,10 +84,11 @@ export class AuthController {
       );
       return;
     } catch (e) {
-      if (e instanceof NotInDBError) {
-        throw new UnauthorizedException(
-          'Verifying your identity with the current password did not work.',
-        );
+      if (e instanceof InvalidCredentialsError) {
+        throw new UnauthorizedException('Password is not correct');
+      }
+      if (e instanceof NoLocalIdentityError) {
+        throw new BadRequestException('User has no local identity.');
       }
       throw e;
     }

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -43,3 +43,11 @@ export class MediaBackendError extends Error {
 export class PrimaryAliasDeletionForbiddenError extends Error {
   name = 'PrimaryAliasDeletionForbiddenError';
 }
+
+export class InvalidCredentialsError extends Error {
+  name = 'InvalidCredentialsError';
+}
+
+export class NoLocalIdentityError extends Error {
+  name = 'NoLocalIdentityError';
+}

--- a/src/identity/local/local.strategy.ts
+++ b/src/identity/local/local.strategy.ts
@@ -7,7 +7,10 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthGuard, PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
 
-import { NotInDBError } from '../../errors/errors';
+import {
+  InvalidCredentialsError,
+  NoLocalIdentityError,
+} from '../../errors/errors';
 import { UserRelationEnum } from '../../users/user-relation.enum';
 import { User } from '../../users/user.entity';
 import { UsersService } from '../../users/users.service';
@@ -33,9 +36,12 @@ export class LocalStrategy extends PassportStrategy(Strategy, 'local') {
       await this.identityService.checkLocalPassword(user, password);
       return user;
     } catch (e) {
-      if (e instanceof NotInDBError) {
+      if (
+        e instanceof InvalidCredentialsError ||
+        e instanceof NoLocalIdentityError
+      ) {
         throw new UnauthorizedException(
-          'This username and password combination did not work.',
+          'This username and password combination is not valid.',
         );
       }
       throw e;


### PR DESCRIPTION
### Component/Part
`identityService`

### Description
This PR changes error types in `checkLocalPassword` and `updateLocalPassword` to `InvalidCredentialsError` and `NoLocalIdentityError`.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#1936
