### PR TITLE
Actually use configured database

### DIFF
--- a/docs/content/config/index.md
+++ b/docs/content/config/index.md
@@ -55,15 +55,14 @@ We officially support and test these databases:
 - PostgreSQL
 - MariaDB
 
-| environment variable   | default | example             | description                                                                                   |
-|------------------------|---------|---------------------|-----------------------------------------------------------------------------------------------|
-| `HD_DATABASE_DIALECT`  | -       | `postgres`          | The database dialect you want to use. This can be `postgres`, `mysql`, `mariadb` or `sqlite`. |
-| `HD_DATABASE_HOST`     | -       | `db.example.com`    | The host, where the database runs. *Only if you're **not** using `sqlite`.*                   |
-| `HD_DATABASE_PORT`     | -       | `5432`              | The port, where the database runs. *Only if you're **not** using `sqlite`.*                   |
-| `HD_DATABASE_NAME`     | -       | `hedgedoc`          | The name of the database to use. *Only if you're **not** using `sqlite`.*                     |
-| `HD_DATABASE_USER`     | -       | `hedgedoc`          | The user that logs in the database. *Only if you're **not** using `sqlite`.*                   |
-| `HD_DATABASE_PASS`     | -       | `password`          | The password to log into the database. *Only if you're **not** using `sqlite`.*               |
-| `HD_DATABASE_STORAGE`  | -       | `./hedgedoc.sqlite` | The location of the database file. *Only if you're using `sqlite`.*                           |
+| environment variable  | default | example             | description                                                                                |
+|-----------------------|---------|---------------------|--------------------------------------------------------------------------------------------|
+| `HD_DATABASE_TYPE`    | -       | `postgres`          | The database type you want to use. This can be `postgres`, `mysql`, `mariadb` or `sqlite`. |
+| `HD_DATABASE_NAME`    | -       | `hedgedoc`          | The name of the database to use. When using SQLite, this is the path to the database file. |
+| `HD_DATABASE_HOST`    | -       | `db.example.com`    | The host, where the database runs. *Only if you're **not** using `sqlite`.*                |
+| `HD_DATABASE_PORT`    | -       | `5432`              | The port, where the database runs. *Only if you're **not** using `sqlite`.*                |
+| `HD_DATABASE_USER`    | -       | `hedgedoc`          | The user that logs in the database. *Only if you're **not** using `sqlite`.*               |
+| `HD_DATABASE_PASS`    | -       | `password`          | The password to log into the database. *Only if you're **not** using `sqlite`.*            |
 
 ## External services
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,7 +17,7 @@ import appConfig from './config/app.config';
 import authConfig from './config/auth.config';
 import cspConfig from './config/csp.config';
 import customizationConfig from './config/customization.config';
-import databaseConfig from './config/database.config';
+import databaseConfig, { DatabaseConfig } from './config/database.config';
 import externalConfig from './config/external-services.config';
 import hstsConfig from './config/hsts.config';
 import mediaConfig from './config/media.config';
@@ -49,11 +49,21 @@ const routes: Routes = [
 @Module({
   imports: [
     RouterModule.forRoutes(routes),
-    TypeOrmModule.forRoot({
-      type: 'sqlite',
-      database: './hedgedoc.sqlite',
-      autoLoadEntities: true,
-      synchronize: true, // ToDo: Remove this before release
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [databaseConfig.KEY],
+      useFactory: (databaseConfig: DatabaseConfig) => {
+        return {
+          type: databaseConfig.type,
+          host: databaseConfig.host,
+          port: databaseConfig.port,
+          username: databaseConfig.username,
+          password: databaseConfig.password,
+          database: databaseConfig.database,
+          autoLoadEntities: true,
+          synchronize: true, // ToDo: Remove this before release
+        };
+      },
     }),
     ConfigModule.forRoot({
       load: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,6 +28,7 @@ import { GroupsModule } from './groups/groups.module';
 import { HistoryModule } from './history/history.module';
 import { IdentityModule } from './identity/identity.module';
 import { LoggerModule } from './logger/logger.module';
+import { TypeormLoggerService } from './logger/typeorm-logger.service';
 import { MediaModule } from './media/media.module';
 import { MonitoringModule } from './monitoring/monitoring.module';
 import { NotesModule } from './notes/notes.module';
@@ -50,9 +51,12 @@ const routes: Routes = [
   imports: [
     RouterModule.forRoutes(routes),
     TypeOrmModule.forRootAsync({
-      imports: [ConfigModule],
-      inject: [databaseConfig.KEY],
-      useFactory: (databaseConfig: DatabaseConfig) => {
+      imports: [ConfigModule, LoggerModule],
+      inject: [databaseConfig.KEY, TypeormLoggerService],
+      useFactory: (
+        databaseConfig: DatabaseConfig,
+        logger: TypeormLoggerService,
+      ) => {
         return {
           type: databaseConfig.type,
           host: databaseConfig.host,
@@ -62,6 +66,8 @@ const routes: Routes = [
           database: databaseConfig.database,
           autoLoadEntities: true,
           synchronize: true, // ToDo: Remove this before release
+          logging: true,
+          logger: logger,
         };
       },
     }),

--- a/src/config/database-type.enum.ts
+++ b/src/config/database-type.enum.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-export enum DatabaseDialect {
+export enum DatabaseType {
   POSTGRES = 'postgres',
   MYSQL = 'mysql',
   MARIADB = 'mariadb',

--- a/src/config/mock/database.config.mock.ts
+++ b/src/config/mock/database.config.mock.ts
@@ -5,18 +5,18 @@
  */
 import { registerAs } from '@nestjs/config';
 
-import { DatabaseDialect } from '../database-dialect.enum';
+import { DatabaseType } from '../database-type.enum';
 import { DatabaseConfig } from '../database.config';
 
 export default registerAs(
   'databaseConfig',
   (): DatabaseConfig => ({
-    dialect: (process.env.HEDGEDOC_TEST_DB_TYPE || 'sqlite') as DatabaseDialect,
+    type: (process.env.HEDGEDOC_TEST_DB_TYPE ||
+      DatabaseType.SQLITE) as DatabaseType,
     database: 'hedgedoc',
     password: 'hedgedoc',
     host: 'localhost',
     port: 0,
-    storage: '',
     username: 'hedgedoc',
   }),
 );

--- a/src/logger/console-logger.service.ts
+++ b/src/logger/console-logger.service.ts
@@ -23,6 +23,7 @@ import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
 export class ConsoleLoggerService implements LoggerService {
   private classContext: string | undefined;
   private lastTimestamp: number;
+  private skipColor = false;
 
   constructor(
     @Inject(appConfiguration.KEY)
@@ -34,6 +35,10 @@ export class ConsoleLoggerService implements LoggerService {
 
   setContext(context: string): void {
     this.classContext = context;
+  }
+
+  setSkipColor(skipColor: boolean): void {
+    this.skipColor = skipColor;
   }
 
   error(message: unknown, trace = '', functionContext?: string): void {
@@ -118,12 +123,22 @@ export class ConsoleLoggerService implements LoggerService {
     isTimeDiffEnabled?: boolean,
   ): void {
     let output;
-    if (isObject(message)) {
-      output = `${color('Object:')}\n${ConsoleLoggerService.sanitize(
-        JSON.stringify(message, null, 2),
-      )}\n`;
+
+    // if skipColor is set, we do not use colors and skip sanitizing
+    if (this.skipColor) {
+      if (isObject(message)) {
+        output = `${color('Object:')}\n${JSON.stringify(message, null, 2)}\n`;
+      } else {
+        output = message as string;
+      }
     } else {
-      output = color(ConsoleLoggerService.sanitize(message as string));
+      if (isObject(message)) {
+        output = `${color('Object:')}\n${ConsoleLoggerService.sanitize(
+          JSON.stringify(message, null, 2),
+        )}\n`;
+      } else {
+        output = color(ConsoleLoggerService.sanitize(message as string));
+      }
     }
 
     const localeStringOptions: DateTimeFormatOptions = {

--- a/src/logger/logger.module.ts
+++ b/src/logger/logger.module.ts
@@ -6,9 +6,10 @@
 import { Module } from '@nestjs/common';
 
 import { ConsoleLoggerService } from './console-logger.service';
+import { TypeormLoggerService } from './typeorm-logger.service';
 
 @Module({
-  providers: [ConsoleLoggerService],
-  exports: [ConsoleLoggerService],
+  providers: [ConsoleLoggerService, TypeormLoggerService],
+  exports: [ConsoleLoggerService, TypeormLoggerService],
 })
 export class LoggerModule {}

--- a/src/logger/typeorm-logger.service.ts
+++ b/src/logger/typeorm-logger.service.ts
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ *
+ * The code in this class is based on:
+ * https://github.com/typeorm/typeorm/blob/master/src/logger/AdvancedConsoleLogger.ts
+ */
+import { Injectable } from '@nestjs/common';
+import { Logger, QueryRunner } from 'typeorm';
+import { PlatformTools } from 'typeorm/platform/PlatformTools';
+
+import { ConsoleLoggerService } from './console-logger.service';
+
+@Injectable()
+export class TypeormLoggerService implements Logger {
+  constructor(private readonly logger: ConsoleLoggerService) {
+    this.logger.setContext('TypeORM');
+    this.logger.setSkipColor(true);
+  }
+
+  log(level: 'log' | 'info' | 'warn', message: unknown, _?: QueryRunner): void {
+    switch (level) {
+      case 'log':
+      case 'info':
+        this.logger.log(message);
+        break;
+      case 'warn':
+        this.logger.warn(message);
+    }
+  }
+
+  logMigration(message: string, _?: QueryRunner): void {
+    // eslint-disable-next-line local-rules/correct-logger-context
+    this.logger.log(message, 'migration');
+  }
+
+  logQuery(query: string, parameters?: unknown[], _?: QueryRunner): void {
+    const sql =
+      query +
+      (parameters && parameters.length
+        ? ' -- PARAMETERS: ' + this.stringifyParams(parameters)
+        : '');
+    // eslint-disable-next-line local-rules/correct-logger-context
+    this.logger.debug(PlatformTools.highlightSql(sql), 'query');
+  }
+
+  logQueryError(
+    error: string | Error,
+    query: string,
+    parameters?: unknown[],
+    _?: QueryRunner,
+  ): void {
+    const sql =
+      query +
+      (parameters && parameters.length
+        ? ` -- PARAMETERS: ${this.stringifyParams(parameters)}`
+        : '');
+    this.logger.debug(PlatformTools.highlightSql(sql));
+    // eslint-disable-next-line local-rules/correct-logger-context
+    this.logger.debug(error.toString(), 'queryError');
+  }
+
+  logQuerySlow(
+    time: number,
+    query: string,
+    parameters?: unknown[],
+    _?: QueryRunner,
+  ): void {
+    const sql =
+      query +
+      (parameters && parameters.length
+        ? ` -- PARAMETERS: ${this.stringifyParams(parameters)}`
+        : '');
+    /* eslint-disable local-rules/correct-logger-context */
+    this.logger.warn(PlatformTools.highlightSql(sql), 'querySlow');
+    this.logger.warn(`execution time: ${time}`, 'querySlow');
+    /* eslint-enable local-rules/correct-logger-context */
+  }
+
+  logSchemaBuild(message: string, _?: QueryRunner): void {
+    // eslint-disable-next-line local-rules/correct-logger-context
+    this.logger.debug(message, 'schemaBuild');
+  }
+
+  /**
+   * Converts parameters to a string.
+   * Sometimes parameters can have circular objects and therefore we are handle this case too.
+   */
+  protected stringifyParams(parameters: unknown[]): string {
+    try {
+      return JSON.stringify(parameters);
+    } catch (error) {
+      // most probably circular objects in parameters
+      return parameters.toString();
+    }
+  }
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -10,7 +10,7 @@ import session from 'express-session';
 import { Repository } from 'typeorm';
 
 import { AuthConfig } from '../config/auth.config';
-import { DatabaseDialect } from '../config/database-dialect.enum';
+import { DatabaseType } from '../config/database-type.enum';
 import { DatabaseConfig } from '../config/database.config';
 import { Session } from '../users/session.entity';
 
@@ -36,7 +36,7 @@ export function setupSessionMiddleware(
       saveUninitialized: false,
       store: new TypeormStore({
         cleanupLimit: 2,
-        limitSubquery: dbConfig.dialect !== DatabaseDialect.MARIADB,
+        limitSubquery: dbConfig.type !== DatabaseType.MARIADB,
       }).connect(app.get<Repository<Session>>(getRepositoryToken(Session))),
     }),
   );

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -33,8 +33,8 @@ describe('App', () => {
       })
       .overrideProvider(getConfigToken('databaseConfig'))
       .useValue({
-        storage: ':memory:',
-        dialect: 'sqlite',
+        database: ':memory:',
+        type: 'sqlite',
       })
       .overrideProvider(getConfigToken('authConfig'))
       .useValue({


### PR DESCRIPTION
### Component/Part
AppModule, logging, db config

### Description
This PR
- Uses the database from the config in `AppModule`
- Adapts our config options to follow TypeORM terminology
- Adds a logging adapter for TypeORM, which logs queries on the DEBUG level

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
