### PR TITLE
feat(validation): send error message to client

### DIFF
--- a/src/utils/setup-pipes.ts
+++ b/src/utils/setup-pipes.ts
@@ -22,7 +22,7 @@ export function setupValidationPipe(
         'ValidationPipe',
       );
       return new BadRequestException(
-        'Encountered an exception while validating the request.',
+        `Errors were encountered while validating a request:\n${errorMessage}`,
       );
     },
   });


### PR DESCRIPTION
### Component/Part
Validation

### Description
For some reason, 2021-me did not send the exact validation error to the client.
I now don't see any reason to not do that, so this PR changes the implementation.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
