### PR TITLE
Add Traefik as reversy proxy

### DIFF
--- a/docs/content/guides/reverse-proxy.md
+++ b/docs/content/guides/reverse-proxy.md
@@ -114,3 +114,25 @@ Here is an example config snippet:
   Include /etc/letsencrypt/options-ssl-apache.conf
 </VirtualHost>
 ```
+### Traefik
+
+In traefik we have to add the traefik labels and it is also very important: add our domain to "CMD_DOMAIN", "CMD_URL_ADDPORT=false", "CMD_PROTOCOL_USESSL=true".
+
+``` yaml
+  app:
+    # Make sure to use the latest release from https://hedgedoc.org/latest-release
+    image: quay.io/hedgedoc/hedgedoc:1.9.2
+    environment:
+      - CMD_DB_URL=postgres://hedgedoc:password@database:5432/hedgedoc
+      - CMD_DOMAIN=yourdomain.com
+      - CMD_URL_ADDPORT=false
+      - CMD_PROTOCOL_USESSL=true
+    volumes:
+      - uploads:/hedgedoc/public/uploads
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.hedgedoc.entryPoints=web-secure
+      - traefik.http.routers.hedgedoc.rule=Host(`yourdomain.com`)
+      - traefik.http.routers.hedgedoc.tls.certresolver=default
+      - traefik.http.services.hedgedoc.loadbalancer.server.port=3000
+```


### PR DESCRIPTION
Signed-off-by: Crstian19 <kiyoma19@gmail.com>

### Component/Part
Docs

### Description
Added to docs Traefik config as reverse proxy.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ ] Added implementation
- [ ] Added / updated tests
- [x] Added / updated documentation
- [ ] Added changelog snippet
- [ ] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
