### PR TITLE
chore: add .gitignore to docs

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# virtualenv
+venv/
+ENV/
+
+# Build files
+/build
+/MANIFEST
+/site


### PR DESCRIPTION
### Component/Part
docs

### Description
This PR add a gitignore files in the docs directory.

This prevents common folders used in the documentation process to be
considered by git.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

