### PR TITLE
Do not embed User/Group objects

### DIFF
--- a/src/notes/note-metadata.dto.ts
+++ b/src/notes/note-metadata.dto.ts
@@ -77,10 +77,10 @@ export class NoteMetadataDto {
   /**
    * User that last edited the note
    */
-  @ValidateNested()
-  @ApiPropertyOptional({ type: UserInfoDto })
+  @IsString()
+  @ApiPropertyOptional()
   @IsOptional()
-  updateUser: UserInfoDto | null;
+  updateUsername: string | null;
 
   /**
    * Counts how many times the published note has been viewed

--- a/src/notes/note-permissions.dto.ts
+++ b/src/notes/note-permissions.dto.ts
@@ -12,9 +12,6 @@ import {
   ValidateNested,
 } from 'class-validator';
 
-import { GroupInfoDto } from '../groups/group-info.dto';
-import { UserInfoDto } from '../users/user-info.dto';
-
 export class NoteUserPermissionEntryDto {
   /**
    * Username of the User this permission applies to

--- a/src/notes/note-permissions.dto.ts
+++ b/src/notes/note-permissions.dto.ts
@@ -52,11 +52,11 @@ export class NoteUserPermissionUpdateDto {
 
 export class NoteGroupPermissionEntryDto {
   /**
-   * Group this permission applies to
+   * Name of the Group this permission applies to
    */
-  @ValidateNested()
-  @ApiProperty({ type: GroupInfoDto })
-  group: GroupInfoDto;
+  @IsString()
+  @ApiProperty()
+  groupName: string;
 
   /**
    * True if the group members are allowed to edit the note

--- a/src/notes/note-permissions.dto.ts
+++ b/src/notes/note-permissions.dto.ts
@@ -87,12 +87,12 @@ export class NoteGroupPermissionUpdateDto {
 
 export class NotePermissionsDto {
   /**
-   * User this permission applies to
+   * Username of the User this permission applies to
    */
-  @ValidateNested()
-  @ApiPropertyOptional({ type: UserInfoDto })
+  @IsString()
+  @ApiPropertyOptional()
   @IsOptional()
-  owner: UserInfoDto | null;
+  owner: string | null;
 
   /**
    * List of users the note is shared with

--- a/src/notes/note-permissions.dto.ts
+++ b/src/notes/note-permissions.dto.ts
@@ -74,7 +74,7 @@ export class NoteGroupPermissionUpdateDto {
    */
   @IsString()
   @ApiProperty()
-  groupname: string;
+  groupName: string;
 
   /**
    * True if the group members should be allowed to edit the note

--- a/src/notes/note-permissions.dto.ts
+++ b/src/notes/note-permissions.dto.ts
@@ -17,11 +17,11 @@ import { UserInfoDto } from '../users/user-info.dto';
 
 export class NoteUserPermissionEntryDto {
   /**
-   * User this permission applies to
+   * Username of the User this permission applies to
    */
-  @ValidateNested()
-  @ApiProperty({ type: UserInfoDto })
-  user: UserInfoDto;
+  @IsString()
+  @ApiProperty()
+  username: string;
 
   /**
    * True if the user is allowed to edit the note

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -691,7 +691,7 @@ describe('NotesService', () => {
       expect(permissions.sharedToUsers[0].username).toEqual(user.username);
       expect(permissions.sharedToUsers[0].canEdit).toEqual(true);
       expect(permissions.sharedToGroups).toHaveLength(1);
-      expect(permissions.sharedToGroups[0].group.displayName).toEqual(
+      expect(permissions.sharedToGroups[0].groupName).toEqual(
         group.displayName,
       );
       expect(permissions.sharedToGroups[0].canEdit).toEqual(true);
@@ -783,9 +783,9 @@ describe('NotesService', () => {
       );
       expect(metadataDto.permissions.sharedToUsers[0].canEdit).toEqual(true);
       expect(metadataDto.permissions.sharedToGroups).toHaveLength(1);
-      expect(
-        metadataDto.permissions.sharedToGroups[0].group.displayName,
-      ).toEqual(group.displayName);
+      expect(metadataDto.permissions.sharedToGroups[0].groupName).toEqual(
+        group.displayName,
+      );
       expect(metadataDto.permissions.sharedToGroups[0].canEdit).toEqual(true);
       expect(metadataDto.tags).toHaveLength(1);
       expect(metadataDto.tags[0]).toEqual((await note.tags)[0].name);
@@ -887,9 +887,9 @@ describe('NotesService', () => {
         true,
       );
       expect(noteDto.metadata.permissions.sharedToGroups).toHaveLength(1);
-      expect(
-        noteDto.metadata.permissions.sharedToGroups[0].group.displayName,
-      ).toEqual(group.displayName);
+      expect(noteDto.metadata.permissions.sharedToGroups[0].groupName).toEqual(
+        group.displayName,
+      );
       expect(noteDto.metadata.permissions.sharedToGroups[0].canEdit).toEqual(
         true,
       );

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -688,7 +688,7 @@ describe('NotesService', () => {
       const permissions = await service.toNotePermissionsDto(note);
       expect(permissions.owner).toEqual(user.username);
       expect(permissions.sharedToUsers).toHaveLength(1);
-      expect(permissions.sharedToUsers[0].user.username).toEqual(user.username);
+      expect(permissions.sharedToUsers[0].username).toEqual(user.username);
       expect(permissions.sharedToUsers[0].canEdit).toEqual(true);
       expect(permissions.sharedToGroups).toHaveLength(1);
       expect(permissions.sharedToGroups[0].group.displayName).toEqual(
@@ -778,7 +778,7 @@ describe('NotesService', () => {
       expect(metadataDto.editedBy[0]).toEqual(user.username);
       expect(metadataDto.permissions.owner).toEqual(user.username);
       expect(metadataDto.permissions.sharedToUsers).toHaveLength(1);
-      expect(metadataDto.permissions.sharedToUsers[0].user.username).toEqual(
+      expect(metadataDto.permissions.sharedToUsers[0].username).toEqual(
         user.username,
       );
       expect(metadataDto.permissions.sharedToUsers[0].canEdit).toEqual(true);
@@ -880,9 +880,9 @@ describe('NotesService', () => {
       expect(noteDto.metadata.editedBy[0]).toEqual(user.username);
       expect(noteDto.metadata.permissions.owner).toEqual(user.username);
       expect(noteDto.metadata.permissions.sharedToUsers).toHaveLength(1);
-      expect(
-        noteDto.metadata.permissions.sharedToUsers[0].user.username,
-      ).toEqual(user.username);
+      expect(noteDto.metadata.permissions.sharedToUsers[0].username).toEqual(
+        user.username,
+      );
       expect(noteDto.metadata.permissions.sharedToUsers[0].canEdit).toEqual(
         true,
       );

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -359,12 +359,12 @@ describe('NotesService', () => {
     userPermissionUpdate.username = 'hardcoded';
     userPermissionUpdate.canEdit = true;
     const groupPermissionUpate = new NoteGroupPermissionUpdateDto();
-    groupPermissionUpate.groupname = 'testGroup';
+    groupPermissionUpate.groupName = 'testGroup';
     groupPermissionUpate.canEdit = false;
     const user = User.create(userPermissionUpdate.username, 'Testy') as User;
     const group = Group.create(
-      groupPermissionUpate.groupname,
-      groupPermissionUpate.groupname,
+      groupPermissionUpate.groupName,
+      groupPermissionUpate.groupName,
       false,
     ) as Group;
     const note = Note.create(user) as Note;
@@ -443,7 +443,7 @@ describe('NotesService', () => {
         });
         expect(await savedNote.userPermissions).toHaveLength(0);
         expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpate.groupname,
+          groupPermissionUpate.groupName,
         );
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpate.canEdit,
@@ -468,7 +468,7 @@ describe('NotesService', () => {
           userPermissionUpdate.canEdit,
         );
         expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpate.groupname,
+          groupPermissionUpate.groupName,
         );
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpate.canEdit,
@@ -504,7 +504,7 @@ describe('NotesService', () => {
           userPermissionUpdate.canEdit,
         );
         expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpate.groupname,
+          groupPermissionUpate.groupName,
         );
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpate.canEdit,
@@ -534,7 +534,7 @@ describe('NotesService', () => {
         );
         expect(await savedNote.userPermissions).toHaveLength(0);
         expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpate.groupname,
+          groupPermissionUpate.groupName,
         );
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpate.canEdit,
@@ -570,7 +570,7 @@ describe('NotesService', () => {
           userPermissionUpdate.canEdit,
         );
         expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpate.groupname,
+          groupPermissionUpate.groupName,
         );
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpate.canEdit,
@@ -613,7 +613,7 @@ describe('NotesService', () => {
           userPermissionUpdate.canEdit,
         );
         expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpate.groupname,
+          groupPermissionUpate.groupName,
         );
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpate.canEdit,

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -686,8 +686,7 @@ describe('NotesService', () => {
         },
       ]);
       const permissions = await service.toNotePermissionsDto(note);
-      expect(permissions.owner).not.toEqual(null);
-      expect(permissions.owner?.username).toEqual(user.username);
+      expect(permissions.owner).toEqual(user.username);
       expect(permissions.sharedToUsers).toHaveLength(1);
       expect(permissions.sharedToUsers[0].user.username).toEqual(user.username);
       expect(permissions.sharedToUsers[0].canEdit).toEqual(true);
@@ -777,7 +776,7 @@ describe('NotesService', () => {
       expect(metadataDto.description).toEqual(note.description);
       expect(metadataDto.editedBy).toHaveLength(1);
       expect(metadataDto.editedBy[0]).toEqual(user.username);
-      expect(metadataDto.permissions.owner.username).toEqual(user.username);
+      expect(metadataDto.permissions.owner).toEqual(user.username);
       expect(metadataDto.permissions.sharedToUsers).toHaveLength(1);
       expect(metadataDto.permissions.sharedToUsers[0].user.username).toEqual(
         user.username,
@@ -879,9 +878,7 @@ describe('NotesService', () => {
       expect(noteDto.metadata.description).toEqual(note.description);
       expect(noteDto.metadata.editedBy).toHaveLength(1);
       expect(noteDto.metadata.editedBy[0]).toEqual(user.username);
-      expect(noteDto.metadata.permissions.owner.username).toEqual(
-        user.username,
-      );
+      expect(noteDto.metadata.permissions.owner).toEqual(user.username);
       expect(noteDto.metadata.permissions.sharedToUsers).toHaveLength(1);
       expect(
         noteDto.metadata.permissions.sharedToUsers[0].user.username,

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -790,7 +790,7 @@ describe('NotesService', () => {
       expect(metadataDto.tags).toHaveLength(1);
       expect(metadataDto.tags[0]).toEqual((await note.tags)[0].name);
       expect(metadataDto.updatedAt).toEqual(revisions[0].createdAt);
-      expect(metadataDto.updateUser.username).toEqual(user.username);
+      expect(metadataDto.updateUsername).toEqual(user.username);
       expect(metadataDto.viewCount).toEqual(note.viewCount);
     });
   });
@@ -896,7 +896,7 @@ describe('NotesService', () => {
       expect(noteDto.metadata.tags).toHaveLength(1);
       expect(noteDto.metadata.tags[0]).toEqual((await note.tags)[0].name);
       expect(noteDto.metadata.updatedAt).toEqual(revisions[0].createdAt);
-      expect(noteDto.metadata.updateUser.username).toEqual(user.username);
+      expect(noteDto.metadata.updateUsername).toEqual(user.username);
       expect(noteDto.metadata.viewCount).toEqual(note.viewCount);
       expect(noteDto.content).toEqual(content);
     });

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -285,7 +285,7 @@ export class NotesService {
     );
 
     const groups = newPermissions.sharedToGroups.map(
-      (groupPermission) => groupPermission.groupname,
+      (groupPermission) => groupPermission.groupName,
     );
 
     if (checkArrayForDuplicates(users) || checkArrayForDuplicates(groups)) {
@@ -318,7 +318,7 @@ export class NotesService {
     // Create groupPermissions
     for (const newGroupPermission of newPermissions.sharedToGroups) {
       const group = await this.groupsService.getGroupByName(
-        newGroupPermission.groupname,
+        newGroupPermission.groupName,
       );
       const createdPermission = NoteGroupPermission.create(
         group,

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -375,7 +375,7 @@ export class NotesService {
     return {
       owner: owner ? owner.username : null,
       sharedToUsers: userPermissions.map((noteUserPermission) => ({
-        user: this.usersService.toUserDto(noteUserPermission.user),
+        username: noteUserPermission.user.username,
         canEdit: noteUserPermission.canEdit,
       })),
       sharedToGroups: groupPermissions.map((noteGroupPermission) => ({

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -406,7 +406,7 @@ export class NotesService {
       permissions: await this.toNotePermissionsDto(note),
       tags: await this.toTagList(note),
       updatedAt: (await this.getLatestRevision(note)).createdAt,
-      updateUser: updateUser ? this.usersService.toUserDto(updateUser) : null,
+      updateUsername: updateUser ? updateUser.username : null,
       viewCount: note.viewCount,
     };
   }

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -373,7 +373,7 @@ export class NotesService {
     const userPermissions = await note.userPermissions;
     const groupPermissions = await note.groupPermissions;
     return {
-      owner: owner ? this.usersService.toUserDto(owner) : null,
+      owner: owner ? owner.username : null,
       sharedToUsers: userPermissions.map((noteUserPermission) => ({
         user: this.usersService.toUserDto(noteUserPermission.user),
         canEdit: noteUserPermission.canEdit,

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -379,7 +379,7 @@ export class NotesService {
         canEdit: noteUserPermission.canEdit,
       })),
       sharedToGroups: groupPermissions.map((noteGroupPermission) => ({
-        group: this.groupsService.toGroupDto(noteGroupPermission.group),
+        groupName: noteGroupPermission.group.name,
         canEdit: noteGroupPermission.canEdit,
       })),
     };

--- a/test/public-api/me.e2e-spec.ts
+++ b/test/public-api/me.e2e-spec.ts
@@ -175,7 +175,7 @@ describe('Me', () => {
     const noteMetaDtos = response.body as NoteMetadataDto[];
     expect(noteMetaDtos).toHaveLength(1);
     expect(noteMetaDtos[0].primaryAlias).toEqual(noteName);
-    expect(noteMetaDtos[0].updateUser?.username).toEqual(user.username);
+    expect(noteMetaDtos[0].updateUsername).toEqual(user.username);
   });
 
   it('GET /me/media', async () => {

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -281,10 +281,7 @@ describe('Notes', () => {
       expect(metadata.body.permissions.sharedToUsers).toEqual([]);
       expect(metadata.body.tags).toEqual([]);
       expect(typeof metadata.body.updatedAt).toEqual('string');
-      expect(typeof metadata.body.updateUser.displayName).toEqual('string');
-      expect(typeof metadata.body.updateUser.username).toEqual('string');
-      expect(typeof metadata.body.updateUser.email).toEqual('string');
-      expect(typeof metadata.body.updateUser.photo).toEqual('string');
+      expect(typeof metadata.body.updateUsername).toEqual('string');
       expect(typeof metadata.body.viewCount).toEqual('number');
       expect(metadata.body.editedBy).toEqual([]);
     });

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -276,7 +276,7 @@ describe('Notes', () => {
       expect(metadata.body.description).toEqual('');
       expect(typeof metadata.body.createdAt).toEqual('string');
       expect(metadata.body.editedBy).toEqual([]);
-      expect(metadata.body.permissions.owner.username).toEqual('hardcoded');
+      expect(metadata.body.permissions.owner).toEqual('hardcoded');
       expect(metadata.body.permissions.sharedToUsers).toEqual([]);
       expect(metadata.body.permissions.sharedToUsers).toEqual([]);
       expect(metadata.body.tags).toEqual([]);


### PR DESCRIPTION
### Component/Part
API

### Description
This PR removes embedded user and group objects from the API

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
