### PR TITLE
Use libravatar image if email address is defined

### DIFF
--- a/lib/letter-avatars.js
+++ b/lib/letter-avatars.js
@@ -37,11 +37,11 @@ exports.generateAvatarURL = function (name, email = '', big = true) {
   const hexDigest = hash.digest('hex')
 
   if (email !== '' && config.allowGravatar) {
-    photo = 'https://cdn.libravatar.org/avatar/' + hexDigest
+    photo = `https://cdn.libravatar.org/avatar/${hexDigest}?default=identicon`
     if (big) {
-      photo += '?s=400'
+      photo += '&s=400'
     } else {
-      photo += '?s=96'
+      photo += '&s=96'
     }
   } else {
     photo = config.serverURL + '/user/' + (name || email.substring(0, email.lastIndexOf('@')) || hexDigest) + '/avatar.svg'

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -133,6 +133,10 @@ module.exports = function (sequelize, DataTypes) {
         photo = generateAvatarURL(profile.username, profile.emails[0], bigger)
         break
       default:
+        if (profile.emails && profile.emails.length > 0) {
+          photo = generateAvatarURL(profile.username, profile.emails[0])
+          break
+        }
         photo = generateAvatarURL(profile.username)
         break
     }

--- a/lib/web/auth/oauth2/index.js
+++ b/lib/web/auth/oauth2/index.js
@@ -62,7 +62,7 @@ function parseProfile (data) {
     id: id || username,
     username: username,
     displayName: displayName,
-    email: email
+    emails: email ? [email] : []
   }
 }
 

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## UNRELEASED
+
+### Bugfixes
+- Fix error that Libravatar user avatars were not shown when using OAuth2 login
+
+### Enhancements
+- Libravatar avatars render as ident-icons when no avatar image was uploaded to Libravatar or Gravatar
+
 ## <i class="fa fa-tag"></i> 1.9.2 <i class="fa fa-calendar-o"></i> 2021-12-03
 
 ### Bugfixes

--- a/test/letter-avatars.js
+++ b/test/letter-avatars.js
@@ -19,8 +19,8 @@ describe('generateAvatarURL() gravatar enabled', function () {
   })
 
   it('should return correct urls', function () {
-    assert.strictEqual(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', true), 'https://cdn.libravatar.org/avatar/d41b5f3508cc3f31865566a47dd0336b?s=400')
-    assert.strictEqual(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', false), 'https://cdn.libravatar.org/avatar/d41b5f3508cc3f31865566a47dd0336b?s=96')
+    assert.strictEqual(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', true), 'https://cdn.libravatar.org/avatar/d41b5f3508cc3f31865566a47dd0336b?default=identicon&s=400')
+    assert.strictEqual(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', false), 'https://cdn.libravatar.org/avatar/d41b5f3508cc3f31865566a47dd0336b?default=identicon&s=96')
   })
 
   it('should return correct urls for names with spaces', function () {


### PR DESCRIPTION
### Component/Part
user avatars

### Description
This PR fixes user avatars for OAuth2 which were not based on the email address.
It also adds libravatar's fallback to identicons.

See the commit messages for more details.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Updated tests
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
https://community.hedgedoc.org/t/oauth2-gravatar-avatars-not-showing-up/544
