### PR TITLE
refactor(media-apis): Implement a decorator to convert header to Note instance

### DIFF
--- a/src/api/private/media/media.controller.ts
+++ b/src/api/private/media/media.controller.ts
@@ -6,7 +6,6 @@
 import {
   Controller,
   Delete,
-  Headers,
   Param,
   Post,
   UploadedFile,
@@ -25,7 +24,9 @@ import { MulterFile } from '../../../media/multer-file.interface';
 import { Note } from '../../../notes/note.entity';
 import { NotesService } from '../../../notes/notes.service';
 import { User } from '../../../users/user.entity';
+import { NoteHeaderInterceptor } from '../../utils/note-header.interceptor';
 import { OpenApi } from '../../utils/openapi.decorator';
+import { RequestNote } from '../../utils/request-note.decorator';
 import { RequestUser } from '../../utils/request-user.decorator';
 
 @UseGuards(SessionGuard)
@@ -59,6 +60,7 @@ export class MediaController {
     description: 'ID or alias of the parent note',
   })
   @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(NoteHeaderInterceptor)
   @OpenApi(
     {
       code: 201,
@@ -72,13 +74,11 @@ export class MediaController {
   )
   async uploadMedia(
     @UploadedFile() file: MulterFile,
-    @Headers('HedgeDoc-Note') noteId: string,
+    @RequestNote() note: Note,
     @RequestUser() user: User,
   ): Promise<MediaUploadDto> {
-    // TODO: Move getting the Note object into a decorator
-    const note: Note = await this.noteService.getNoteByIdOrAlias(noteId);
     this.logger.debug(
-      `Recieved filename '${file.originalname}' for note '${noteId}' from user '${user.username}'`,
+      `Recieved filename '${file.originalname}' for note '${note.id}' from user '${user.username}'`,
       'uploadMedia',
     );
     const upload = await this.mediaService.saveFile(file.buffer, user, note);

--- a/src/api/public/media/media.controller.ts
+++ b/src/api/public/media/media.controller.ts
@@ -6,7 +6,6 @@
 import {
   Controller,
   Delete,
-  Headers,
   Param,
   Post,
   UploadedFile,
@@ -31,7 +30,9 @@ import { MulterFile } from '../../../media/multer-file.interface';
 import { Note } from '../../../notes/note.entity';
 import { NotesService } from '../../../notes/notes.service';
 import { User } from '../../../users/user.entity';
+import { NoteHeaderInterceptor } from '../../utils/note-header.interceptor';
 import { OpenApi } from '../../utils/openapi.decorator';
+import { RequestNote } from '../../utils/request-note.decorator';
 import { RequestUser } from '../../utils/request-user.decorator';
 
 @UseGuards(TokenAuthGuard)
@@ -77,15 +78,14 @@ export class MediaController {
     500,
   )
   @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(NoteHeaderInterceptor)
   async uploadMedia(
     @RequestUser() user: User,
     @UploadedFile() file: MulterFile,
-    @Headers('HedgeDoc-Note') noteId: string,
+    @RequestNote() note: Note,
   ): Promise<MediaUploadDto> {
-    // TODO: Move getting the Note object into a decorator
-    const note: Note = await this.noteService.getNoteByIdOrAlias(noteId);
     this.logger.debug(
-      `Recieved filename '${file.originalname}' for note '${noteId}' from user '${user.username}'`,
+      `Recieved filename '${file.originalname}' for note '${note.id}' from user '${user.username}'`,
       'uploadMedia',
     );
     const upload = await this.mediaService.saveFile(file.buffer, user, note);

--- a/src/api/utils/note-header.interceptor.ts
+++ b/src/api/utils/note-header.interceptor.ts
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { Observable } from 'rxjs';
+
+import { Note } from '../../notes/note.entity';
+import { NotesService } from '../../notes/notes.service';
+
+/**
+ * Saves the note identified by the `HedgeDoc-Note` header
+ * under the `note` property of the request object.
+ */
+@Injectable()
+export class NoteHeaderInterceptor implements NestInterceptor {
+  constructor(private noteService: NotesService) {}
+
+  async intercept<T>(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<T>> {
+    const request: Request & {
+      note: Note;
+    } = context.switchToHttp().getRequest();
+    const noteId: string = request.headers['hedgedoc-note'] as string;
+    request.note = await this.noteService.getNoteByIdOrAlias(noteId);
+    return next.handle();
+  }
+}


### PR DESCRIPTION
### Component/Part
Media APIs routes (both private and public)

### Description
This PR is a refactor in the upload file routes. I have followed the issue comments (https://github.com/hedgedoc/hedgedoc/issues/1594#issuecomment-942629384) so I added a guard to find the related note to a new uploaded file and call it in both routes.

Its my first contribution in this project so please help me if I am doing something in a wrong way.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
https://github.com/hedgedoc/hedgedoc/issues/1594
