### PR TITLE
[1.x] Drop Node 12

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/bin/setup
+++ b/bin/setup
@@ -31,11 +31,11 @@ EOF
   exit 1
 fi
 
-if version_lt "$(node --version)" 'v12.0.0'; then
+if version_lt "$(node --version)" 'v14.13.1'; then
   cat << EOF
 FATAL: Your Node.js version is not supported.
 
-Please upgrade to version 12 or higher and try again.
+Please upgrade to version 14.13.1 or higher and try again.
 We recommend running the latest LTS release, see https://nodejs.org/en/about/releases/ for details.
 EOF
   exit 1

--- a/docs/content/setup/manual-setup.md
+++ b/docs/content/setup/manual-setup.md
@@ -1,7 +1,7 @@
 # Manual Installation
 
 !!! info "Requirements on your server"
-    - Node.js `>= 12.20.0`, `>= 14.13.1` or `>= 16`. We recommend you run HedgeDoc with the latest release of Node 16.
+    - Node.js `>= 14.13.1` or `>= 16`. We recommend you run HedgeDoc with the latest release of Node 16.
     - Database (PostgreSQL, MySQL, MariaDB, SQLite)  
       The database must use charset `utf8`. This is typically the default in PostgreSQL and SQLite.  
       In MySQL and MariaDB UTF-8 might need to be set with `alter database <DBNAME> character set utf8 collate utf8_bin;`  

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "xss": "^1.0.3"
   },
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || 16.x"
+    "node": "^14.13.1 || 16.x"
   },
   "bugs": "https://github.com/hedgedoc/hedgedoc/issues",
   "keywords": [

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## <i class="fa fa-tag"></i> 1.x.x <i class="fa fa-calendar-o"></i> UNRELEASED
+
+This release drops support for Node.js 12, as it has reached end-of-life.
+
+
 ## <i class="fa fa-tag"></i> 1.9.3 <i class="fa fa-calendar-o"></i> 2022-04-10
 
 This release fixes a security issue. We recommend upgrading as soon as possible.


### PR DESCRIPTION
### Component/Part
package metadata, setup script, docs

### Description
This PR drops support for Node 12
### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated tests
- [x] Added / updated documentation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
