### PR TITLE
Replace fs.rmdir recursive by fs.rm recursive

### DIFF
--- a/test/private-api/notes.e2e-spec.ts
+++ b/test/private-api/notes.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -331,7 +331,7 @@ describe('Notes', () => {
         // delete the file afterwards
         await fs.unlink(join(uploadPath, fileName));
       }
-      await fs.rmdir(uploadPath, { recursive: true });
+      await fs.rm(uploadPath, { recursive: true });
     });
     it('fails, when note does not exist', async () => {
       await agent

--- a/test/public-api/me.e2e-spec.ts
+++ b/test/public-api/me.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -216,7 +216,7 @@ describe('Me', () => {
       // delete the file afterwards
       await fs.unlink(join(uploadPath, fileName));
     }
-    await fs.rmdir(uploadPath, { recursive: true });
+    await fs.rm(uploadPath, { recursive: true });
   });
 
   afterAll(async () => {

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -442,7 +442,7 @@ describe('Notes', () => {
         // delete the file afterwards
         await fs.unlink(join(uploadPath, fileName));
       }
-      await fs.rmdir(uploadPath, { recursive: true });
+      await fs.rm(uploadPath, { recursive: true });
     });
     it('fails, when note does not exist', async () => {
       await request(testSetup.app.getHttpServer())

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -11,7 +11,7 @@ import { promises as fs } from 'fs';
  */
 export async function ensureDeleted(path: string): Promise<void> {
   try {
-    await fs.rmdir(path, { recursive: true });
+    await fs.rm(path, { recursive: true });
   } catch (e) {
     if (e.code && e.code == 'ENOENT') {
       // ignore error, path is already deleted


### PR DESCRIPTION
### Component/Part
e2e tests

### Description
fs.rmdir(path, { recursive: true}) is deprecated and
is replaced by fs.rm(path, { recursive: true}).

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
