### PR TITLE
fix(revision-service): fix count of duplicate authors

### DIFF
--- a/src/revisions/revisions.service.spec.ts
+++ b/src/revisions/revisions.service.spec.ts
@@ -163,4 +163,26 @@ describe('RevisionsService', () => {
       expect(revisions).toEqual(updatedRevisions);
     });
   });
+
+  describe('getRevisionUserInfo', () => {
+    it('counts users correctly', async () => {
+      const user = User.create('test', 'test') as User;
+      const author = Author.create(123) as Author;
+      author.user = Promise.resolve(user);
+      const anonAuthor = Author.create(123) as Author;
+      const anonAuthor2 = Author.create(123) as Author;
+      const edits = [Edit.create(author, 12, 15) as Edit];
+      edits.push(Edit.create(author, 16, 18) as Edit);
+      edits.push(Edit.create(author, 29, 20) as Edit);
+      edits.push(Edit.create(anonAuthor, 29, 20) as Edit);
+      edits.push(Edit.create(anonAuthor, 29, 20) as Edit);
+      edits.push(Edit.create(anonAuthor2, 29, 20) as Edit);
+      const revision = Revision.create('', '', {} as Note) as Revision;
+      revision.edits = Promise.resolve(edits);
+
+      const userInfo = await service.getRevisionUserInfo(revision);
+      expect(userInfo.usernames.length).toEqual(1);
+      expect(userInfo.anonymousUserCount).toEqual(2);
+    });
+  });
 });


### PR DESCRIPTION
### Component/Part
RevisionService

### Description
`getRevisionUserInfo` returned an incorrect list of usernames,
as users who edited a note at multiple places appeared multiple times.

This PR fixes this behavior by deduplicating the author
  objects using a Set.

  Closes #2180


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
