### PR TITLE
fix(notes): primaryAddress reveals internal UUID

### DIFF
--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -331,7 +331,7 @@ export class NotesService {
           await note.aliases
         ).map((alias) => this.aliasService.toAliasDto(alias, note)),
       ),
-      primaryAddress: (await getPrimaryAlias(note)) ?? note.id,
+      primaryAddress: (await getPrimaryAlias(note)) ?? note.publicId,
       title: note.title ?? '',
       createdAt: note.createdAt,
       description: note.description ?? '',


### PR DESCRIPTION
### Component/Part
notes metadata API

### Description
The primaryAddress field of a note contained the internal UUID of the note when no primary alias was defined instead of the public note id.
This PR fixes that by changing the exposed field.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
