### PR TITLE
test(e2e/app): disable debug logging

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -19,7 +19,6 @@ describe('App', () => {
       .useValue({
         domain: 'localhost',
         port: 3333,
-        loglevel: 'debug',
       })
       .overrideProvider(getConfigToken('mediaConfig'))
       .useValue({


### PR DESCRIPTION


### Component/Part
E2E test of the `AppModule`

### Description
Debug logging seems to have been left enabled accidentally
and is very spammy.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
