### PR TITLE
bin/manage_users: Always treat pass argument as string

### DIFF
--- a/bin/manage_users
+++ b/bin/manage_users
@@ -92,8 +92,8 @@ const options = {
 	reset: resetUser,
 };
 
-// Perform commandline-parsing
-const argv = minimist(process.argv.slice(2));
+// Perform commandline-parsing and always treat 'pass' argument as string
+const argv = minimist(process.argv.slice(2), {string: ["pass"]});
 
 const keys = Object.keys(options);
 const opts = keys.filter((key) => argv[key] !== undefined);

--- a/bin/manage_users
+++ b/bin/manage_users
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
-// First configure the logger so it does not spam the console
-const logger = require("../lib/logger");
-logger.transports.forEach((transport) => transport.level = "warning")
+// First configure the logger, so it does not spam the console
+const logger = require('../lib/logger')
+logger.transports.forEach((transport) => transport.level = 'warning')
 
-const models = require("../lib/models/");
-const readline = require("readline-sync");
-const minimist = require("minimist");
+const models = require('../lib/models/')
+const readline = require('readline-sync')
+const minimist = require('minimist')
 
-function showUsage(tips) {
-	console.log(`${tips}
+function showUsage (tips) {
+  console.log(`${tips}
 
 Command-line utility to create users for email-signin.
 
@@ -19,104 +19,102 @@ Usage: bin/manage_users [--pass password] (--add | --del) user-email
 		--del 	Delete user with specified user-email
 		--reset Reset user password with specified user-email
 		--pass	Use password from cmdline rather than prompting
-`);
-	process.exit(1);
+`)
+  process.exit(1)
 }
 
-function getPass(argv, action) {
-	// Find whether we use cmdline or prompt password
-	if(typeof argv["pass"] !== 'string') {
-		return readline.question(`Password for ${argv[action]}:`, {hideEchoBack: true});
-	}
-	console.log("Using password from commandline...");
-	return argv["pass"];
+function getPass (argv, action) {
+  // Find whether we use cmdline or prompt password
+  if (typeof argv['pass'] !== 'string') {
+    return readline.question(`Password for ${argv[action]}:`, { hideEchoBack: true })
+  }
+  console.log('Using password from commandline...')
+  return argv['pass']
 }
 
 // Using an async function to be able to use await inside
-async function createUser(argv) {
-	const existing_user = await models.User.findOne({where: {email: argv["add"]}});
-	// Cannot create already-existing users
-	if(existing_user) {
-		console.log(`User with e-mail ${existing_user.email} already exists! Aborting ...`);
-		process.exit(2);
-	}
-
-	const pass = getPass(argv, "add");
-  if (pass.length === 0) {
-    console.log("Password cannot be empty!");
-    process.exit(1);
+async function createUser (argv) {
+  const existing_user = await models.User.findOne({ where: { email: argv['add'] } })
+  // Cannot create already-existing users
+  if (existing_user) {
+    console.log(`User with e-mail ${existing_user.email} already exists! Aborting ...`)
+    process.exit(2)
   }
 
-	// Lets try to create, and check success
-	const ref = await models.User.create({email: argv["add"], password: pass});
-	if(ref == undefined) {
-		console.log(`Could not create user with email ${argv["add"]}`);
-		process.exit(1);
-	} else
-		console.log(`Created user with email ${argv["add"]}`);
+  const pass = getPass(argv, 'add')
+  if (pass.length === 0) {
+    console.log('Password cannot be empty!')
+    process.exit(1)
+  }
+
+  // Lets try to create, and check success
+  const ref = await models.User.create({ email: argv['add'], password: pass })
+  if (ref === undefined) {
+    console.log(`Could not create user with email ${argv['add']}`)
+    process.exit(1)
+  } else {
+    console.log(`Created user with email ${argv['add']}`)
+  }
 }
 
 // Using an async function to be able to use await inside
-async function deleteUser(argv) {
-	// Cannot delete non-existing users
-	const existing_user = await models.User.findOne({where: {email: argv["del"]}});
-	if(!existing_user) {
-		console.log(`User with e-mail ${argv["del"]} does not exist, cannot delete`);
-		process.exit(1);
-	}
+async function deleteUser (argv) {
+  // Cannot delete non-existing users
+  const existing_user = await models.User.findOne({ where: { email: argv['del'] } })
+  if (!existing_user) {
+    console.log(`User with e-mail ${argv['del']} does not exist, cannot delete`)
+    process.exit(1)
+  }
 
-	// Sadly .destroy() does not return any success value with all
-	// backends. See sequelize #4124
-	await existing_user.destroy();
-	console.log(`Deleted user ${argv["del"]} ...`);
+  // Sadly .destroy() does not return any success value with all
+  // backends. See sequelize #4124
+  await existing_user.destroy()
+  console.log(`Deleted user ${argv['del']} ...`)
 }
 
-
 // Using an async function to be able to use await inside
-async function resetUser(argv) {
-	const existing_user = await models.User.findOne({where: {email: argv["reset"]}});
-	// Cannot reset non-existing users
-	if(!existing_user) {
-		console.log(`User with e-mail ${argv["reset"]} does not exist, cannot reset`);
-		process.exit(1);
-	}
+async function resetUser (argv) {
+  const existing_user = await models.User.findOne({ where: { email: argv['reset'] } })
+  // Cannot reset non-existing users
+  if (!existing_user) {
+    console.log(`User with e-mail ${argv['reset']} does not exist, cannot reset`)
+    process.exit(1)
+  }
 
-	const pass = getPass(argv, "reset");
-
-	// set password and save
-	existing_user.password = pass;
-	await existing_user.save();
-	console.log(`User with email ${argv["reset"]} password has been reset`);
+  // set password and save
+  existing_user.password = getPass(argv, 'reset')
+  await existing_user.save()
+  console.log(`User with email ${argv['reset']} password has been reset`)
 }
 
 const options = {
-	add: createUser,
-	del: deleteUser,
-	reset: resetUser,
-};
+  add: createUser,
+  del: deleteUser,
+  reset: resetUser,
+}
 
 // Perform commandline-parsing and always treat 'pass' argument as string
-const argv = minimist(process.argv.slice(2), {string: ["pass"]});
+const argv = minimist(process.argv.slice(2), { string: ['pass'] })
 
-const keys = Object.keys(options);
-const opts = keys.filter((key) => argv[key] !== undefined);
-const action = opts[0];
+const keys = Object.keys(options)
+const opts = keys.filter((key) => argv[key] !== undefined)
+const action = opts[0]
 
 // Check for options missing
 if (opts.length === 0) {
-	showUsage(`You did not specify either ${keys.map((key) => `--${key}`).join(' or ')}!`);
+  showUsage(`You did not specify either ${keys.map((key) => `--${key}`).join(' or ')}!`)
 }
 
 // Check if both are specified
 if (opts.length > 1) {
-	showUsage(`You cannot ${action.join(' and ')} at the same time!`);
+  showUsage(`You cannot ${action.join(' and ')} at the same time!`)
 }
 // Check if not string
 if (typeof argv[action] !== 'string') {
-	showUsage(`You must follow an email after --${action}`);
+  showUsage(`You must follow an email after --${action}`)
 }
 
 // Call respective processing functions
-options[action](argv).then(function() {
+options[action](argv).then(function () {
   process.exit(0);
 });

--- a/bin/manage_users
+++ b/bin/manage_users
@@ -42,7 +42,10 @@ async function createUser(argv) {
 	}
 
 	const pass = getPass(argv, "add");
-
+  if (pass.length === 0) {
+    console.log("Password cannot be empty!");
+    process.exit(1);
+  }
 
 	// Lets try to create, and check success
 	const ref = await models.User.create({email: argv["add"], password: pass});

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -4,6 +4,7 @@
 
 ### Bugfixes
 - Fix error that Libravatar user avatars were not shown when using OAuth2 login
+- Fix `bin/manage_users` not accepting numeric passwords (thanks to [@carr0t2](https://github.com/carr0t2) for reporting)
 
 ### Enhancements
 - Libravatar avatars render as ident-icons when no avatar image was uploaded to Libravatar or Gravatar


### PR DESCRIPTION
### Component/Part
`bin/manage_users`

### Description
This PR fixes #1945 by telling [minimist](https://github.com/substack/minimist) to always treat the `pass` command line option as a string.

It also adds a check for empty passwords and minor code-style improvements.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#1945
