### PR TITLE
Correctly initialize exception mapping

### DIFF
--- a/src/errors/error-mapping.ts
+++ b/src/errors/error-mapping.ts
@@ -6,6 +6,7 @@
 import {
   ArgumentsHost,
   BadRequestException,
+  Catch,
   ConflictException,
   InternalServerErrorException,
   NotFoundException,
@@ -67,6 +68,7 @@ const mapOfHedgeDocErrorsToHttpErrors: Map<string, HttpExceptionConstructor> =
     ],
   ]);
 
+@Catch()
 export class ErrorExceptionMapping extends BaseExceptionFilter<Error> {
   catch(error: Error, host: ArgumentsHost): void {
     super.catch(ErrorExceptionMapping.transformError(error), host);

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@
  */
 import { LogLevel } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { NestFactory } from '@nestjs/core';
+import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 
 import { AppModule } from './app.module';
@@ -79,7 +79,8 @@ async function bootstrap(): Promise<void> {
   app.useStaticAssets('public', {
     prefix: '/public/',
   });
-  app.useGlobalFilters(new ErrorExceptionMapping());
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  app.useGlobalFilters(new ErrorExceptionMapping(httpAdapter));
   await app.listen(appConfig.port);
   logger.log(`Listening on port ${appConfig.port}`, 'AppBootstrap');
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { getConfigToken } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AppModule } from '../src/app.module';
+import { BackendType } from '../src/media/backends/backend-type.enum';
+
+describe('App', () => {
+  it('should not crash on requests to /', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(getConfigToken('appConfig'))
+      .useValue({
+        domain: 'localhost',
+        port: 3333,
+        loglevel: 'debug',
+      })
+      .overrideProvider(getConfigToken('mediaConfig'))
+      .useValue({
+        backend: {
+          use: BackendType.FILESYSTEM,
+          filesystem: {
+            uploadPath:
+              'test_uploads' + Math.floor(Math.random() * 100000).toString(),
+          },
+        },
+      })
+      .overrideProvider(getConfigToken('databaseConfig'))
+      .useValue({
+        storage: ':memory:',
+        dialect: 'sqlite',
+      })
+      .overrideProvider(getConfigToken('authConfig'))
+      .useValue({
+        session: {
+          secret: 'secret',
+        },
+      })
+      .compile();
+
+    /**
+     * TODO: This is not really a regression test, as it does not use the
+     * real initialization code in main.ts.
+     * Should be fixed after https://github.com/hedgedoc/hedgedoc/issues/2083
+     * is done.
+     */
+    const app = moduleRef.createNestApplication();
+    await app.init();
+    await request(app.getHttpServer()).get('/').expect(404);
+    await app.close();
+  });
+});


### PR DESCRIPTION
### Component/Part
exception mapping

### Description
The constructor of an exception filter must be given
an instance of HttpAdapterHost, otherwise it will crash at runtime.

This can be reproduced by GETing /.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

