### PR TITLE
Use localhost instead of 127.0.0.1 in docker guide

### DIFF
--- a/docs/content/setup/docker.md
+++ b/docs/content/setup/docker.md
@@ -44,7 +44,7 @@ volumes:
   database:
   uploads:
 ```
-After executing `docker-compose up`, HedgeDoc should be available at [http://127.0.0.1:3000](http://127.0.0.1:3000).  
+After executing `docker-compose up`, HedgeDoc should be available at [http://localhost:3000](http://localhost:3000).  
 You can now continue to configure your container with environment variables.
 Check out [the configuration docs](/configuration) for more details.
 


### PR DESCRIPTION
### Component/Part
docs -> setup -> docker

### Description
The example docker-compose.yml in the docker guide sets CMD_DOMAIN to `localhost`. This results in HedgeDoc only being fully accessible from http://localhost:3000 as the Content-Security-Policy forbids access to e.g. http://127.0.0.1:3000.

This PR fixes the docs to use http://localhost:3000 over http://127.0.0.1:3000.

### Steps
- [x] Tested example from docs
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #2098 
