### PR TITLE
Improve aria tags for view mode labels

### DIFF
--- a/public/views/hedgedoc/header.ejs
+++ b/public/views/hedgedoc/header.ejs
@@ -78,14 +78,14 @@
     <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-form navbar-left" style="padding:0;">
             <div class="btn-group" data-toggle="buttons">
-                <label class="btn btn-default ui-view" title="<%= __('View') %> (Ctrl+Alt+V)">
-                    <input type="radio" name="mode" autocomplete="off"><i class="fa fa-eye"></i>
+                <label class="btn btn-default ui-view" for="view-mode-toggle-view" title="<%= __('View') %> (Ctrl+Alt+V)" aria-label="<%= __('View') %> (Ctrl+Alt+V)">
+                    <input type="radio" name="mode" id="view-mode-toggle-view" autocomplete="off"><i class="fa fa-eye"></i>
                 </label>
-                <label class="btn btn-default ui-both" title="<%= __('Both') %> (Ctrl+Alt+B)">
-                    <input type="radio" name="mode" autocomplete="off"><i class="fa fa-columns"></i>
+                <label class="btn btn-default ui-both" for="view-mode-toggle-both" title="<%= __('Both') %> (Ctrl+Alt+B)" aria-label="<%= __('Both') %> (Ctrl+Alt+B)">
+                    <input type="radio" name="mode" id="view-mode-toggle-both" autocomplete="off"><i class="fa fa-columns"></i>
                 </label>
-                <label class="btn btn-default ui-edit" title="<%= __('Edit') %> (Ctrl+Alt+E)">
-                    <input type="radio" name="mode" autocomplete="off"><i class="fa fa-pencil"></i>
+                <label class="btn btn-default ui-edit" for="view-mode-toggle-edit" title="<%= __('Edit') %> (Ctrl+Alt+E)" aria-label="<%= __('Edit') %> (Ctrl+Alt+E)">
+                    <input type="radio" name="mode" id="view-mode-toggle-edit" autocomplete="off"><i class="fa fa-pencil"></i>
                 </label>
             </div>
             <div class="btn-group" data-toggle="buttons">


### PR DESCRIPTION
### Component/Part
View mode toggles

### Description
This PR tries to improve the screen reader visibility of the view mode toggles by adding some html attributes.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Probably fix https://github.com/hedgedoc/hedgedoc/issues/2125
