### PR TITLE
Add PikaPods as additional deployment option.

### DIFF
--- a/docs/content/setup/pikapods.md
+++ b/docs/content/setup/pikapods.md
@@ -1,0 +1,6 @@
+# PikaPods Deployment
+
+[PikaPods](https://www.pikapods.com/) offers simple hosting for open source apps. Run HedgeDoc within seconds 
+using the button below. This will run the official Docker image from [quay.io](https://quay.io/repository/hedgedoc/hedgedoc).
+
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=hedgedoc)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
           - 'YunoHost App': setup/yunohost.md
           - 'Cloudron App': setup/cloudron.md
           - 'Arch Linux Package': setup/arch-linux.md
+          - 'PikaPods Hosting': setup/pikapods.md
   - Guides:
       - 'Reverse Proxy': guides/reverse-proxy.md
       - Authentication:


### PR DESCRIPTION
### Component/Part
Docs/install methods

### Description
This PR adds [PikaPods.com](https://www.pikapods.com/) as additional deployment option.

About PikaPods: Our mission is to make great open source apps, like HedgeDoc more accessible and easier to get started with. We already offer HedgeDoc in our “[app store](https://www.pikapods.com/apps#documentation)” after it was requested by users.

So I'm suggesting to add PikaPods as additional install option to run HedgeDoc. This would help an even wider audience to benefit from the project.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO. (cached a wrong name)
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
None