### PR TITLE
CI: build and test docker image

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+name: Delete old container images
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # every day at midnight
+  workflow_dispatch:
+
+jobs:
+  clean-ghcr:
+    name: Cleanup CI containers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup CI containers
+        uses: snok/container-retention-policy@v1
+        with:
+          image-names: ${{ github.event.repository.name }}-ci
+          cut-off: A day ago UTC
+          account-type: org
+          org-name: ${{ github.repository_owner }}
+          token: ${{ secrets.PAT_IMAGE_CLEANUP }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+name: Docker
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build dev image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: docker/Dockerfile
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-ci:${{ github.sha }}
+          target: development
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  sqlite-test:
+    runs-on: ubuntu-latest
+    needs: [build-dev]
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-ci:${{ github.sha }}
+    steps:
+      - run: cd /usr/src/app && yarn run test
+
+  sqlite-e2e:
+    runs-on: ubuntu-latest
+    needs: [build-dev]
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-ci:${{ github.sha }}
+    steps:
+      - run: cd /usr/src/app && yarn run test:e2e
+
+  build-prod:
+    runs-on: ubuntu-latest
+    needs: [sqlite-test, sqlite-e2e]
+    steps:
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          file: docker/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR adds new workflows performing these steps:
- A development docker image is built and pushed to GHCR as
  'hedgedoc-ci' labeled with the commit hash
- Tests are run with the image
- If the tests are successful, a production image is built and
  pushed to GHCR as 'hedgedoc' labeled with the branch and the version tag if available
- Every day, 'hedgedoc-ci' images older than one day are deleted.


At a later time, the built dev image could also be used to run E2E tests
with the other supported databases. Currently, this is not yet possible,
as the database is always expected to run on localhost, not other hosts.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
