### PR TITLE
fix(console-logger): don't sanitize colors away

### DIFF
--- a/src/logger/console-logger.service.ts
+++ b/src/logger/console-logger.service.ts
@@ -119,11 +119,11 @@ export class ConsoleLoggerService implements LoggerService {
   ): void {
     let output;
     if (isObject(message)) {
-      output = ConsoleLoggerService.sanitize(
-        `${color('Object:')}\n${JSON.stringify(message, null, 2)}\n`,
-      );
+      output = `${color('Object:')}\n${ConsoleLoggerService.sanitize(
+        JSON.stringify(message, null, 2),
+      )}\n`;
     } else {
-      output = ConsoleLoggerService.sanitize(color(message as string));
+      output = color(ConsoleLoggerService.sanitize(message as string));
     }
 
     const localeStringOptions: DateTimeFormatOptions = {


### PR DESCRIPTION
### Component/Part
logging

### Description
2467b125 mistakenly applied the sanitize function
to the log messages *after* the color was applied.

This PR reverses the order to un-break colored logs.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
