### PR TITLE
CI: Do not allow ESLint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,11 +18,16 @@ module.exports = {
         '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/require-await': 'off',
+        '@typescript-eslint/explicit-function-return-type': 'off',
         'jest/unbound-method': 'error',
         'jest/expect-expect': [
           'error',
           {
-            assertFunctionNames: ['expect', 'request.**.expect', 'agent.**.expect'],
+            assertFunctionNames: [
+              'expect',
+              'request.**.expect',
+              'agent.**.expect',
+            ],
           },
         ],
         'jest/no-standalone-expect': [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start:dev": "rimraf dist && nest start --watch",
     "start:debug": "rimraf dist && nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
+    "lint": "eslint --max-warnings 0 \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/history/history.service.spec.ts
+++ b/src/history/history.service.spec.ts
@@ -35,7 +35,6 @@ describe('HistoryService', () => {
   let historyRepo: Repository<HistoryEntry>;
   let connection;
   let noteRepo: Repository<Note>;
-  let aliasRepo: Repository<Alias>;
 
   type MockConnection = {
     transaction: () => void;
@@ -102,7 +101,6 @@ describe('HistoryService', () => {
     historyRepo = module.get<Repository<HistoryEntry>>(
       getRepositoryToken(HistoryEntry),
     );
-    aliasRepo = module.get<Repository<Alias>>(getRepositoryToken(Alias));
     connection = module.get<Connection>(Connection);
     noteRepo = module.get<Repository<Note>>(getRepositoryToken(Note));
   });

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -27,7 +27,6 @@ import { HistoryModule } from '../src/history/history.module';
 import { HistoryService } from '../src/history/history.service';
 import { IdentityModule } from '../src/identity/identity.module';
 import { IdentityService } from '../src/identity/identity.service';
-import { ConsoleLoggerService } from '../src/logger/console-logger.service';
 import { LoggerModule } from '../src/logger/logger.module';
 import { MediaModule } from '../src/media/media.module';
 import { MediaService } from '../src/media/media.service';
@@ -40,7 +39,6 @@ import { RevisionsModule } from '../src/revisions/revisions.module';
 import { UsersModule } from '../src/users/users.module';
 import { UsersService } from '../src/users/users.service';
 import { setupSessionMiddleware } from '../src/utils/session';
-import { setupValidationPipe } from '../src/utils/setup-pipes';
 
 export class TestSetup {
   moduleRef: TestingModule;


### PR DESCRIPTION
### Component/Part
CI, code style

### Description
This PR enables ESLint's "strict mode", which fails CI if ESLint returns warnings.
It also fixes the remaining style-issues that caused warnings.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
