### PR TITLE
Extract common app setup code

### DIFF
--- a/src/app-init.ts
+++ b/src/app-init.ts
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { HttpAdapterHost } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
+
+import { AppConfig } from './config/app.config';
+import { AuthConfig } from './config/auth.config';
+import { DatabaseConfig } from './config/database.config';
+import { MediaConfig } from './config/media.config';
+import { ErrorExceptionMapping } from './errors/error-mapping';
+import { ConsoleLoggerService } from './logger/console-logger.service';
+import { BackendType } from './media/backends/backend-type.enum';
+import { setupSpecialGroups } from './utils/createSpecialGroups';
+import { setupFrontendProxy } from './utils/frontend-integration';
+import { setupSessionMiddleware } from './utils/session';
+import { setupValidationPipe } from './utils/setup-pipes';
+import { setupPrivateApiDocs, setupPublicApiDocs } from './utils/swagger';
+
+/**
+ * Common setup function which is called by main.ts and the E2E tests.
+ */
+export async function setupApp(
+  app: NestExpressApplication,
+  appConfig: AppConfig,
+  authConfig: AuthConfig,
+  databaseConfig: DatabaseConfig,
+  mediaConfig: MediaConfig,
+  logger: ConsoleLoggerService,
+): Promise<void> {
+  setupPublicApiDocs(app);
+  logger.log(
+    `Serving OpenAPI docs for public api under '/apidoc'`,
+    'AppBootstrap',
+  );
+
+  if (process.env.NODE_ENV === 'development') {
+    setupPrivateApiDocs(app);
+    logger.log(
+      `Serving OpenAPI docs for private api under '/private/apidoc'`,
+      'AppBootstrap',
+    );
+
+    await setupFrontendProxy(app, logger);
+  }
+
+  await setupSpecialGroups(app);
+
+  setupSessionMiddleware(app, authConfig, databaseConfig);
+
+  app.enableCors({
+    origin: appConfig.rendererOrigin,
+  });
+  logger.log(`Enabling CORS for '${appConfig.rendererOrigin}'`, 'AppBootstrap');
+
+  app.useGlobalPipes(setupValidationPipe(logger));
+
+  if (mediaConfig.backend.use === BackendType.FILESYSTEM) {
+    logger.log(
+      `Serving the local folder '${mediaConfig.backend.filesystem.uploadPath}' under '/uploads'`,
+      'AppBootstrap',
+    );
+    app.useStaticAssets(mediaConfig.backend.filesystem.uploadPath, {
+      prefix: '/uploads/',
+    });
+  }
+
+  logger.log(
+    `Serving the local folder 'public' under '/public'`,
+    'AppBootstrap',
+  );
+  app.useStaticAssets('public', {
+    prefix: '/public/',
+  });
+
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  app.useGlobalFilters(new ErrorExceptionMapping(httpAdapter));
+}

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -12,14 +12,17 @@ import { Connection, createConnection } from 'typeorm';
 
 import { PrivateApiModule } from '../src/api/private/private-api.module';
 import { PublicApiModule } from '../src/api/public/public-api.module';
+import { setupApp } from '../src/app-init';
 import { AuthTokenWithSecretDto } from '../src/auth/auth-token.dto';
 import { AuthModule } from '../src/auth/auth.module';
 import { AuthService } from '../src/auth/auth.service';
 import { MockAuthGuard } from '../src/auth/mock-auth.guard';
 import { TokenAuthGuard } from '../src/auth/token.strategy';
 import { AuthorsModule } from '../src/authors/authors.module';
+import { AppConfig } from '../src/config/app.config';
 import { AuthConfig } from '../src/config/auth.config';
 import { DatabaseConfig } from '../src/config/database.config';
+import { MediaConfig } from '../src/config/media.config';
 import appConfigMock from '../src/config/mock/app.config.mock';
 import authConfigMock from '../src/config/mock/auth.config.mock';
 import customizationConfigMock from '../src/config/mock/customization.config.mock';
@@ -50,8 +53,6 @@ import { RevisionsModule } from '../src/revisions/revisions.module';
 import { User } from '../src/users/user.entity';
 import { UsersModule } from '../src/users/users.module';
 import { UsersService } from '../src/users/users.service';
-import { setupSessionMiddleware } from '../src/utils/session';
-import { setupValidationPipe } from '../src/utils/setup-pipes';
 
 export class TestSetup {
   moduleRef: TestingModule;
@@ -271,15 +272,13 @@ export class TestSetupBuilder {
 
     this.testSetup.app = this.testSetup.moduleRef.createNestApplication();
 
-    setupSessionMiddleware(
+    await setupApp(
       this.testSetup.app,
+      this.testSetup.configService.get<AppConfig>('appConfig'),
       this.testSetup.configService.get<AuthConfig>('authConfig'),
       this.testSetup.configService.get<DatabaseConfig>('databaseConfig'),
-    );
-    this.testSetup.app.useGlobalPipes(
-      setupValidationPipe(
-        await this.testSetup.app.resolve(ConsoleLoggerService),
-      ),
+      this.testSetup.configService.get<MediaConfig>('mediaConfig'),
+      await this.testSetup.app.resolve(ConsoleLoggerService),
     );
 
     for (const setupFunction of this.setupPostCompile) {


### PR DESCRIPTION
### Component/Part
App bootstrap/E2E tests

### Description
This allows the E2E tests and the real app to share the same setup.

Fixes #2083

### Steps


- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
