### PR TITLE
fix: openapi decorator

### DIFF
--- a/src/api/utils/openapi.decorator.ts
+++ b/src/api/utils/openapi.decorator.ts
@@ -106,7 +106,7 @@ export const OpenApi = (
           ApiOkResponse({
             description: description ?? okDescription,
             isArray: isArray,
-            type: () => dto,
+            type: dto ? (): BaseDto => dto as BaseDto : undefined,
           }),
         );
         break;
@@ -115,7 +115,7 @@ export const OpenApi = (
           ApiCreatedResponse({
             description: description ?? createdDescription,
             isArray: isArray,
-            type: () => dto,
+            type: dto ? (): BaseDto => dto as BaseDto : undefined,
           }),
           HttpCode(201),
         );


### PR DESCRIPTION
### Component/Part
openapi decorator

### Description
This now correctly returns the dto if it is provided. Previously it would return () => undefined, when the dto was not defined, which crashed some internal logic in nestjs.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
