### PR TITLE
Use 'HedgeDoc' instead of 'CodiMD' in changelog and license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,5 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 Please refer to the release notes published on
 [our releases page](https://hedgedoc.org/releases/) or [on GitHub](https://github.com/hedgedoc/hedgedoc/releases).
 
-These are also available on each CodiMD instance under
+These are also available on each HedgeDoc instance under
 https://[domain-name]/release-notes

--- a/LICENSE
+++ b/LICENSE
@@ -629,13 +629,12 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    CodiMD - Realtime collaborative markdown notes on all platforms.
-    Copyright (C) 2019  Christoph (Sheogorath) Kern
-    Copyright (C) 2019  Claudius Coenen
-    Copyright (C) 2019  Max Wu
-    Copyright (C) 2017  Yukai Huang
-    And more can be found on https://github.com/codimd/server/graphs/contributors
-    Or in the local AUTHORS file
+    HedgeDoc - The best platform to write and share markdown.
+    Copyright (C) 2022  The HedgeDoc developers
+    
+    The individual contributors can be found on
+    https://github.com/hedgedoc/hedgedoc/graphs/contributors
+    or in the local AUTHORS file.
 
 
 

--- a/docs/content/dev/public_api.yml
+++ b/docs/content/dev/public_api.yml
@@ -5,13 +5,13 @@ info:
   version: 2.0.0
   contact:
     name: HedgeDoc on GitHub
-    url: https://github.com/codimd/server
+    url: https://github.com/hedgedoc/hedgedoc
   license:
     name: AGPLv3
-    url: https://github.com/codimd/server/blob/master/LICENSE
+    url: https://github.com/hedgedoc/hedgedoc/blob/develop/LICENSE
 externalDocs:
-  description: The CodiMD Documentation.
-  url: https://github.com/codimd/server/tree/master/docs
+  description: The HedgeDoc Documentation.
+  url: https://docs.hedgedoc.org
 servers:
   - url: "/api/v2"
     description: The base API Path.


### PR DESCRIPTION
### Component/Part
changelog file, license file

### Description
This PR changes CodiMD to HedgeDoc on some places where it hasn't been done yet.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
