### PR TITLE
Refactor/note config

### DIFF
--- a/src/api/private/alias/alias.controller.spec.ts
+++ b/src/api/private/alias/alias.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,6 +15,7 @@ import { AuthToken } from '../../../auth/auth-token.entity';
 import { Author } from '../../../authors/author.entity';
 import appConfigMock from '../../../config/mock/app.config.mock';
 import mediaConfigMock from '../../../config/mock/media.config.mock';
+import noteConfigMock from '../../../config/mock/note.config.mock';
 import { Group } from '../../../groups/group.entity';
 import { GroupsModule } from '../../../groups/groups.module';
 import { HistoryEntry } from '../../../history/history-entry.entity';
@@ -75,7 +76,7 @@ describe('AliasController', () => {
         MediaModule,
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock, mediaConfigMock],
+          load: [appConfigMock, noteConfigMock, mediaConfigMock],
         }),
         TypeOrmModule.forRoot(),
       ],

--- a/src/api/private/config/config.controller.spec.ts
+++ b/src/api/private/config/config.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -10,6 +10,7 @@ import appConfigMock from '../../../config/mock/app.config.mock';
 import authConfigMock from '../../../config/mock/auth.config.mock';
 import customizationConfigMock from '../../../config/mock/customization.config.mock';
 import externalConfigMock from '../../../config/mock/external-services.config.mock';
+import noteConfigMock from '../../../config/mock/note.config.mock';
 import { FrontendConfigModule } from '../../../frontend-config/frontend-config.module';
 import { LoggerModule } from '../../../logger/logger.module';
 import { ConfigController } from './config.controller';
@@ -24,6 +25,7 @@ describe('ConfigController', () => {
           isGlobal: true,
           load: [
             appConfigMock,
+            noteConfigMock,
             authConfigMock,
             customizationConfigMock,
             externalConfigMock,

--- a/src/api/private/me/history/history.controller.spec.ts
+++ b/src/api/private/me/history/history.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -14,6 +14,7 @@ import {
 import { AuthToken } from '../../../../auth/auth-token.entity';
 import { Author } from '../../../../authors/author.entity';
 import appConfigMock from '../../../../config/mock/app.config.mock';
+import noteConfigMock from '../../../../config/mock/note.config.mock';
 import { Group } from '../../../../groups/group.entity';
 import { HistoryEntry } from '../../../../history/history-entry.entity';
 import { HistoryModule } from '../../../../history/history.module';
@@ -45,7 +46,7 @@ describe('HistoryController', () => {
         LoggerModule,
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock],
+          load: [appConfigMock, noteConfigMock],
         }),
         TypeOrmModule.forRoot(),
       ],

--- a/src/api/private/me/me.controller.spec.ts
+++ b/src/api/private/me/me.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -13,6 +13,7 @@ import authConfigMock from '../../../config/mock/auth.config.mock';
 import customizationConfigMock from '../../../config/mock/customization.config.mock';
 import externalServicesConfigMock from '../../../config/mock/external-services.config.mock';
 import mediaConfigMock from '../../../config/mock/media.config.mock';
+import noteConfigMock from '../../../config/mock/note.config.mock';
 import { Group } from '../../../groups/group.entity';
 import { Identity } from '../../../identity/identity.entity';
 import { LoggerModule } from '../../../logger/logger.module';
@@ -44,6 +45,7 @@ describe('MeController', () => {
           isGlobal: true,
           load: [
             appConfigMock,
+            noteConfigMock,
             authConfigMock,
             mediaConfigMock,
             customizationConfigMock,

--- a/src/api/private/media/media.controller.spec.ts
+++ b/src/api/private/media/media.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -14,6 +14,7 @@ import authConfigMock from '../../../config/mock/auth.config.mock';
 import customizationConfigMock from '../../../config/mock/customization.config.mock';
 import externalConfigMock from '../../../config/mock/external-services.config.mock';
 import mediaConfigMock from '../../../config/mock/media.config.mock';
+import noteConfigMock from '../../../config/mock/note.config.mock';
 import { Group } from '../../../groups/group.entity';
 import { Identity } from '../../../identity/identity.entity';
 import { LoggerModule } from '../../../logger/logger.module';
@@ -45,6 +46,7 @@ describe('MediaController', () => {
           isGlobal: true,
           load: [
             appConfigMock,
+            noteConfigMock,
             mediaConfigMock,
             authConfigMock,
             customizationConfigMock,

--- a/src/api/private/notes/notes.controller.spec.ts
+++ b/src/api/private/notes/notes.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,6 +15,7 @@ import { AuthToken } from '../../../auth/auth-token.entity';
 import { Author } from '../../../authors/author.entity';
 import appConfigMock from '../../../config/mock/app.config.mock';
 import mediaConfigMock from '../../../config/mock/media.config.mock';
+import noteConfigMock from '../../../config/mock/note.config.mock';
 import { Group } from '../../../groups/group.entity';
 import { GroupsModule } from '../../../groups/groups.module';
 import { HistoryEntry } from '../../../history/history-entry.entity';
@@ -73,7 +74,7 @@ describe('NotesController', () => {
         MediaModule,
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock, mediaConfigMock],
+          load: [appConfigMock, noteConfigMock, mediaConfigMock],
         }),
         TypeOrmModule.forRoot(),
       ],

--- a/src/api/public/alias/alias.controller.spec.ts
+++ b/src/api/public/alias/alias.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,6 +15,7 @@ import { AuthToken } from '../../../auth/auth-token.entity';
 import { Author } from '../../../authors/author.entity';
 import appConfigMock from '../../../config/mock/app.config.mock';
 import mediaConfigMock from '../../../config/mock/media.config.mock';
+import noteConfigMock from '../../../config/mock/note.config.mock';
 import { Group } from '../../../groups/group.entity';
 import { GroupsModule } from '../../../groups/groups.module';
 import { HistoryEntry } from '../../../history/history-entry.entity';
@@ -75,7 +76,7 @@ describe('AliasController', () => {
         MediaModule,
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock, mediaConfigMock],
+          load: [appConfigMock, noteConfigMock, mediaConfigMock],
         }),
         TypeOrmModule.forRoot(),
       ],

--- a/src/api/public/me/me.controller.spec.ts
+++ b/src/api/public/me/me.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,6 +15,7 @@ import { AuthToken } from '../../../auth/auth-token.entity';
 import { Author } from '../../../authors/author.entity';
 import appConfigMock from '../../../config/mock/app.config.mock';
 import mediaConfigMock from '../../../config/mock/media.config.mock';
+import noteConfigMock from '../../../config/mock/note.config.mock';
 import { Group } from '../../../groups/group.entity';
 import { HistoryEntry } from '../../../history/history-entry.entity';
 import { HistoryModule } from '../../../history/history.module';
@@ -44,7 +45,7 @@ describe('Me Controller', () => {
       imports: [
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock, mediaConfigMock],
+          load: [appConfigMock, noteConfigMock, mediaConfigMock],
         }),
         UsersModule,
         HistoryModule,

--- a/src/api/public/media/media.controller.spec.ts
+++ b/src/api/public/media/media.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -11,6 +11,7 @@ import { AuthToken } from '../../../auth/auth-token.entity';
 import { Author } from '../../../authors/author.entity';
 import appConfigMock from '../../../config/mock/app.config.mock';
 import mediaConfigMock from '../../../config/mock/media.config.mock';
+import noteConfigMock from '../../../config/mock/note.config.mock';
 import { Group } from '../../../groups/group.entity';
 import { Identity } from '../../../identity/identity.entity';
 import { LoggerModule } from '../../../logger/logger.module';
@@ -37,7 +38,7 @@ describe('Media Controller', () => {
       imports: [
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock, mediaConfigMock],
+          load: [appConfigMock, noteConfigMock, mediaConfigMock],
         }),
         LoggerModule,
         MediaModule,

--- a/src/api/public/notes/notes.controller.spec.ts
+++ b/src/api/public/notes/notes.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,6 +15,7 @@ import { AuthToken } from '../../../auth/auth-token.entity';
 import { Author } from '../../../authors/author.entity';
 import appConfigMock from '../../../config/mock/app.config.mock';
 import mediaConfigMock from '../../../config/mock/media.config.mock';
+import noteConfigMock from '../../../config/mock/note.config.mock';
 import { Group } from '../../../groups/group.entity';
 import { GroupsModule } from '../../../groups/groups.module';
 import { HistoryEntry } from '../../../history/history-entry.entity';
@@ -73,7 +74,7 @@ describe('Notes Controller', () => {
         MediaModule,
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock, mediaConfigMock],
+          load: [appConfigMock, noteConfigMock, mediaConfigMock],
         }),
         TypeOrmModule.forRoot(),
       ],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -21,6 +21,7 @@ import databaseConfig from './config/database.config';
 import externalConfig from './config/external-services.config';
 import hstsConfig from './config/hsts.config';
 import mediaConfig from './config/media.config';
+import noteConfig from './config/note.config';
 import { FrontendConfigModule } from './frontend-config/frontend-config.module';
 import { FrontendConfigService } from './frontend-config/frontend-config.service';
 import { GroupsModule } from './groups/groups.module';
@@ -57,6 +58,7 @@ const routes: Routes = [
     ConfigModule.forRoot({
       load: [
         appConfig,
+        noteConfig,
         mediaConfig,
         hstsConfig,
         cspConfig,

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -7,15 +7,13 @@ import { registerAs } from '@nestjs/config';
 import * as Joi from 'joi';
 
 import { Loglevel } from './loglevel.enum';
-import { buildErrorMessage, parseOptionalInt, toArrayConfig } from './utils';
+import { buildErrorMessage, parseOptionalInt } from './utils';
 
 export interface AppConfig {
   domain: string;
   rendererOrigin: string;
   port: number;
   loglevel: Loglevel;
-  forbiddenNoteIds: string[];
-  maxDocumentLength: number;
 }
 
 const schema = Joi.object({
@@ -30,15 +28,6 @@ const schema = Joi.object({
     .default(Loglevel.WARN)
     .optional()
     .label('HD_LOGLEVEL'),
-  forbiddenNoteIds: Joi.array()
-    .items(Joi.string())
-    .optional()
-    .default([])
-    .label('HD_FORBIDDEN_NOTE_IDS'),
-  maxDocumentLength: Joi.number()
-    .default(100000)
-    .optional()
-    .label('HD_MAX_DOCUMENT_LENGTH'),
 });
 
 export default registerAs('appConfig', () => {
@@ -48,8 +37,6 @@ export default registerAs('appConfig', () => {
       rendererOrigin: process.env.HD_RENDERER_ORIGIN,
       port: parseOptionalInt(process.env.PORT),
       loglevel: process.env.HD_LOGLEVEL,
-      forbiddenNoteIds: toArrayConfig(process.env.HD_FORBIDDEN_NOTE_IDS, ','),
-      maxDocumentLength: parseOptionalInt(process.env.HD_MAX_DOCUMENT_LENGTH),
     },
     {
       abortEarly: false,

--- a/src/config/media.config.ts
+++ b/src/config/media.config.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -10,29 +10,31 @@ import { BackendType } from '../media/backends/backend-type.enum';
 import { buildErrorMessage } from './utils';
 
 export interface MediaConfig {
-  backend: {
-    use: BackendType;
-    filesystem: {
-      uploadPath: string;
-    };
-    s3: {
-      accessKeyId: string;
-      secretAccessKey: string;
-      bucket: string;
-      endPoint: string;
-    };
-    azure: {
-      connectionString: string;
-      container: string;
-    };
-    imgur: {
-      clientID: string;
-    };
-    webdav: {
-      connectionString: string;
-      uploadDir: string;
-      publicUrl: string;
-    };
+  backend: MediaBackendConfig;
+}
+
+export interface MediaBackendConfig {
+  use: BackendType;
+  filesystem: {
+    uploadPath: string;
+  };
+  s3: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    bucket: string;
+    endPoint: string;
+  };
+  azure: {
+    connectionString: string;
+    container: string;
+  };
+  imgur: {
+    clientID: string;
+  };
+  webdav: {
+    connectionString: string;
+    uploadDir: string;
+    publicUrl: string;
   };
 }
 

--- a/src/config/mock/app.config.mock.ts
+++ b/src/config/mock/app.config.mock.ts
@@ -1,17 +1,19 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { registerAs } from '@nestjs/config';
 
+import { AppConfig } from '../app.config';
 import { Loglevel } from '../loglevel.enum';
 
-export default registerAs('appConfig', () => ({
-  domain: 'md.example.com',
-  rendererOrigin: 'md-renderer.example.com',
-  port: 3000,
-  loglevel: Loglevel.ERROR,
-  maxDocumentLength: 100000,
-  forbiddenNoteIds: ['forbiddenNoteId'],
-}));
+export default registerAs(
+  'appConfig',
+  (): AppConfig => ({
+    domain: 'md.example.com',
+    rendererOrigin: 'md-renderer.example.com',
+    port: 3000,
+    loglevel: Loglevel.ERROR,
+  }),
+);

--- a/src/config/mock/auth.config.mock.ts
+++ b/src/config/mock/auth.config.mock.ts
@@ -1,43 +1,48 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { registerAs } from '@nestjs/config';
 
-export default registerAs('authConfig', () => ({
-  session: {
-    secret: 'my_secret',
-    lifetime: 1209600000,
-  },
-  local: {
-    enableLogin: true,
-    enableRegister: true,
-  },
-  facebook: {
-    clientID: undefined,
-    clientSecret: undefined,
-  },
-  twitter: {
-    consumerKey: undefined,
-    consumerSecret: undefined,
-  },
-  github: {
-    clientID: undefined,
-    clientSecret: undefined,
-  },
-  dropbox: {
-    clientID: undefined,
-    clientSecret: undefined,
-    appKey: undefined,
-  },
-  google: {
-    clientID: undefined,
-    clientSecret: undefined,
-    apiKey: undefined,
-  },
-  gitlab: [],
-  ldap: [],
-  saml: [],
-  oauth2: [],
-}));
+import { AuthConfig } from '../auth.config';
+
+export default registerAs(
+  'authConfig',
+  (): AuthConfig => ({
+    session: {
+      secret: 'my_secret',
+      lifetime: 1209600000,
+    },
+    local: {
+      enableLogin: true,
+      enableRegister: true,
+    },
+    facebook: {
+      clientID: '',
+      clientSecret: '',
+    },
+    twitter: {
+      consumerKey: '',
+      consumerSecret: '',
+    },
+    github: {
+      clientID: '',
+      clientSecret: '',
+    },
+    dropbox: {
+      clientID: '',
+      clientSecret: '',
+      appKey: '',
+    },
+    google: {
+      clientID: '',
+      clientSecret: '',
+      apiKey: '',
+    },
+    gitlab: [],
+    ldap: [],
+    saml: [],
+    oauth2: [],
+  }),
+);

--- a/src/config/mock/customization.config.mock.ts
+++ b/src/config/mock/customization.config.mock.ts
@@ -1,18 +1,23 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { registerAs } from '@nestjs/config';
 
-export default registerAs('customizationConfig', () => ({
-  branding: {
-    customName: 'ACME Corp',
-    customLogo: '',
-  },
-  specialUrls: {
-    privacy: '/test/privacy',
-    termsOfUse: '/test/termsOfUse',
-    imprint: '/test/imprint',
-  },
-}));
+import { CustomizationConfig } from '../customization.config';
+
+export default registerAs(
+  'customizationConfig',
+  (): CustomizationConfig => ({
+    branding: {
+      customName: 'ACME Corp',
+      customLogo: '',
+    },
+    specialUrls: {
+      privacy: '/test/privacy',
+      termsOfUse: '/test/termsOfUse',
+      imprint: '/test/imprint',
+    },
+  }),
+);

--- a/src/config/mock/external-services.config.mock.ts
+++ b/src/config/mock/external-services.config.mock.ts
@@ -1,11 +1,16 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { registerAs } from '@nestjs/config';
 
-export default registerAs('externalServicesConfig', () => ({
-  plantUmlServer: 'plantuml.example.com',
-  imageProxy: 'imageProxy.example.com',
-}));
+import { ExternalServicesConfig } from '../external-services.config';
+
+export default registerAs(
+  'externalServicesConfig',
+  (): ExternalServicesConfig => ({
+    plantUmlServer: 'plantuml.example.com',
+    imageProxy: 'imageProxy.example.com',
+  }),
+);

--- a/src/config/mock/media.config.mock.ts
+++ b/src/config/mock/media.config.mock.ts
@@ -1,16 +1,24 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { registerAs } from '@nestjs/config';
 
-export default registerAs('mediaConfig', () => ({
-  backend: {
-    use: 'filesystem',
-    filesystem: {
-      uploadPath:
-        'test_uploads' + Math.floor(Math.random() * 100000).toString(),
+import { BackendType } from '../../media/backends/backend-type.enum';
+import { MediaBackendConfig, MediaConfig } from '../media.config';
+
+export default registerAs(
+  'mediaConfig',
+  (): Omit<MediaConfig, 'backend'> & {
+    backend: Pick<MediaBackendConfig, 'use' | 'filesystem'>;
+  } => ({
+    backend: {
+      use: BackendType.FILESYSTEM,
+      filesystem: {
+        uploadPath:
+          'test_uploads' + Math.floor(Math.random() * 100000).toString(),
+      },
     },
-  },
-}));
+  }),
+);

--- a/src/config/mock/note.config.mock.ts
+++ b/src/config/mock/note.config.mock.ts
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { registerAs } from '@nestjs/config';
+
+import { NoteConfig } from '../note.config';
+
+export default registerAs(
+  'noteConfig',
+  (): NoteConfig => ({
+    maxDocumentLength: 100000,
+    forbiddenNoteIds: ['forbiddenNoteId'],
+  }),
+);

--- a/src/config/note.config.ts
+++ b/src/config/note.config.ts
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { registerAs } from '@nestjs/config';
+import * as Joi from 'joi';
+
+import { buildErrorMessage, parseOptionalInt, toArrayConfig } from './utils';
+
+export interface NoteConfig {
+  forbiddenNoteIds: string[];
+  maxDocumentLength: number;
+}
+
+const schema = Joi.object({
+  forbiddenNoteIds: Joi.array()
+    .items(Joi.string())
+    .optional()
+    .default([])
+    .label('HD_FORBIDDEN_NOTE_IDS'),
+  maxDocumentLength: Joi.number()
+    .default(100000)
+    .optional()
+    .label('HD_MAX_DOCUMENT_LENGTH'),
+});
+
+export default registerAs('noteConfig', () => {
+  const noteConfig = schema.validate(
+    {
+      forbiddenNoteIds: toArrayConfig(process.env.HD_FORBIDDEN_NOTE_IDS, ','),
+      maxDocumentLength: parseOptionalInt(process.env.HD_MAX_DOCUMENT_LENGTH),
+    },
+    {
+      abortEarly: false,
+      presence: 'required',
+    },
+  );
+  if (noteConfig.error) {
+    const errorMessages = noteConfig.error.details.map(
+      (detail) => detail.message,
+    );
+    throw new Error(buildErrorMessage(errorMessages));
+  }
+  return noteConfig.value as NoteConfig;
+});

--- a/src/frontend-config/frontend-config.service.spec.ts
+++ b/src/frontend-config/frontend-config.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -13,6 +13,7 @@ import { CustomizationConfig } from '../config/customization.config';
 import { ExternalServicesConfig } from '../config/external-services.config';
 import { GitlabScope, GitlabVersion } from '../config/gitlab.enum';
 import { Loglevel } from '../config/loglevel.enum';
+import { NoteConfig } from '../config/note.config';
 import { LoggerModule } from '../logger/logger.module';
 import { getServerVersionFromPackageJson } from '../utils/serverVersion';
 import { AuthProviderType } from './frontend-config.dto';
@@ -194,8 +195,6 @@ describe('FrontendConfigService', () => {
                               rendererOrigin: renderOrigin ?? domain,
                               port: 3000,
                               loglevel: Loglevel.ERROR,
-                              forbiddenNoteIds: [],
-                              maxDocumentLength: maxDocumentLength,
                             };
                             const authConfig: AuthConfig = {
                               ...emptyAuthConfig,
@@ -221,6 +220,10 @@ describe('FrontendConfigService', () => {
                                 plantUmlServer: plantUmlServer,
                                 imageProxy: imageProxy,
                               };
+                            const noteConfig: NoteConfig = {
+                              forbiddenNoteIds: [],
+                              maxDocumentLength: maxDocumentLength,
+                            };
                             const module: TestingModule =
                               await Test.createTestingModule({
                                 imports: [
@@ -239,6 +242,10 @@ describe('FrontendConfigService', () => {
                                       registerAs(
                                         'externalServicesConfig',
                                         () => externalServicesConfig,
+                                      ),
+                                      registerAs(
+                                        'noteConfig',
+                                        () => noteConfig,
                                       ),
                                     ],
                                   }),

--- a/src/frontend-config/frontend-config.service.ts
+++ b/src/frontend-config/frontend-config.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -14,6 +14,7 @@ import customizationConfiguration, {
 import externalServicesConfiguration, {
   ExternalServicesConfig,
 } from '../config/external-services.config';
+import noteConfiguration, { NoteConfig } from '../config/note.config';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
 import { getServerVersionFromPackageJson } from '../utils/serverVersion';
 import {
@@ -31,6 +32,8 @@ export class FrontendConfigService {
     private readonly logger: ConsoleLoggerService,
     @Inject(appConfiguration.KEY)
     private appConfig: AppConfig,
+    @Inject(noteConfiguration.KEY)
+    private noteConfig: NoteConfig,
     @Inject(authConfiguration.KEY)
     private authConfig: AuthConfig,
     @Inject(customizationConfiguration.KEY)
@@ -49,7 +52,7 @@ export class FrontendConfigService {
       authProviders: this.getAuthProviders(),
       branding: this.getBranding(),
       iframeCommunication: this.getIframeCommunication(),
-      maxDocumentLength: this.appConfig.maxDocumentLength,
+      maxDocumentLength: this.noteConfig.maxDocumentLength,
       plantUmlServer: this.externalServicesConfig.plantUmlServer
         ? new URL(this.externalServicesConfig.plantUmlServer)
         : undefined,

--- a/src/history/history.service.spec.ts
+++ b/src/history/history.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -11,6 +11,7 @@ import { Connection, Repository } from 'typeorm';
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
 import appConfigMock from '../config/mock/app.config.mock';
+import noteConfigMock from '../config/mock/note.config.mock';
 import { NotInDBError } from '../errors/errors';
 import { Group } from '../groups/group.entity';
 import { Identity } from '../identity/identity.entity';
@@ -65,7 +66,7 @@ describe('HistoryService', () => {
         NotesModule,
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock],
+          load: [appConfigMock, noteConfigMock],
         }),
       ],
     })

--- a/src/media/media.service.spec.ts
+++ b/src/media/media.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -13,6 +13,7 @@ import appConfigMock from '../../src/config/mock/app.config.mock';
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
 import mediaConfigMock from '../config/mock/media.config.mock';
+import noteConfigMock from '../config/mock/note.config.mock';
 import { ClientError, NotInDBError } from '../errors/errors';
 import { Group } from '../groups/group.entity';
 import { Identity } from '../identity/identity.entity';
@@ -51,7 +52,7 @@ describe('MediaService', () => {
       imports: [
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [mediaConfigMock, appConfigMock],
+          load: [mediaConfigMock, appConfigMock, noteConfigMock],
         }),
         LoggerModule,
         NotesModule,

--- a/src/notes/alias.service.spec.ts
+++ b/src/notes/alias.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -11,6 +11,7 @@ import { Repository } from 'typeorm';
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
 import appConfigMock from '../config/mock/app.config.mock';
+import noteConfigMock from '../config/mock/note.config.mock';
 import {
   AlreadyInDBError,
   ForbiddenIdError,
@@ -65,7 +66,7 @@ describe('AliasService', () => {
       imports: [
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock],
+          load: [appConfigMock, noteConfigMock],
         }),
         LoggerModule,
         UsersModule,
@@ -102,7 +103,7 @@ describe('AliasService', () => {
       .compile();
 
     const config = module.get<ConfigService>(ConfigService);
-    forbiddenNoteId = config.get('appConfig').forbiddenNoteIds[0];
+    forbiddenNoteId = config.get('noteConfig').forbiddenNoteIds[0];
     service = module.get<AliasService>(AliasService);
     noteRepo = module.get<Repository<Note>>(getRepositoryToken(Note));
     aliasRepo = module.get<Repository<Alias>>(getRepositoryToken(Alias));

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -11,6 +11,7 @@ import { Repository } from 'typeorm';
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
 import appConfigMock from '../config/mock/app.config.mock';
+import noteConfigMock from '../config/mock/note.config.mock';
 import {
   AlreadyInDBError,
   ForbiddenIdError,
@@ -76,7 +77,7 @@ describe('NotesService', () => {
       imports: [
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock],
+          load: [appConfigMock, noteConfigMock],
         }),
         LoggerModule,
         UsersModule,
@@ -113,7 +114,7 @@ describe('NotesService', () => {
       .compile();
 
     const config = module.get<ConfigService>(ConfigService);
-    forbiddenNoteId = config.get('appConfig').forbiddenNoteIds[0];
+    forbiddenNoteId = config.get('noteConfig').forbiddenNoteIds[0];
     service = module.get<NotesService>(NotesService);
     noteRepo = module.get<Repository<Note>>(getRepositoryToken(Note));
     revisionRepo = module.get<Repository<Revision>>(

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -7,7 +7,7 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
-import appConfiguration, { AppConfig } from '../config/app.config';
+import noteConfiguration, { NoteConfig } from '../config/note.config';
 import {
   AlreadyInDBError,
   ForbiddenIdError,
@@ -47,8 +47,8 @@ export class NotesService {
     @Inject(GroupsService) private groupsService: GroupsService,
     @Inject(forwardRef(() => RevisionsService))
     private revisionsService: RevisionsService,
-    @Inject(appConfiguration.KEY)
-    private appConfig: AppConfig,
+    @Inject(noteConfiguration.KEY)
+    private noteConfig: NoteConfig,
   ) {
     this.logger.setContext(NotesService.name);
   }
@@ -227,7 +227,7 @@ export class NotesService {
    * @throws {ForbiddenIdError} the requested id or alias is forbidden
    */
   checkNoteIdOrAlias(noteIdOrAlias: string): void {
-    if (this.appConfig.forbiddenNoteIds.includes(noteIdOrAlias)) {
+    if (this.noteConfig.forbiddenNoteIds.includes(noteIdOrAlias)) {
       this.logger.debug(
         `A note with the alias '${noteIdOrAlias}' is forbidden by the administrator.`,
         'checkNoteIdOrAlias',

--- a/src/permissions/permissions.service.spec.ts
+++ b/src/permissions/permissions.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -10,6 +10,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
 import appConfigMock from '../config/mock/app.config.mock';
+import noteConfigMock from '../config/mock/note.config.mock';
 import { Group } from '../groups/group.entity';
 import { SpecialGroup } from '../groups/groups.special';
 import { Identity } from '../identity/identity.entity';
@@ -42,7 +43,7 @@ describe('PermissionsService', () => {
         NotesModule,
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock],
+          load: [appConfigMock, noteConfigMock],
         }),
       ],
     })

--- a/src/revisions/revisions.service.spec.ts
+++ b/src/revisions/revisions.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -11,6 +11,7 @@ import { Repository } from 'typeorm';
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
 import appConfigMock from '../config/mock/app.config.mock';
+import noteConfigMock from '../config/mock/note.config.mock';
 import { NotInDBError } from '../errors/errors';
 import { Group } from '../groups/group.entity';
 import { Identity } from '../identity/identity.entity';
@@ -45,7 +46,7 @@ describe('RevisionsService', () => {
         LoggerModule,
         ConfigModule.forRoot({
           isGlobal: true,
-          load: [appConfigMock],
+          load: [appConfigMock, noteConfigMock],
         }),
       ],
     })

--- a/test/private-api/alias.e2e-spec.ts
+++ b/test/private-api/alias.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -25,7 +25,7 @@ describe('Alias', () => {
     await testSetup.app.init();
 
     forbiddenNoteId =
-      testSetup.configService.get('appConfig').forbiddenNoteIds[0];
+      testSetup.configService.get('noteConfig').forbiddenNoteIds[0];
     users = testSetup.users;
 
     agent1 = request.agent(testSetup.app.getHttpServer());

--- a/test/private-api/history.e2e-spec.ts
+++ b/test/private-api/history.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -33,12 +33,11 @@ describe('History', () => {
     testSetup = await TestSetupBuilder.create().build();
 
     forbiddenNoteId =
-      testSetup.configService.get('appConfig').forbiddenNoteIds[0];
+      testSetup.configService.get('noteConfig').forbiddenNoteIds[0];
 
     const moduleRef = testSetup.moduleRef;
 
     const config = moduleRef.get<ConfigService>(ConfigService);
-    forbiddenNoteId = config.get('appConfig').forbiddenNoteIds[0];
 
     const authConfig = config.get('authConfig') as AuthConfig;
     setupSessionMiddleware(testSetup.app, authConfig);

--- a/test/private-api/notes.e2e-spec.ts
+++ b/test/private-api/notes.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -28,7 +28,7 @@ describe('Notes', () => {
     testSetup = await TestSetupBuilder.create().build();
 
     forbiddenNoteId =
-      testSetup.configService.get('appConfig').forbiddenNoteIds[0];
+      testSetup.configService.get('noteConfig').forbiddenNoteIds[0];
     uploadPath =
       testSetup.configService.get('mediaConfig').backend.filesystem.uploadPath;
 

--- a/test/public-api/alias.e2e-spec.ts
+++ b/test/public-api/alias.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -18,7 +18,7 @@ describe('Alias', () => {
   beforeEach(async () => {
     testSetup = await TestSetupBuilder.create().withUsers().withNotes().build();
     forbiddenNoteId =
-      testSetup.configService.get('appConfig').forbiddenNoteIds[0];
+      testSetup.configService.get('noteConfig').forbiddenNoteIds[0];
 
     await testSetup.app.init();
 

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -26,7 +26,7 @@ describe('Notes', () => {
     testSetup = await TestSetupBuilder.create().withMockAuth().build();
 
     forbiddenNoteId =
-      testSetup.configService.get('appConfig').forbiddenNoteIds[0];
+      testSetup.configService.get('noteConfig').forbiddenNoteIds[0];
     uploadPath =
       testSetup.configService.get('mediaConfig').backend.filesystem.uploadPath;
 

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -23,6 +23,7 @@ import authConfigMock from '../src/config/mock/auth.config.mock';
 import customizationConfigMock from '../src/config/mock/customization.config.mock';
 import externalServicesConfigMock from '../src/config/mock/external-services.config.mock';
 import mediaConfigMock from '../src/config/mock/media.config.mock';
+import noteConfigMock from '../src/config/mock/note.config.mock';
 import { FrontendConfigModule } from '../src/frontend-config/frontend-config.module';
 import { GroupsModule } from '../src/groups/groups.module';
 import { HistoryModule } from '../src/history/history.module';
@@ -105,6 +106,7 @@ export class TestSetupBuilder {
           isGlobal: true,
           load: [
             appConfigMock,
+            noteConfigMock,
             authConfigMock,
             mediaConfigMock,
             customizationConfigMock,


### PR DESCRIPTION
### Component/Part
config

### Description
This PR extracts noteConfig from appConfig.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x