### PR TITLE
Refactor NoteService unit tests

### DIFF
--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -483,6 +483,11 @@ describe('NotesService', () => {
       expect(metadataDto.updateUsername).toEqual(user.username);
       expect(metadataDto.viewCount).toEqual(note.viewCount);
     });
+    it('returns publicId if no alias exists', async () => {
+      const [note, ,] = await getMockData();
+      const metadataDto = await service.toNoteMetadataDto(note);
+      expect(metadataDto.primaryAddress).toEqual(note.publicId);
+    });
   });
 
   describe('toNoteDto', () => {


### PR DESCRIPTION
### Description
This PR moves common mocking code into one function and adds a new test `toNoteMetadataDto`, checking that it returns the publicId when no aliases are present.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
