### PR TITLE
Fix missing inline authorship colors

### DIFF
--- a/public/.eslintrc.js
+++ b/public/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
     FilePicker: false,
     ot: false,
     MediaUploader: false,
-    hex2rgb: false,
     num_loaded: false,
     Visibility: false,
     inlineAttachment: false

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -6,6 +6,7 @@
 - Fix error that Libravatar user avatars were not shown when using OAuth2 login
 - Fix `bin/manage_users` not accepting numeric passwords (thanks to [@carr0t2](https://github.com/carr0t2) for reporting)
 - Fix visibility of modals for screen readers
+- Fix missing inline authorship colors (thanks to [@EBendinelli](https://github.com/EBendinelli) for reporting)
 
 ### Enhancements
 - Libravatar avatars render as ident-icons when no avatar image was uploaded to Libravatar or Gravatar

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,7 +1,7 @@
 /* eslint-env browser, jquery */
 /* eslint no-console: ["error", { allow: ["warn", "error", "debug"] }] */
 /* global Cookies, moment, serverurl,
-   key, Dropbox, hex2rgb, Visibility */
+   key, Dropbox, Visibility */
 
 import TurndownService from 'turndown'
 import CodeMirror from 'codemirror/lib/codemirror.js'
@@ -14,6 +14,7 @@ import Idle from 'Idle.Js'
 import '../vendor/jquery-textcomplete/jquery.textcomplete'
 
 import { ot } from '../vendor/ot/ot.min.js'
+import hex2rgb from '../vendor/ot/hex2rgb'
 
 import { saveAs } from 'file-saver'
 import randomColor from 'randomcolor'

--- a/public/vendor/ot/hex2rgb.js
+++ b/public/vendor/ot/hex2rgb.js
@@ -1,0 +1,17 @@
+function hex2rgb (hex) {
+  if (hex[0] == '#') hex = hex.substr(1)
+  if (hex.length == 3) {
+    var temp = hex
+    hex = ''
+    temp = /^([a-f0-9])([a-f0-9])([a-f0-9])$/i.exec(temp).slice(1)
+    for (var i = 0; i < 3; i++) hex += temp[i] + temp[i]
+  }
+  var triplets = /^([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})$/i.exec(hex).slice(1)
+  return {
+    red: parseInt(triplets[0], 16),
+    green: parseInt(triplets[1], 16),
+    blue: parseInt(triplets[2], 16)
+  }
+}
+
+module.exports = hex2rgb


### PR DESCRIPTION
### Component/Part
Frontend JS

### Description
The `hex2rgb` function seems to previously have been available globally.
It probably got lost in the great Webpack refactoring and nobody noticed
 that.

This copies the function into its own file (to make importing it easy)
 and adds an import in index.js.

Fixes https://github.com/hedgedoc/hedgedoc/issues/2248

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
(https://github.com/hedgedoc/hedgedoc/issues/2248)
