### PR TITLE
Force change of aria-hidden when modal shows or hides

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 - Fix error that Libravatar user avatars were not shown when using OAuth2 login
 - Fix `bin/manage_users` not accepting numeric passwords (thanks to [@carr0t2](https://github.com/carr0t2) for reporting)
+- Fix visibility of modals for screen readers
 
 ### Enhancements
 - Libravatar avatars render as ident-icons when no avatar image was uploaded to Libravatar or Gravatar

--- a/public/js/cover.js
+++ b/public/js/cover.js
@@ -32,6 +32,8 @@ require('./locale')
 require('../css/cover.css')
 require('../css/site.css')
 
+require('./fix-aria-hidden-for-modals')
+
 const options = {
   valueNames: ['id', 'text', 'timestamp', 'fromNow', 'time', 'tags', 'pinned'],
   item: `<li class="col-xs-12 col-sm-6 col-md-6 col-lg-4">

--- a/public/js/fix-aria-hidden-for-modals.js
+++ b/public/js/fix-aria-hidden-for-modals.js
@@ -1,0 +1,5 @@
+$(document).on('shown.bs.modal', function (event) {
+  $(event.target).attr('aria-hidden', 'false')
+}).on('hidden.bs.modal', function (event) {
+  $(event.target).attr('aria-hidden', 'true')
+})

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -93,6 +93,7 @@ require('../css/slide-preview.css')
 require('../css/site.css')
 
 require('highlight.js/styles/github-gist.css')
+require('./fix-aria-hidden-for-modals')
 
 let defaultTextHeight = 20
 let viewportMargin = 20


### PR DESCRIPTION
### Component/Part
Modals

### Description
This PR fixes the usability of modals when using screen readers by adjusting the `aria-hidden` attribute correctly.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes https://github.com/hedgedoc/hedgedoc/issues/2126
