### PR TITLE
Add error mapping

### DIFF
--- a/src/api/private/alias/alias.controller.ts
+++ b/src/api/private/alias/alias.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,9 +15,14 @@ import {
   UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
-
 import {
+  ApiBadRequestResponse,
+  ApiConflictResponse,
+  ApiNotFoundResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiUnprocessableEntityResponse,
+} from '@nestjs/swagger';
 
 import { SessionGuard } from '../../../identity/session.guard';
 import { ConsoleLoggerService } from '../../../logger/console-logger.service';
@@ -29,6 +34,13 @@ import { NotesService } from '../../../notes/notes.service';
 import { PermissionsService } from '../../../permissions/permissions.service';
 import { User } from '../../../users/user.entity';
 import { UsersService } from '../../../users/users.service';
+import {
+  badRequestDescription,
+  conflictDescription,
+  notFoundDescription,
+  unauthorizedDescription,
+  unprocessableEntityDescription,
+} from '../../utils/descriptions';
 import { RequestUser } from '../../utils/request-user.decorator';
 
 @UseGuards(SessionGuard)
@@ -46,6 +58,9 @@ export class AliasController {
   }
 
   @Post()
+  @ApiConflictResponse({ description: conflictDescription })
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   async addAlias(
     @RequestUser() user: User,
     @Body() newAliasDto: AliasCreateDto,
@@ -64,6 +79,9 @@ export class AliasController {
   }
 
   @Put(':alias')
+  @ApiBadRequestResponse({ description: badRequestDescription })
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   async makeAliasPrimary(
     @RequestUser() user: User,
     @Param('alias') alias: string,
@@ -84,6 +102,11 @@ export class AliasController {
 
   @Delete(':alias')
   @HttpCode(204)
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
+  @ApiUnprocessableEntityResponse({
+    description: unprocessableEntityDescription,
+  })
   async removeAlias(
     @RequestUser() user: User,
     @Param('alias') alias: string,

--- a/src/api/private/alias/alias.controller.ts
+++ b/src/api/private/alias/alias.controller.ts
@@ -21,7 +21,6 @@ import {
   ApiNotFoundResponse,
   ApiTags,
   ApiUnauthorizedResponse,
-  ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
 
 import { SessionGuard } from '../../../identity/session.guard';
@@ -39,7 +38,6 @@ import {
   conflictDescription,
   notFoundDescription,
   unauthorizedDescription,
-  unprocessableEntityDescription,
 } from '../../utils/descriptions';
 import { RequestUser } from '../../utils/request-user.decorator';
 
@@ -58,6 +56,7 @@ export class AliasController {
   }
 
   @Post()
+  @ApiBadRequestResponse({ description: badRequestDescription })
   @ApiConflictResponse({ description: conflictDescription })
   @ApiUnauthorizedResponse({ description: unauthorizedDescription })
   @ApiNotFoundResponse({ description: notFoundDescription })
@@ -104,8 +103,8 @@ export class AliasController {
   @HttpCode(204)
   @ApiUnauthorizedResponse({ description: unauthorizedDescription })
   @ApiNotFoundResponse({ description: notFoundDescription })
-  @ApiUnprocessableEntityResponse({
-    description: unprocessableEntityDescription,
+  @ApiBadRequestResponse({
+    description: badRequestDescription,
   })
   async removeAlias(
     @RequestUser() user: User,

--- a/src/api/private/auth/auth.controller.ts
+++ b/src/api/private/auth/auth.controller.ts
@@ -12,17 +12,12 @@ import {
   Post,
   Put,
   Req,
-  UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Session } from 'express-session';
 
-import {
-  AlreadyInDBError,
-  InvalidCredentialsError,
-  NoLocalIdentityError,
-} from '../../../errors/errors';
+import { AlreadyInDBError } from '../../../errors/errors';
 import { IdentityService } from '../../../identity/identity.service';
 import { LocalAuthGuard } from '../../../identity/local/local.strategy';
 import { LoginDto } from '../../../identity/local/login.dto';
@@ -62,6 +57,7 @@ export class AuthController {
       );
       return;
     } catch (e) {
+      // This special handling can't be omitted since AlreadyInDBErrors get mapped to BadRequestException usually.
       if (e instanceof AlreadyInDBError) {
         throw new ConflictException(e.message);
       }

--- a/src/api/private/auth/auth.controller.ts
+++ b/src/api/private/auth/auth.controller.ts
@@ -75,25 +75,15 @@ export class AuthController {
     @RequestUser() user: User,
     @Body() changePasswordDto: UpdatePasswordDto,
   ): Promise<void> {
-    try {
-      await this.identityService.checkLocalPassword(
-        user,
-        changePasswordDto.currentPassword,
-      );
-      await this.identityService.updateLocalPassword(
-        user,
-        changePasswordDto.newPassword,
-      );
-      return;
-    } catch (e) {
-      if (e instanceof InvalidCredentialsError) {
-        throw new UnauthorizedException('Password is not correct');
-      }
-      if (e instanceof NoLocalIdentityError) {
-        throw new BadRequestException('User has no local identity.');
-      }
-      throw e;
-    }
+    await this.identityService.checkLocalPassword(
+      user,
+      changePasswordDto.currentPassword,
+    );
+    await this.identityService.updateLocalPassword(
+      user,
+      changePasswordDto.newPassword,
+    );
+    return;
   }
 
   @UseGuards(LoginEnabledGuard, LocalAuthGuard)

--- a/src/api/private/me/history/history.controller.ts
+++ b/src/api/private/me/history/history.controller.ts
@@ -13,7 +13,11 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiNotFoundResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 
 import { HistoryEntryImportDto } from '../../../../history/history-entry-import.dto';
 import { HistoryEntryUpdateDto } from '../../../../history/history-entry-update.dto';
@@ -23,6 +27,10 @@ import { SessionGuard } from '../../../../identity/session.guard';
 import { ConsoleLoggerService } from '../../../../logger/console-logger.service';
 import { Note } from '../../../../notes/note.entity';
 import { User } from '../../../../users/user.entity';
+import {
+  notFoundDescription,
+  unauthorizedDescription,
+} from '../../../utils/descriptions';
 import { GetNoteInterceptor } from '../../../utils/get-note.interceptor';
 import { RequestNote } from '../../../utils/request-note.decorator';
 import { RequestUser } from '../../../utils/request-user.decorator';
@@ -39,6 +47,8 @@ export class HistoryController {
   }
 
   @Get()
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   async getHistory(@RequestUser() user: User): Promise<HistoryEntryDto[]> {
     const foundEntries = await this.historyService.getEntriesByUser(user);
     return await Promise.all(
@@ -47,6 +57,8 @@ export class HistoryController {
   }
 
   @Post()
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   async setHistory(
     @RequestUser() user: User,
     @Body('history') history: HistoryEntryImportDto[],
@@ -55,11 +67,15 @@ export class HistoryController {
   }
 
   @Delete()
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   async deleteHistory(@RequestUser() user: User): Promise<void> {
     await this.historyService.deleteHistory(user);
   }
 
   @Put(':noteIdOrAlias')
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   @UseInterceptors(GetNoteInterceptor)
   async updateHistoryEntry(
     @RequestNote() note: Note,
@@ -75,6 +91,8 @@ export class HistoryController {
   }
 
   @Delete(':noteIdOrAlias')
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   @UseInterceptors(GetNoteInterceptor)
   async deleteHistoryEntry(
     @RequestNote() note: Note,

--- a/src/api/private/media/media.controller.ts
+++ b/src/api/private/media/media.controller.ts
@@ -16,12 +16,15 @@ import {
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
+  ApiBadRequestResponse,
   ApiBody,
   ApiConsumes,
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiHeader,
+  ApiInternalServerErrorResponse,
   ApiNoContentResponse,
+  ApiNotFoundResponse,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -36,7 +39,10 @@ import { Note } from '../../../notes/note.entity';
 import { NotesService } from '../../../notes/notes.service';
 import { User } from '../../../users/user.entity';
 import {
+  badRequestDescription,
   forbiddenDescription,
+  internalServerErrorDescription,
+  notFoundDescription,
   successfullyDeletedDescription,
   unauthorizedDescription,
 } from '../../utils/descriptions';
@@ -72,14 +78,19 @@ export class MediaController {
     name: 'HedgeDoc-Note',
     description: 'ID or alias of the parent note',
   })
+  @UseInterceptors(FileInterceptor('file'))
+  @HttpCode(201)
   @ApiCreatedResponse({
     description: 'The file was uploaded successfully',
     type: MediaUploadUrlDto,
   })
+  @ApiBadRequestResponse({ description: badRequestDescription })
   @ApiUnauthorizedResponse({ description: unauthorizedDescription })
   @ApiForbiddenResponse({ description: forbiddenDescription })
-  @UseInterceptors(FileInterceptor('file'))
-  @HttpCode(201)
+  @ApiNotFoundResponse({ description: notFoundDescription })
+  @ApiInternalServerErrorResponse({
+    description: internalServerErrorDescription,
+  })
   async uploadMedia(
     @UploadedFile() file: MulterFile,
     @Headers('HedgeDoc-Note') noteId: string,
@@ -99,6 +110,9 @@ export class MediaController {
   @HttpCode(204)
   @ApiNoContentResponse({ description: successfullyDeletedDescription })
   @FullApi
+  @ApiInternalServerErrorResponse({
+    description: internalServerErrorDescription,
+  })
   async deleteMedia(
     @RequestUser() user: User,
     @Param('filename') filename: string,

--- a/src/api/private/notes/notes.controller.ts
+++ b/src/api/private/notes/notes.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -14,7 +14,14 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiBadRequestResponse,
+  ApiConflictResponse,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 
 import { HistoryService } from '../../../history/history.service';
 import { SessionGuard } from '../../../identity/session.guard';
@@ -32,6 +39,13 @@ import { RevisionDto } from '../../../revisions/revision.dto';
 import { RevisionsService } from '../../../revisions/revisions.service';
 import { User } from '../../../users/user.entity';
 import { UsersService } from '../../../users/users.service';
+import {
+  badRequestDescription,
+  conflictDescription,
+  internalServerErrorDescription,
+  notFoundDescription,
+  unauthorizedDescription,
+} from '../../utils/descriptions';
 import { GetNoteInterceptor } from '../../utils/get-note.interceptor';
 import { MarkdownBody } from '../../utils/markdownbody-decorator';
 import { PermissionsGuard } from '../../utils/permissions.guard';
@@ -54,6 +68,7 @@ export class NotesController {
   }
 
   @Get(':noteIdOrAlias')
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
   @Permissions(Permission.READ)
   @UseInterceptors(GetNoteInterceptor)
   @UseGuards(PermissionsGuard)
@@ -66,6 +81,7 @@ export class NotesController {
   }
 
   @Get(':noteIdOrAlias/media')
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
   @Permissions(Permission.READ)
   @UseInterceptors(GetNoteInterceptor)
   @UseGuards(PermissionsGuard)
@@ -78,6 +94,7 @@ export class NotesController {
 
   @Post()
   @HttpCode(201)
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
   @Permissions(Permission.CREATE)
   @UseGuards(PermissionsGuard)
   async createNote(
@@ -92,6 +109,10 @@ export class NotesController {
 
   @Post(':noteAlias')
   @HttpCode(201)
+  @ApiBadRequestResponse({ description: badRequestDescription })
+  @ApiConflictResponse({ description: conflictDescription })
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   @Permissions(Permission.CREATE)
   @UseGuards(PermissionsGuard)
   async createNamedNote(
@@ -107,6 +128,11 @@ export class NotesController {
 
   @Delete(':noteIdOrAlias')
   @HttpCode(204)
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
+  @ApiInternalServerErrorResponse({
+    description: internalServerErrorDescription,
+  })
   @Permissions(Permission.OWNER)
   @UseInterceptors(GetNoteInterceptor)
   @UseGuards(PermissionsGuard)
@@ -130,6 +156,8 @@ export class NotesController {
   }
 
   @Get(':noteIdOrAlias/revisions')
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   @Permissions(Permission.READ)
   @UseInterceptors(GetNoteInterceptor)
   @UseGuards(PermissionsGuard)
@@ -147,6 +175,8 @@ export class NotesController {
 
   @Delete(':noteIdOrAlias/revisions')
   @HttpCode(204)
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   @Permissions(Permission.READ)
   @UseInterceptors(GetNoteInterceptor)
   @UseGuards(PermissionsGuard)
@@ -167,6 +197,8 @@ export class NotesController {
   }
 
   @Get(':noteIdOrAlias/revisions/:revisionId')
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   @Permissions(Permission.READ)
   @UseInterceptors(GetNoteInterceptor)
   @UseGuards(PermissionsGuard)

--- a/src/api/private/tokens/tokens.controller.ts
+++ b/src/api/private/tokens/tokens.controller.ts
@@ -14,7 +14,11 @@ import {
   UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiNotFoundResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 
 import { AuthTokenWithSecretDto } from '../../../auth/auth-token-with-secret.dto';
 import { AuthTokenDto } from '../../../auth/auth-token.dto';
@@ -23,6 +27,10 @@ import { SessionGuard } from '../../../identity/session.guard';
 import { ConsoleLoggerService } from '../../../logger/console-logger.service';
 import { User } from '../../../users/user.entity';
 import { TimestampMillis } from '../../../utils/timestamp';
+import {
+  notFoundDescription,
+  unauthorizedDescription,
+} from '../../utils/descriptions';
 import { RequestUser } from '../../utils/request-user.decorator';
 
 @UseGuards(SessionGuard)
@@ -37,6 +45,7 @@ export class TokensController {
   }
 
   @Get()
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
   async getUserTokens(@RequestUser() user: User): Promise<AuthTokenDto[]> {
     return (await this.authService.getTokensByUser(user)).map((token) =>
       this.authService.toAuthTokenDto(token),
@@ -44,6 +53,7 @@ export class TokensController {
   }
 
   @Post()
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
   async postTokenRequest(
     @Body('label') label: string,
     @Body('validUntil') validUntil: TimestampMillis,
@@ -54,6 +64,8 @@ export class TokensController {
 
   @Delete('/:keyId')
   @HttpCode(204)
+  @ApiUnauthorizedResponse({ description: unauthorizedDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
   async deleteToken(
     @RequestUser() user: User,
     @Param('keyId') keyId: string,

--- a/src/api/private/tokens/tokens.controller.ts
+++ b/src/api/private/tokens/tokens.controller.ts
@@ -9,7 +9,6 @@ import {
   Delete,
   Get,
   HttpCode,
-  NotFoundException,
   Param,
   Post,
   UnauthorizedException,
@@ -20,7 +19,6 @@ import { ApiTags } from '@nestjs/swagger';
 import { AuthTokenWithSecretDto } from '../../../auth/auth-token-with-secret.dto';
 import { AuthTokenDto } from '../../../auth/auth-token.dto';
 import { AuthService } from '../../../auth/auth.service';
-import { NotInDBError } from '../../../errors/errors';
 import { SessionGuard } from '../../../identity/session.guard';
 import { ConsoleLoggerService } from '../../../logger/console-logger.service';
 import { User } from '../../../users/user.entity';
@@ -61,15 +59,9 @@ export class TokensController {
     @Param('keyId') keyId: string,
   ): Promise<void> {
     const tokens = await this.authService.getTokensByUser(user);
-    try {
-      for (const token of tokens) {
-        if (token.keyId == keyId) {
-          return await this.authService.removeToken(keyId);
-        }
-      }
-    } catch (e) {
-      if (e instanceof NotInDBError) {
-        throw new NotFoundException(e.message);
+    for (const token of tokens) {
+      if (token.keyId == keyId) {
+        return await this.authService.removeToken(keyId);
       }
     }
     throw new UnauthorizedException(

--- a/src/api/public/alias/alias.controller.ts
+++ b/src/api/public/alias/alias.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -20,6 +20,7 @@ import {
   ApiOkResponse,
   ApiSecurity,
   ApiTags,
+  ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
 
 import { TokenAuthGuard } from '../../../auth/token.strategy';
@@ -31,6 +32,7 @@ import { AliasService } from '../../../notes/alias.service';
 import { NotesService } from '../../../notes/notes.service';
 import { PermissionsService } from '../../../permissions/permissions.service';
 import { User } from '../../../users/user.entity';
+import { unprocessableEntityDescription } from '../../utils/descriptions';
 import { FullApi } from '../../utils/fullapi-decorator';
 import { RequestUser } from '../../utils/request-user.decorator';
 
@@ -101,6 +103,9 @@ export class AliasController {
     description: 'The alias was deleted',
   })
   @FullApi
+  @ApiUnprocessableEntityResponse({
+    description: unprocessableEntityDescription,
+  })
   async removeAlias(
     @RequestUser() user: User,
     @Param('alias') alias: string,

--- a/src/api/public/alias/alias.controller.ts
+++ b/src/api/public/alias/alias.controller.ts
@@ -16,11 +16,11 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiNoContentResponse,
   ApiOkResponse,
   ApiSecurity,
   ApiTags,
-  ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
 
 import { TokenAuthGuard } from '../../../auth/token.strategy';
@@ -32,7 +32,7 @@ import { AliasService } from '../../../notes/alias.service';
 import { NotesService } from '../../../notes/notes.service';
 import { PermissionsService } from '../../../permissions/permissions.service';
 import { User } from '../../../users/user.entity';
-import { unprocessableEntityDescription } from '../../utils/descriptions';
+import { badRequestDescription } from '../../utils/descriptions';
 import { FullApi } from '../../utils/fullapi-decorator';
 import { RequestUser } from '../../utils/request-user.decorator';
 
@@ -103,8 +103,8 @@ export class AliasController {
     description: 'The alias was deleted',
   })
   @FullApi
-  @ApiUnprocessableEntityResponse({
-    description: unprocessableEntityDescription,
+  @ApiBadRequestResponse({
+    description: badRequestDescription,
   })
   async removeAlias(
     @RequestUser() user: User,

--- a/src/api/public/me/me.controller.ts
+++ b/src/api/public/me/me.controller.ts
@@ -46,6 +46,7 @@ import { GetNoteInterceptor } from '../../utils/get-note.interceptor';
 import { RequestNote } from '../../utils/request-note.decorator';
 import { RequestUser } from '../../utils/request-user.decorator';
 
+@UseGuards(TokenAuthGuard)
 @ApiTags('me')
 @ApiSecurity('token')
 @Controller('me')
@@ -60,7 +61,6 @@ export class MeController {
     this.logger.setContext(MeController.name);
   }
 
-  @UseGuards(TokenAuthGuard)
   @Get()
   @ApiOkResponse({
     description: 'The user information',
@@ -71,7 +71,6 @@ export class MeController {
     return this.usersService.toUserDto(user);
   }
 
-  @UseGuards(TokenAuthGuard)
   @Get('history')
   @ApiOkResponse({
     description: 'The history entries of the user',
@@ -87,7 +86,6 @@ export class MeController {
   }
 
   @UseInterceptors(GetNoteInterceptor)
-  @UseGuards(TokenAuthGuard)
   @Get('history/:noteIdOrAlias')
   @ApiOkResponse({
     description: 'The history entry of the user which points to the note',
@@ -99,19 +97,11 @@ export class MeController {
     @RequestUser() user: User,
     @RequestNote() note: Note,
   ): Promise<HistoryEntryDto> {
-    try {
-      const foundEntry = await this.historyService.getEntryByNote(note, user);
-      return await this.historyService.toHistoryEntryDto(foundEntry);
-    } catch (e) {
-      if (e instanceof NotInDBError) {
-        throw new NotFoundException(e.message);
-      }
-      throw e;
-    }
+    const foundEntry = await this.historyService.getEntryByNote(note, user);
+    return await this.historyService.toHistoryEntryDto(foundEntry);
   }
 
   @UseInterceptors(GetNoteInterceptor)
-  @UseGuards(TokenAuthGuard)
   @Put('history/:noteIdOrAlias')
   @ApiOkResponse({
     description: 'The updated history entry',
@@ -125,24 +115,12 @@ export class MeController {
     @Body() entryUpdateDto: HistoryEntryUpdateDto,
   ): Promise<HistoryEntryDto> {
     // ToDo: Check if user is allowed to pin this history entry
-    try {
-      return await this.historyService.toHistoryEntryDto(
-        await this.historyService.updateHistoryEntry(
-          note,
-          user,
-          entryUpdateDto,
-        ),
-      );
-    } catch (e) {
-      if (e instanceof NotInDBError) {
-        throw new NotFoundException(e.message);
-      }
-      throw e;
-    }
+    return await this.historyService.toHistoryEntryDto(
+      await this.historyService.updateHistoryEntry(note, user, entryUpdateDto),
+    );
   }
 
   @UseInterceptors(GetNoteInterceptor)
-  @UseGuards(TokenAuthGuard)
   @Delete('history/:noteIdOrAlias')
   @HttpCode(204)
   @ApiNoContentResponse({ description: successfullyDeletedDescription })
@@ -153,17 +131,9 @@ export class MeController {
     @RequestNote() note: Note,
   ): Promise<void> {
     // ToDo: Check if user is allowed to delete note
-    try {
-      await this.historyService.deleteHistoryEntry(note, user);
-    } catch (e) {
-      if (e instanceof NotInDBError) {
-        throw new NotFoundException(e.message);
-      }
-      throw e;
-    }
+    await this.historyService.deleteHistoryEntry(note, user);
   }
 
-  @UseGuards(TokenAuthGuard)
   @Get('notes')
   @ApiOkResponse({
     description: 'Metadata of all notes of the user',
@@ -178,7 +148,6 @@ export class MeController {
     );
   }
 
-  @UseGuards(TokenAuthGuard)
   @Get('media')
   @ApiOkResponse({
     description: 'All media uploads of the user',

--- a/src/api/public/me/me.controller.ts
+++ b/src/api/public/me/me.controller.ts
@@ -9,7 +9,6 @@ import {
   Delete,
   Get,
   HttpCode,
-  NotFoundException,
   Put,
   UseGuards,
   UseInterceptors,
@@ -24,7 +23,6 @@ import {
 } from '@nestjs/swagger';
 
 import { TokenAuthGuard } from '../../../auth/token.strategy';
-import { NotInDBError } from '../../../errors/errors';
 import { HistoryEntryUpdateDto } from '../../../history/history-entry-update.dto';
 import { HistoryEntryDto } from '../../../history/history-entry.dto';
 import { HistoryService } from '../../../history/history.service';

--- a/src/api/public/media/media.controller.ts
+++ b/src/api/public/media/media.controller.ts
@@ -16,12 +16,15 @@ import {
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
+  ApiBadRequestResponse,
   ApiBody,
   ApiConsumes,
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiHeader,
+  ApiInternalServerErrorResponse,
   ApiNoContentResponse,
+  ApiNotFoundResponse,
   ApiSecurity,
   ApiTags,
   ApiUnauthorizedResponse,
@@ -37,7 +40,10 @@ import { Note } from '../../../notes/note.entity';
 import { NotesService } from '../../../notes/notes.service';
 import { User } from '../../../users/user.entity';
 import {
+  badRequestDescription,
   forbiddenDescription,
+  internalServerErrorDescription,
+  notFoundDescription,
   successfullyDeletedDescription,
   unauthorizedDescription,
 } from '../../utils/descriptions';
@@ -78,8 +84,13 @@ export class MediaController {
     description: 'The file was uploaded successfully',
     type: MediaUploadUrlDto,
   })
+  @ApiBadRequestResponse({ description: badRequestDescription })
   @ApiUnauthorizedResponse({ description: unauthorizedDescription })
   @ApiForbiddenResponse({ description: forbiddenDescription })
+  @ApiNotFoundResponse({ description: notFoundDescription })
+  @ApiInternalServerErrorResponse({
+    description: internalServerErrorDescription,
+  })
   @UseInterceptors(FileInterceptor('file'))
   @HttpCode(201)
   async uploadMedia(
@@ -100,6 +111,9 @@ export class MediaController {
   @Delete(':filename')
   @HttpCode(204)
   @ApiNoContentResponse({ description: successfullyDeletedDescription })
+  @ApiInternalServerErrorResponse({
+    description: internalServerErrorDescription,
+  })
   @FullApi
   async deleteMedia(
     @RequestUser() user: User,

--- a/src/api/public/monitoring/monitoring.controller.ts
+++ b/src/api/public/monitoring/monitoring.controller.ts
@@ -21,13 +21,13 @@ import {
   unauthorizedDescription,
 } from '../../utils/descriptions';
 
+@UseGuards(TokenAuthGuard)
 @ApiTags('monitoring')
 @ApiSecurity('token')
 @Controller('monitoring')
 export class MonitoringController {
   constructor(private monitoringService: MonitoringService) {}
 
-  @UseGuards(TokenAuthGuard)
   @Get()
   @ApiOkResponse({
     description: 'The server info',
@@ -40,7 +40,6 @@ export class MonitoringController {
     return this.monitoringService.getServerStatus();
   }
 
-  @UseGuards(TokenAuthGuard)
   @Get('prometheus')
   @ApiOkResponse({
     description: 'Prometheus compatible monitoring data',

--- a/src/api/public/notes/notes.controller.ts
+++ b/src/api/public/notes/notes.controller.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import {
-  BadRequestException,
   Body,
   Controller,
   Delete,

--- a/src/api/public/notes/notes.controller.ts
+++ b/src/api/public/notes/notes.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -17,8 +17,11 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
+  ApiConflictResponse,
   ApiCreatedResponse,
   ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
   ApiNoContentResponse,
   ApiOkResponse,
   ApiProduces,
@@ -48,7 +51,10 @@ import { RevisionDto } from '../../../revisions/revision.dto';
 import { RevisionsService } from '../../../revisions/revisions.service';
 import { User } from '../../../users/user.entity';
 import {
+  badRequestDescription,
+  conflictDescription,
   forbiddenDescription,
+  internalServerErrorDescription,
   successfullyDeletedDescription,
   unauthorizedDescription,
 } from '../../utils/descriptions';
@@ -115,6 +121,8 @@ export class NotesController {
     description: 'Get information about the newly created note',
     type: NoteDto,
   })
+  @ApiBadRequestResponse({ description: badRequestDescription })
+  @ApiConflictResponse({ description: conflictDescription })
   @ApiUnauthorizedResponse({ description: unauthorizedDescription })
   @ApiForbiddenResponse({ description: forbiddenDescription })
   async createNamedNote(
@@ -135,6 +143,9 @@ export class NotesController {
   @HttpCode(204)
   @ApiNoContentResponse({ description: successfullyDeletedDescription })
   @FullApi
+  @ApiInternalServerErrorResponse({
+    description: internalServerErrorDescription,
+  })
   async deleteNote(
     @RequestUser() user: User,
     @RequestNote() note: Note,

--- a/src/api/utils/descriptions.ts
+++ b/src/api/utils/descriptions.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+export const badRequestDescription =
+  "The request is malformed and can't be processed";
 export const unauthorizedDescription =
   'Authorization information is missing or invalid';
 export const forbiddenDescription =
@@ -11,3 +13,9 @@ export const forbiddenDescription =
 export const notFoundDescription = 'The requested resource was not found';
 export const successfullyDeletedDescription =
   'The requested resource was sucessfully deleted';
+export const unprocessableEntityDescription =
+  "The request change can't be processed";
+export const conflictDescription =
+  'The request conflicts with the current state of the application';
+export const internalServerErrorDescription =
+  'The request triggered an internal server error.';

--- a/src/api/utils/get-note.interceptor.ts
+++ b/src/api/utils/get-note.interceptor.ts
@@ -4,17 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import {
-  BadRequestException,
   CallHandler,
   ExecutionContext,
   Injectable,
   NestInterceptor,
-  NotFoundException,
 } from '@nestjs/common';
 import { Request } from 'express';
 import { Observable } from 'rxjs';
 
-import { ForbiddenIdError, NotInDBError } from '../../errors/errors';
 import { Note } from '../../notes/note.entity';
 import { NotesService } from '../../notes/notes.service';
 import { User } from '../../users/user.entity';
@@ -44,17 +41,5 @@ export async function getNote(
   noteService: NotesService,
   noteIdOrAlias: string,
 ): Promise<Note> {
-  let note: Note;
-  try {
-    note = await noteService.getNoteByIdOrAlias(noteIdOrAlias);
-  } catch (e) {
-    if (e instanceof NotInDBError) {
-      throw new NotFoundException(e.message);
-    }
-    if (e instanceof ForbiddenIdError) {
-      throw new BadRequestException(e.message);
-    }
-    throw e;
-  }
-  return note;
+  return await noteService.getNoteByIdOrAlias(noteIdOrAlias);
 }

--- a/src/errors/error-mapping.ts
+++ b/src/errors/error-mapping.ts
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import {
+  ArgumentsHost,
+  BadRequestException,
+  ConflictException,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { HttpException } from '@nestjs/common/exceptions/http.exception';
+import { BaseExceptionFilter } from '@nestjs/core';
+
+import {
+  buildHttpExceptionObject,
+  HttpExceptionObject,
+} from './http-exception-object';
+
+type HttpExceptionConstructor = (object: HttpExceptionObject) => HttpException;
+
+const mapOfHedgeDocErrorsToHttpErrors: Map<string, HttpExceptionConstructor> =
+  new Map([
+    ['NotInDBError', (object): HttpException => new NotFoundException(object)],
+    [
+      'AlreadyInDBError',
+      (object): HttpException => new ConflictException(object),
+    ],
+    [
+      'ForbiddenIdError',
+      (object): HttpException => new BadRequestException(object),
+    ],
+    ['ClientError', (object): HttpException => new BadRequestException(object)],
+    [
+      'PermissionError',
+      (object): HttpException => new UnauthorizedException(object),
+    ],
+    [
+      'TokenNotValidError',
+      (object): HttpException => new UnauthorizedException(object),
+    ],
+    [
+      'TooManyTokensError',
+      (object): HttpException => new BadRequestException(object),
+    ],
+    [
+      'PermissionsUpdateInconsistentError',
+      (object): HttpException => new BadRequestException(object),
+    ],
+    [
+      'MediaBackendError',
+      (object): HttpException => new InternalServerErrorException(object),
+    ],
+    [
+      'PrimaryAliasDeletionForbiddenError',
+      (object): HttpException => new BadRequestException(object),
+    ],
+    [
+      'InvalidCredentialsError',
+      (object): HttpException => new UnauthorizedException(object),
+    ],
+    [
+      'NoLocalIdentityError',
+      (object): HttpException => new BadRequestException(object),
+    ],
+  ]);
+
+export class ErrorExceptionMapping extends BaseExceptionFilter<Error> {
+  catch(error: Error, host: ArgumentsHost): void {
+    super.catch(ErrorExceptionMapping.transformError(error), host);
+  }
+
+  private static transformError(error: Error): Error {
+    const httpExceptionConstructor = mapOfHedgeDocErrorsToHttpErrors.get(
+      error.name,
+    );
+    if (httpExceptionConstructor === undefined) {
+      // We don't know how to map this error and just leave it be
+      return error;
+    }
+    const httpExceptionObject = buildHttpExceptionObject(
+      error.name,
+      error.message,
+    );
+    return httpExceptionConstructor(httpExceptionObject);
+  }
+}

--- a/src/errors/http-exception-object.ts
+++ b/src/errors/http-exception-object.ts
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export interface HttpExceptionObject {
+  name: string;
+  message: string;
+}
+
+export function buildHttpExceptionObject(
+  name: string,
+  message: string,
+): HttpExceptionObject {
+  return {
+    name: name,
+    message: message,
+  };
+}

--- a/src/identity/identity.service.ts
+++ b/src/identity/identity.service.ts
@@ -85,14 +85,14 @@ export class IdentityService {
         `The user with the username ${user.username} does not have a internal identity.`,
         'checkLocalPassword',
       );
-      throw new NoLocalIdentityError();
+      throw new NoLocalIdentityError('This user has no internal identity.');
     }
     if (!(await checkPassword(password, internalIdentity.passwordHash ?? ''))) {
       this.logger.debug(
         `Password check for ${user.username} did not succeed.`,
         'checkLocalPassword',
       );
-      throw new InvalidCredentialsError();
+      throw new InvalidCredentialsError('Password is not correct');
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { AppModule } from './app.module';
 import { AppConfig } from './config/app.config';
 import { AuthConfig } from './config/auth.config';
 import { MediaConfig } from './config/media.config';
+import { ErrorExceptionMapping } from './errors/error-mapping';
 import { ConsoleLoggerService } from './logger/console-logger.service';
 import { BackendType } from './media/backends/backend-type.enum';
 import { setupSpecialGroups } from './utils/createSpecialGroups';
@@ -78,6 +79,7 @@ async function bootstrap(): Promise<void> {
   app.useStaticAssets('public', {
     prefix: '/public/',
   });
+  app.useGlobalFilters(new ErrorExceptionMapping());
   await app.listen(appConfig.port);
   logger.log(`Listening on port ${appConfig.port}`, 'AppBootstrap');
 }

--- a/src/notes/alias.service.ts
+++ b/src/notes/alias.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -36,6 +36,7 @@ export class AliasService {
    * @param {Note} note - the note to add the alias to
    * @param {string} alias - the alias to add to the note
    * @throws {AlreadyInDBError} the alias is already in use.
+   * @throws {ForbiddenIdError} the requested id or alias is forbidden
    * @return {Alias} the new alias
    */
   async addAlias(note: Note, alias: string): Promise<Alias> {
@@ -79,6 +80,7 @@ export class AliasService {
    * Set the specified alias as the primary alias of the note.
    * @param {Note} note - the note to change the primary alias
    * @param {string} alias - the alias to be the new primary alias of the note
+   * @throws {ForbiddenIdError} the requested id or alias is forbidden
    * @throws {NotInDBError} the alias is not part of this note.
    * @return {Alias} the new primary alias
    */
@@ -86,6 +88,8 @@ export class AliasService {
     let newPrimaryFound = false;
     let oldPrimaryId = '';
     let newPrimaryId = '';
+
+    this.notesService.checkNoteIdOrAlias(alias);
 
     for (const anAlias of await note.aliases) {
       // found old primary
@@ -130,10 +134,12 @@ export class AliasService {
    * Remove the specified alias from the note.
    * @param {Note} note - the note to remove the alias from
    * @param {string} alias - the alias to remove from the note
+   * @throws {ForbiddenIdError} the requested id or alias is forbidden
    * @throws {NotInDBError} the alias is not part of this note.
    * @throws {PrimaryAliasDeletionForbiddenError} the primary alias can only be deleted if it's the only alias
    */
   async removeAlias(note: Note, alias: string): Promise<Note> {
+    this.notesService.checkNoteIdOrAlias(alias);
     const primaryAlias = await getPrimaryAlias(note);
 
     if (primaryAlias === alias && (await note.aliases).length !== 1) {

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -321,7 +321,7 @@ describe('NotesService', () => {
       it('id is forbidden', async () => {
         await expect(
           service.getNoteByIdOrAlias(forbiddenNoteId),
-        ).rejects.toThrow(ForbiddenIdError);
+        ).rejects.toThrow(NotInDBError);
       });
     });
   });

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -321,7 +321,7 @@ describe('NotesService', () => {
       it('id is forbidden', async () => {
         await expect(
           service.getNoteByIdOrAlias(forbiddenNoteId),
-        ).rejects.toThrow(NotInDBError);
+        ).rejects.toThrow(ForbiddenIdError);
       });
     });
   });

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -156,7 +156,6 @@ export class NotesService {
    * Get a note by either their id or alias.
    * @param {string} noteIdOrAlias - the notes id or alias
    * @return {Note} the note
-   * @throws {ForbiddenIdError} the requested id or alias is forbidden
    * @throws {NotInDBError} there is no note with this id or alias
    */
   async getNoteByIdOrAlias(noteIdOrAlias: string): Promise<Note> {
@@ -164,7 +163,14 @@ export class NotesService {
       `Trying to find note '${noteIdOrAlias}'`,
       'getNoteByIdOrAlias',
     );
-    this.checkNoteIdOrAlias(noteIdOrAlias);
+    try {
+      this.checkNoteIdOrAlias(noteIdOrAlias);
+    } catch (e) {
+      if (e instanceof ForbiddenIdError) {
+        throw new NotInDBError(e.message);
+      }
+      throw e;
+    }
 
     /**
      * This query gets the note's aliases, owner, groupPermissions (and the groups), userPermissions (and the users) and tags and

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -157,20 +157,15 @@ export class NotesService {
    * @param {string} noteIdOrAlias - the notes id or alias
    * @return {Note} the note
    * @throws {NotInDBError} there is no note with this id or alias
+   * @throws {ForbiddenIdError} the requested id or alias is forbidden
    */
   async getNoteByIdOrAlias(noteIdOrAlias: string): Promise<Note> {
     this.logger.debug(
       `Trying to find note '${noteIdOrAlias}'`,
       'getNoteByIdOrAlias',
     );
-    try {
-      this.checkNoteIdOrAlias(noteIdOrAlias);
-    } catch (e) {
-      if (e instanceof ForbiddenIdError) {
-        throw new NotInDBError(e.message);
-      }
-      throw e;
-    }
+
+    this.checkNoteIdOrAlias(noteIdOrAlias);
 
     /**
      * This query gets the note's aliases, owner, groupPermissions (and the groups), userPermissions (and the users) and tags and

--- a/test/private-api/alias.e2e-spec.ts
+++ b/test/private-api/alias.e2e-spec.ts
@@ -96,7 +96,7 @@ describe('Alias', () => {
           .post(`/api/private/alias`)
           .set('Content-Type', 'application/json')
           .send(newAliasDto)
-          .expect(400);
+          .expect(409);
       });
       it('because the user is not an owner', async () => {
         newAliasDto.newAlias = publicId;

--- a/test/private-api/history.e2e-spec.ts
+++ b/test/private-api/history.e2e-spec.ts
@@ -156,7 +156,7 @@ describe('History', () => {
           .post('/api/private/me/history')
           .set('Content-Type', 'application/json')
           .send(JSON.stringify({ history: [brokenEntryDto] }))
-          .expect(400);
+          .expect(404);
       });
       afterEach(async () => {
         const historyEntries = await testSetup.historyService.getEntriesByUser(

--- a/test/private-api/media.e2e-spec.ts
+++ b/test/private-api/media.e2e-spec.ts
@@ -87,7 +87,7 @@ describe('Media', () => {
           .post('/api/private/media')
           .attach('file', 'test/private-api/fixtures/test.zip')
           .set('HedgeDoc-Note', 'i_dont_exist')
-          .expect(400);
+          .expect(404);
         await expect(fs.access(uploadPath)).rejects.toBeDefined();
       });
       it('mediaBackend error', async () => {

--- a/test/private-api/notes.e2e-spec.ts
+++ b/test/private-api/notes.e2e-spec.ts
@@ -123,7 +123,7 @@ describe('Notes', () => {
         .set('Content-Type', 'text/markdown')
         .send(content)
         .expect('Content-Type', /json/)
-        .expect(400);
+        .expect(409);
     });
   });
 

--- a/test/public-api/alias.e2e-spec.ts
+++ b/test/public-api/alias.e2e-spec.ts
@@ -66,7 +66,7 @@ describe('Alias', () => {
             noteIdOrAlias: testAlias,
             newAlias: 'testAlias1',
           })
-          .expect(400);
+          .expect(409);
       });
       it('because of a forbidden alias', async () => {
         await request(testSetup.app.getHttpServer())
@@ -88,7 +88,7 @@ describe('Alias', () => {
             noteIdOrAlias: testAlias,
             newAlias: publicId,
           })
-          .expect(400);
+          .expect(409);
       });
       it('because the user is not an owner', async () => {
         await request(testSetup.app.getHttpServer())
@@ -217,7 +217,6 @@ describe('Alias', () => {
         .delete(`/api/v2/alias/${testAlias}`)
         .set('Authorization', `Bearer ${testSetup.authTokens[0].secret}`)
         .expect(400);
-
       await request(testSetup.app.getHttpServer())
         .get(`/api/v2/notes/${secondAlias}`)
         .set('Authorization', `Bearer ${testSetup.authTokens[0].secret}`)

--- a/test/public-api/media.e2e-spec.ts
+++ b/test/public-api/media.e2e-spec.ts
@@ -79,7 +79,7 @@ describe('Media', () => {
           .post('/api/v2/media')
           .attach('file', 'test/public-api/fixtures/test.zip')
           .set('HedgeDoc-Note', 'i_dont_exist')
-          .expect(400);
+          .expect(404);
         await expect(fs.access(uploadPath)).rejects.toBeDefined();
       });
       it('mediaBackend error', async () => {

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -117,7 +117,7 @@ describe('Notes', () => {
         .set('Content-Type', 'text/markdown')
         .send(content)
         .expect('Content-Type', /json/)
-        .expect(400);
+        .expect(409);
     });
   });
 

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -24,6 +24,7 @@ import customizationConfigMock from '../src/config/mock/customization.config.moc
 import externalServicesConfigMock from '../src/config/mock/external-services.config.mock';
 import mediaConfigMock from '../src/config/mock/media.config.mock';
 import noteConfigMock from '../src/config/mock/note.config.mock';
+import { ErrorExceptionMapping } from '../src/errors/error-mapping';
 import { FrontendConfigModule } from '../src/frontend-config/frontend-config.module';
 import { GroupsModule } from '../src/groups/groups.module';
 import { HistoryModule } from '../src/history/history.module';
@@ -128,6 +129,12 @@ export class TestSetupBuilder {
         AuthModule,
         FrontendConfigModule,
         IdentityModule,
+      ],
+      providers: [
+        {
+          provide: 'APP_FILTER',
+          useClass: ErrorExceptionMapping,
+        },
       ],
     });
     return testSetupBuilder;


### PR DESCRIPTION
### Component/Part
public and private api

### Description
This PR adds an error mapping from internal HedgeDoc Error to HttpExceptions. While doing this I noticed that some error codes are not documented in the openapi docs and added the appropriate annotations. 

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

Fixes #1983
Fixes #1640