### PR TITLE
[Docs] Fix heroku missing logo and non-required env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     ],
     "website": "https://hedgedoc.org",
     "repository": "https://github.com/hedgedoc/hedgedoc",
-    "logo": "https://github.com/hedgedoc/hedgedoc/raw/master/public/hedgedoc-icon-1024.png",
+    "logo": "https://github.com/hedgedoc/hedgedoc-logo/raw/main/LOGOTYPE/PNG/HedgeDoc-Logo%201.png",
     "success_url": "/",
     "env": {
         "NPM_CONFIG_PRODUCTION": {
@@ -40,8 +40,8 @@
             "required": false
         },
         "CMD_DOMAIN": {
-            "description": "domain name",
-            "required": false
+            "description": "your instance domain, like `example.herokuapp.com`",
+            "required": true
         },
         "CMD_URL_PATH": {
             "description": "sub url path, like `www.example.com/<URL_PATH>`",


### PR DESCRIPTION
### Component/Part
Docs -> Setup -> Heroku

### Description
This PR fixes the wrong HedgeDoc logo URL in the heroku deployment and ensures that CMD_DOMAIN is set.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
closes #2293 
