### PR TITLE
[1.x] fix(migrations): Remove unexpected shell call

### DIFF
--- a/lib/migrations/20200321153000-fix-account-deletion.js
+++ b/lib/migrations/20200321153000-fix-account-deletion.js
@@ -3,7 +3,7 @@ const { spawnSync } = require('child_process')
 const path = require('path')
 module.exports = {
   up: function (queryInterface, Sequelize) {
-    const cleanup = spawnSync('./bin/cleanup', { cwd: path.resolve(__dirname, '../../') })
+    const cleanup = spawnSync(process.argv[0], ['./bin/cleanup'], { cwd: path.resolve(__dirname, '../../') })
     if (cleanup.status !== 0) {
       throw new Error('Unable to cleanup')
     }

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -2,6 +2,9 @@
 
 ## <i class="fa fa-tag"></i> 1.x.x <i class="fa fa-calendar-o"></i> UNRELEASED
 
+### Enhancements
+- Remove unexpected shell call during migrations
+
 This release drops support for Node.js 12, as it has reached end-of-life.
 
 


### PR DESCRIPTION
### Component/Part
migrations

### Description
This patch removes the call of `/usr/bin/env` when calling the migration
script in favour of using the processes own nodejs invocation path.

This should drop the requirement for `/usr/bin/env` to exist on a
system/in a container that runs hedgedoc.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Required for https://github.com/hedgedoc/container/pull/313
