### PR TITLE
fix(session-middleware): don't hardcode database TTL

### DIFF
--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -32,7 +32,6 @@ export function setupSessionMiddleware(
       saveUninitialized: false,
       store: new TypeormStore({
         cleanupLimit: 2,
-        ttl: 86400,
       }).connect(app.get<Repository<Session>>(getRepositoryToken(Session))),
     }),
   );


### PR DESCRIPTION
### Component/Part
session middleware

### Description
The cookie expiration is taken from the config,
but the expiration date of session data in the database was hardcoded.

This removes the hardcoded value, so TypeormStore defaults
to cookie.maxAge.

References:
https://github.com/nykula/connect-typeorm#options
https://github.com/expressjs/session#cookiemaxage


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
