### PR TITLE
Fix GitLab snippet export

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -50,6 +50,10 @@ const allowPDFEmbedDirectives = {
   frameSrc: ['*'] // Chrome also checks PDFs against frame-src
 }
 
+const configuredGitLabInstanceDirectives = {
+  connectSrc: [config.gitlab.baseURL]
+}
+
 CspStrategy.computeDirectives = function () {
   const directives = {}
   mergeDirectives(directives, config.csp.directives)
@@ -59,6 +63,7 @@ CspStrategy.computeDirectives = function () {
   mergeDirectivesIf(config.dropbox.appKey, directives, dropboxDirectives)
   mergeDirectivesIf(!config.csp.allowFraming, directives, disallowFramingDirectives)
   mergeDirectivesIf(config.csp.allowPDFEmbed, directives, allowPDFEmbedDirectives)
+  mergeDirectivesIf(config.isGitlabSnippetsEnable, directives, configuredGitLabInstanceDirectives)
   addInlineScriptExceptions(directives)
   addUpgradeUnsafeRequestsOptionTo(directives)
   addReportURI(directives)

--- a/lib/response.js
+++ b/lib/response.js
@@ -156,9 +156,13 @@ function gitlabActionProjects (req, res, note) {
       if (!user) {
         return errors.errorNotFound(res)
       }
-      const ret = { baseURL: config.gitlab.baseURL, version: config.gitlab.version }
-      ret.accesstoken = user.accessToken
-      ret.profileid = user.profileid
+      const ret = {
+        baseURL: config.gitlab.baseURL,
+        version: config.gitlab.version,
+        accesstoken: user.accessToken,
+        profileid: user.profileid,
+        projects: []
+      }
       const apiUrl = `${config.gitlab.baseURL}/api/${config.gitlab.version}/projects?membership=yes&per_page=100&access_token=${user.accessToken}`
       fetch(apiUrl).then(resp => {
         if (!resp.ok) {

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -6,6 +6,7 @@
 - Fix error that Libravatar user avatars were not shown when using OAuth2 login
 - Fix `bin/manage_users` not accepting numeric passwords (thanks to [@carr0t2](https://github.com/carr0t2) for reporting)
 - Fix visibility of modals for screen readers
+- Fix GitLab snippet export (thanks to [@semjongeist](https://github.com/semjongeist) for reporting)
 - Fix missing inline authorship colors (thanks to [@EBendinelli](https://github.com/EBendinelli) for reporting)
 
 ### Enhancements

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1918,6 +1918,8 @@ $('#snippetExportModalConfirm').click(function () {
   const accesstoken = $('#snippetExportModalAccessToken').val()
   const baseURL = $('#snippetExportModalBaseURL').val()
   const version = $('#snippetExportModalVersion').val()
+  const projectId = $('#snippetExportModalProjects').val()
+  const visibilityValue = $('#snippetExportModalVisibility').val()
 
   const data = {
     title: $('#snippetExportModalTitle').val(),
@@ -1928,9 +1930,9 @@ $('#snippetExportModalConfirm').click(function () {
       }
     ],
     visibility:
-      $('#snippetExportModalVisibility').val() === '0'
+      visibilityValue === '0'
         ? 'private'
-        : $('#snippetExportModalVisibility').val() === '10'
+        : visibilityValue === '10'
           ? 'internal'
           : 'private'
   }
@@ -1939,10 +1941,10 @@ $('#snippetExportModalConfirm').click(function () {
     !data.title ||
     !data.files[0].file_path ||
     !data.files[0].content ||
-    !$('#snippetExportModalProjects').val()
+    !projectId
   ) { return }
   $('#snippetExportModalLoading').show()
-  const fullURL = `${baseURL}/api/${version}/projects/${$('#snippetExportModalProjects').val()}/snippets?access_token=${accesstoken}`
+  const fullURL = `${baseURL}/api/${version}/projects/${projectId}/snippets?access_token=${accesstoken}`
   $.ajax(fullURL, {
     data: JSON.stringify(data),
     contentType: 'application/json',

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1921,9 +1921,12 @@ $('#snippetExportModalConfirm').click(function () {
 
   const data = {
     title: $('#snippetExportModalTitle').val(),
-    file_name: $('#snippetExportModalFileName').val(),
-    code: editor.getValue(),
-    visibility_level: $('#snippetExportModalVisibility').val(),
+    files: [
+      {
+        file_path: $('#snippetExportModalFileName').val(),
+        content: editor.getValue()
+      }
+    ],
     visibility:
       $('#snippetExportModalVisibility').val() === '0'
         ? 'private'
@@ -1934,40 +1937,27 @@ $('#snippetExportModalConfirm').click(function () {
 
   if (
     !data.title ||
-    !data.file_name ||
-    !data.code ||
-    !data.visibility_level ||
+    !data.files[0].file_path ||
+    !data.files[0].content ||
     !$('#snippetExportModalProjects').val()
   ) { return }
   $('#snippetExportModalLoading').show()
-  const fullURL =
-    baseURL +
-    '/api/' +
-    version +
-    '/projects/' +
-    $('#snippetExportModalProjects').val() +
-    '/snippets?access_token=' +
-    accesstoken
-  $.post(fullURL, data, function (ret) {
-    $('#snippetExportModalLoading').hide()
-    $('#snippetExportModal').modal('hide')
-    const redirect =
-      baseURL +
-      '/' +
-      $(
-        "#snippetExportModalProjects option[value='" +
-          $('#snippetExportModalProjects').val() +
-          "']"
-      ).text() +
-      '/snippets/' +
-      ret.id
-    showMessageModal(
-      '<i class="fa fa-gitlab"></i> Export to Snippet',
-      'Export Successful!',
-      redirect,
-      'View Snippet Here',
-      true
-    )
+  const fullURL = `${baseURL}/api/${version}/projects/${$('#snippetExportModalProjects').val()}/snippets?access_token=${accesstoken}`
+  $.ajax(fullURL, {
+    data: JSON.stringify(data),
+    contentType: 'application/json',
+    type: 'POST',
+    success: function (ret) {
+      $('#snippetExportModalLoading').hide()
+      $('#snippetExportModal').modal('hide')
+      showMessageModal(
+        '<i class="fa fa-gitlab"></i> Export to Snippet',
+        'Export Successful!',
+        ret.web_url,
+        'View Snippet Here',
+        true
+      )
+    }
   })
 })
 

--- a/test/csp.js
+++ b/test/csp.js
@@ -29,6 +29,9 @@ describe('Content security policies', function () {
       },
       dropbox: {
         appKey: undefined
+      },
+      gitlab: {
+        baseURL: undefined
       }
     }
   })


### PR DESCRIPTION
### Component/Part
editor -> GitLab snippet export

### Description
This PR fixes the GitLab snippet export.
The snippet export broke due to two reasons.
First of all, the request to GitLab fail in the default configuration due to the CSP not being set properly. This commit adds the configured GitLab base url to the connect-src directives. The second problem is a change in the GitLab API spec. Instead of `code` and `file_name` the GitLab API now requires an `files` array with `content` and `file_path` entries per snippet.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #2208 
