### PR TITLE
Add APIs to fetch info about Users and Groups

### DIFF
--- a/src/api/private/groups/groups.controller.ts
+++ b/src/api/private/groups/groups.controller.ts
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { GroupInfoDto } from '../../../groups/group-info.dto';
+import { GroupsService } from '../../../groups/groups.service';
+import { SessionGuard } from '../../../identity/session.guard';
+import { ConsoleLoggerService } from '../../../logger/console-logger.service';
+import { OpenApi } from '../../utils/openapi.decorator';
+
+@UseGuards(SessionGuard)
+@OpenApi(401, 403)
+@ApiTags('groups')
+@Controller('groups')
+export class GroupsController {
+  constructor(
+    private readonly logger: ConsoleLoggerService,
+    private groupService: GroupsService,
+  ) {
+    this.logger.setContext(GroupsController.name);
+  }
+
+  @Get(':groupName')
+  @OpenApi(200)
+  async getGroup(@Param('groupName') groupName: string): Promise<GroupInfoDto> {
+    return this.groupService.toGroupDto(
+      await this.groupService.getGroupByName(groupName),
+    );
+  }
+}

--- a/src/api/private/me/me.controller.ts
+++ b/src/api/private/me/me.controller.ts
@@ -10,7 +10,7 @@ import { SessionGuard } from '../../../identity/session.guard';
 import { ConsoleLoggerService } from '../../../logger/console-logger.service';
 import { MediaUploadDto } from '../../../media/media-upload.dto';
 import { MediaService } from '../../../media/media.service';
-import { UserInfoDto } from '../../../users/user-info.dto';
+import { FullUserInfoDto } from '../../../users/user-info.dto';
 import { User } from '../../../users/user.entity';
 import { UsersService } from '../../../users/users.service';
 import { OpenApi } from '../../utils/openapi.decorator';
@@ -28,10 +28,11 @@ export class MeController {
   ) {
     this.logger.setContext(MeController.name);
   }
+
   @Get()
   @OpenApi(200)
-  getMe(@RequestUser() user: User): UserInfoDto {
-    return this.userService.toUserDto(user);
+  getMe(@RequestUser() user: User): FullUserInfoDto {
+    return this.userService.toFullUserDto(user);
   }
 
   @Get('media')

--- a/src/api/private/private-api.module.ts
+++ b/src/api/private/private-api.module.ts
@@ -7,6 +7,7 @@ import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../../auth/auth.module';
 import { FrontendConfigModule } from '../../frontend-config/frontend-config.module';
+import { GroupsModule } from '../../groups/groups.module';
 import { HistoryModule } from '../../history/history.module';
 import { IdentityModule } from '../../identity/identity.module';
 import { LoggerModule } from '../../logger/logger.module';
@@ -18,6 +19,7 @@ import { UsersModule } from '../../users/users.module';
 import { AliasController } from './alias/alias.controller';
 import { AuthController } from './auth/auth.controller';
 import { ConfigController } from './config/config.controller';
+import { GroupsController } from './groups/groups.controller';
 import { HistoryController } from './me/history/history.controller';
 import { MeController } from './me/me.controller';
 import { MediaController } from './media/media.controller';
@@ -37,6 +39,7 @@ import { UsersController } from './users/users.controller';
     MediaModule,
     RevisionsModule,
     IdentityModule,
+    GroupsModule,
   ],
   controllers: [
     TokensController,
@@ -48,7 +51,7 @@ import { UsersController } from './users/users.controller';
     AliasController,
     AuthController,
     UsersController,
-    GroupController,
+    GroupsController,
   ],
 })
 export class PrivateApiModule {}

--- a/src/api/private/private-api.module.ts
+++ b/src/api/private/private-api.module.ts
@@ -23,6 +23,7 @@ import { MeController } from './me/me.controller';
 import { MediaController } from './media/media.controller';
 import { NotesController } from './notes/notes.controller';
 import { TokensController } from './tokens/tokens.controller';
+import { UsersController } from './users/users.controller';
 
 @Module({
   imports: [
@@ -46,6 +47,8 @@ import { TokensController } from './tokens/tokens.controller';
     NotesController,
     AliasController,
     AuthController,
+    UsersController,
+    GroupController,
   ],
 })
 export class PrivateApiModule {}

--- a/src/api/private/users/users.controller.ts
+++ b/src/api/private/users/users.controller.ts
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { ConsoleLoggerService } from '../../../logger/console-logger.service';
+import { UserInfoDto } from '../../../users/user-info.dto';
+import { UsersService } from '../../../users/users.service';
+import { OpenApi } from '../../utils/openapi.decorator';
+
+@ApiTags('users')
+@Controller('users')
+export class UsersController {
+  constructor(
+    private readonly logger: ConsoleLoggerService,
+    private userService: UsersService,
+  ) {
+    this.logger.setContext(UsersController.name);
+  }
+
+  @Get(':username')
+  @OpenApi(200)
+  async getUser(@Param('username') username: string): Promise<UserInfoDto> {
+    return this.userService.toUserDto(
+      await this.userService.getUserByUsername(username),
+    );
+  }
+}

--- a/src/api/public/me/me.controller.ts
+++ b/src/api/public/me/me.controller.ts
@@ -24,7 +24,7 @@ import { MediaService } from '../../../media/media.service';
 import { NoteMetadataDto } from '../../../notes/note-metadata.dto';
 import { Note } from '../../../notes/note.entity';
 import { NotesService } from '../../../notes/notes.service';
-import { UserInfoDto } from '../../../users/user-info.dto';
+import { FullUserInfoDto } from '../../../users/user-info.dto';
 import { User } from '../../../users/user.entity';
 import { UsersService } from '../../../users/users.service';
 import { GetNoteInterceptor } from '../../utils/get-note.interceptor';
@@ -52,10 +52,10 @@ export class MeController {
   @OpenApi({
     code: 200,
     description: 'The user information',
-    dto: UserInfoDto,
+    dto: FullUserInfoDto,
   })
-  getMe(@RequestUser() user: User): UserInfoDto {
-    return this.usersService.toUserDto(user);
+  getMe(@RequestUser() user: User): FullUserInfoDto {
+    return this.usersService.toFullUserDto(user);
   }
 
   @Get('history')

--- a/src/users/user-info.dto.ts
+++ b/src/users/user-info.dto.ts
@@ -34,7 +34,13 @@ export class UserInfoDto extends BaseDto {
   })
   @IsString()
   photo: string;
+}
 
+/**
+ * This DTO contains all attributes of the standard UserInfoDto
+ * in addition to the email address.
+ */
+export class FullUserInfoDto extends UserInfoDto {
   /**
    * Email address of the user
    * @example "john.smith@example.com"

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -148,6 +148,18 @@ describe('UsersService', () => {
       expect(userDto.username).toEqual(username);
       expect(userDto.displayName).toEqual(displayname);
       expect(userDto.photo).toEqual('');
+    });
+  });
+
+  describe('toFullUserDto', () => {
+    const username = 'hardcoded';
+    const displayname = 'Testy';
+    const user = User.create(username, displayname) as User;
+    it('works if a user is provided', () => {
+      const userDto = service.toFullUserDto(user);
+      expect(userDto.username).toEqual(username);
+      expect(userDto.displayName).toEqual(displayname);
+      expect(userDto.photo).toEqual('');
       expect(userDto.email).toEqual('');
     });
   });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -9,7 +9,7 @@ import { Repository } from 'typeorm';
 
 import { AlreadyInDBError, NotInDBError } from '../errors/errors';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
-import { UserInfoDto } from './user-info.dto';
+import { FullUserInfoDto, UserInfoDto } from './user-info.dto';
 import { UserRelationEnum } from './user-relation.enum';
 import { User } from './user.entity';
 
@@ -111,6 +111,19 @@ export class UsersService {
    * @return {(UserInfoDto)} the built UserInfoDto
    */
   toUserDto(user: User): UserInfoDto {
+    return {
+      username: user.username,
+      displayName: user.displayName,
+      photo: this.getPhotoUrl(user),
+    };
+  }
+
+  /**
+   * Build FullUserInfoDto from a user.
+   * @param {User=} user - the user to use
+   * @return {(UserInfoDto)} the built FullUserInfoDto
+   */
+  toFullUserDto(user: User): FullUserInfoDto {
     return {
       username: user.username,
       displayName: user.displayName,

--- a/test/private-api/groups.e2e-spec.ts
+++ b/test/private-api/groups.e2e-spec.ts
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import request from 'supertest';
+
+import { LoginDto } from '../../src/identity/local/login.dto';
+import { TestSetup, TestSetupBuilder } from '../test-setup';
+
+describe('Groups', () => {
+  let testSetup: TestSetup;
+  let testuser1Session: request.SuperAgentTest;
+
+  beforeEach(async () => {
+    testSetup = await TestSetupBuilder.create().withUsers().build();
+    await testSetup.app.init();
+
+    // create a test group
+    await testSetup.groupService.createGroup('testgroup1', 'testgroup1', false);
+
+    // log in to create a session
+    const loginDto: LoginDto = {
+      password: 'testuser1',
+      username: 'testuser1',
+    };
+    testuser1Session = request.agent(testSetup.app.getHttpServer());
+    await testuser1Session
+      .post('/api/private/auth/local/login')
+      .set('Content-Type', 'application/json')
+      .send(JSON.stringify(loginDto))
+      .expect(201);
+  });
+
+  afterEach(async () => {
+    await testSetup.app.close();
+  });
+
+  test('details for existing groups can be retrieved', async () => {
+    const response = await testuser1Session.get(
+      '/api/private/groups/testgroup1',
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.name).toBe('testgroup1');
+  });
+
+  test('details for non-existing groups cannot be retrieved', async () => {
+    const response = await testuser1Session.get(
+      '/api/private/groups/i_dont_exist',
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test('API requires authentication', async () => {
+    const response = await request(testSetup.app.getHttpServer()).get(
+      '/api/private/groups/testgroup1',
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/test/private-api/me.e2e-spec.ts
+++ b/test/private-api/me.e2e-spec.ts
@@ -9,7 +9,7 @@ import request from 'supertest';
 import { AuthConfig } from '../../src/config/auth.config';
 import { NotInDBError } from '../../src/errors/errors';
 import { Note } from '../../src/notes/note.entity';
-import { UserInfoDto } from '../../src/users/user-info.dto';
+import { FullUserInfoDto } from '../../src/users/user-info.dto';
 import { User } from '../../src/users/user.entity';
 import { setupSessionMiddleware } from '../../src/utils/session';
 import { TestSetup, TestSetupBuilder } from '../test-setup';
@@ -50,12 +50,12 @@ describe('Me', () => {
   });
 
   it('GET /me', async () => {
-    const userInfo = testSetup.userService.toUserDto(user);
+    const userInfo = testSetup.userService.toFullUserDto(user);
     const response = await agent
       .get('/api/private/me')
       .expect('Content-Type', /json/)
       .expect(200);
-    const gotUser = response.body as UserInfoDto;
+    const gotUser = response.body as FullUserInfoDto;
     expect(gotUser).toEqual(userInfo);
   });
 

--- a/test/private-api/users.e2e-spec.ts
+++ b/test/private-api/users.e2e-spec.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import request from 'supertest';
+
+import { TestSetup, TestSetupBuilder } from '../test-setup';
+
+describe('Users', () => {
+  let testSetup: TestSetup;
+
+  beforeEach(async () => {
+    testSetup = await TestSetupBuilder.create().withUsers().build();
+    await testSetup.app.init();
+  });
+
+  afterEach(async () => {
+    await testSetup.app.close();
+  });
+
+  test('details for existing users can be retrieved', async () => {
+    let response = await request
+      .agent(testSetup.app.getHttpServer())
+      .get('/api/private/users/testuser1');
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe('testuser1');
+
+    response = await request
+      .agent(testSetup.app.getHttpServer())
+      .get('/api/private/users/testuser2');
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe('testuser2');
+  });
+
+  test('details for non-existing users cannot be retrieved', async () => {
+    const response = await request
+      .agent(testSetup.app.getHttpServer())
+      .get('/api/private/users/i_dont_exist');
+    expect(response.status).toBe(404);
+  });
+});

--- a/test/public-api/me.e2e-spec.ts
+++ b/test/public-api/me.e2e-spec.ts
@@ -32,7 +32,7 @@ describe('Me', () => {
   });
 
   it(`GET /me`, async () => {
-    const userInfo = testSetup.userService.toUserDto(user);
+    const userInfo = testSetup.userService.toFullUserDto(user);
     const response = await request(testSetup.app.getHttpServer())
       .get('/api/v2/me')
       .expect('Content-Type', /json/)

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -27,6 +27,7 @@ import noteConfigMock from '../src/config/mock/note.config.mock';
 import { ErrorExceptionMapping } from '../src/errors/error-mapping';
 import { FrontendConfigModule } from '../src/frontend-config/frontend-config.module';
 import { GroupsModule } from '../src/groups/groups.module';
+import { GroupsService } from '../src/groups/groups.service';
 import { HistoryModule } from '../src/history/history.module';
 import { HistoryService } from '../src/history/history.service';
 import { IdentityModule } from '../src/identity/identity.module';
@@ -51,6 +52,7 @@ export class TestSetup {
   app: NestExpressApplication;
 
   userService: UsersService;
+  groupService: GroupsService;
   configService: ConfigService;
   identityService: IdentityService;
   notesService: NotesService;
@@ -152,6 +154,8 @@ export class TestSetupBuilder {
 
     this.testSetup.userService =
       this.testSetup.moduleRef.get<UsersService>(UsersService);
+    this.testSetup.groupService =
+      this.testSetup.moduleRef.get<GroupsService>(GroupsService);
     this.testSetup.configService =
       this.testSetup.moduleRef.get<ConfigService>(ConfigService);
     this.testSetup.identityService =


### PR DESCRIPTION
### Component/Part
Private API

### Description
This PR adds routes that allow to fetch information about users and groups given their respective names.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
