### PR TITLE
Remove circular dependencies from note, revision and alias service

### DIFF
--- a/src/notes/forbidden-note-id-or-alias.service.spec.ts
+++ b/src/notes/forbidden-note-id-or-alias.service.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import appConfigMock from '../config/mock/app.config.mock';
+import noteConfigMock from '../config/mock/note.config.mock';
+import { ForbiddenIdError } from '../errors/errors';
+import { LoggerModule } from '../logger/logger.module';
+import { ForbiddenNoteIdOrAliasService } from './forbidden-note-id-or-alias.service';
+
+describe('ForbiddenNoteIdOrAliasService', () => {
+  it('crashes if an id is forbidden', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ForbiddenNoteIdOrAliasService],
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [appConfigMock, noteConfigMock],
+        }),
+        LoggerModule,
+      ],
+    }).compile();
+
+    const forbiddenNoteIdOrAliasService: ForbiddenNoteIdOrAliasService =
+      module.get<ForbiddenNoteIdOrAliasService>(ForbiddenNoteIdOrAliasService);
+    const config = module.get<ConfigService>(ConfigService);
+    const forbiddenNoteId = config.get('noteConfig').forbiddenNoteIds[0];
+
+    expect(() =>
+      forbiddenNoteIdOrAliasService.isForbiddenNoteIdOrAlias(forbiddenNoteId),
+    ).toThrow(ForbiddenIdError);
+  });
+});

--- a/src/notes/forbidden-note-id-or-alias.service.ts
+++ b/src/notes/forbidden-note-id-or-alias.service.ts
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { Inject, Injectable } from '@nestjs/common';
+
+import noteConfiguration, { NoteConfig } from '../config/note.config';
+import { ForbiddenIdError } from '../errors/errors';
+import { ConsoleLoggerService } from '../logger/console-logger.service';
+
+@Injectable()
+export class ForbiddenNoteIdOrAliasService {
+  constructor(
+    private readonly logger: ConsoleLoggerService,
+    @Inject(noteConfiguration.KEY)
+    private noteConfig: NoteConfig,
+  ) {}
+
+  /**
+   * Check if the provided note id or alias is forbidden
+   *
+   * @param noteIdOrAlias - the alias or id in question
+   * @throws {ForbiddenIdError} the requested id or alias is forbidden
+   */
+  isForbiddenNoteIdOrAlias(noteIdOrAlias: string): void {
+    if (this.noteConfig.forbiddenNoteIds.includes(noteIdOrAlias)) {
+      this.logger.debug(
+        `A note with the alias '${noteIdOrAlias}' is forbidden by the administrator.`,
+        'isForbiddenNoteIdOrAlias',
+      );
+      throw new ForbiddenIdError(
+        `A note with the alias '${noteIdOrAlias}' is forbidden by the administrator.`,
+      );
+    }
+  }
+}

--- a/src/notes/notes.module.ts
+++ b/src/notes/notes.module.ts
@@ -16,6 +16,7 @@ import { User } from '../users/user.entity';
 import { UsersModule } from '../users/users.module';
 import { Alias } from './alias.entity';
 import { AliasService } from './alias.service';
+import { ForbiddenNoteIdOrAliasService } from './forbidden-note-id-or-alias.service';
 import { Note } from './note.entity';
 import { NotesService } from './notes.service';
 import { Tag } from './tag.entity';
@@ -37,7 +38,7 @@ import { Tag } from './tag.entity';
     ConfigModule,
   ],
   controllers: [],
-  providers: [NotesService, AliasService],
-  exports: [NotesService, AliasService],
+  providers: [NotesService, AliasService, ForbiddenNoteIdOrAliasService],
+  exports: [NotesService, AliasService, ForbiddenNoteIdOrAliasService],
 })
 export class NotesModule {}

--- a/src/revisions/revisions.service.ts
+++ b/src/revisions/revisions.service.ts
@@ -3,14 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { NotInDBError } from '../errors/errors';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
 import { Note } from '../notes/note.entity';
-import { NotesService } from '../notes/notes.service';
 import { EditService } from './edit.service';
 import { RevisionMetadataDto } from './revision-metadata.dto';
 import { RevisionDto } from './revision.dto';
@@ -27,7 +26,6 @@ export class RevisionsService {
     private readonly logger: ConsoleLoggerService,
     @InjectRepository(Revision)
     private revisionRepository: Repository<Revision>,
-    @Inject(forwardRef(() => NotesService)) private notesService: NotesService,
     private editService: EditService,
   ) {
     this.logger.setContext(RevisionsService.name);


### PR DESCRIPTION
### Component/Part
Notes, revision and alias service

### Description
This PR eliminates circular dependencies from some services by deleting unused injections and extraction of code.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
