### PR TITLE
doc: fix socket.io reverse-proxy

### DIFF
--- a/docs/content/guides/reverse-proxy.md
+++ b/docs/content/guides/reverse-proxy.md
@@ -64,7 +64,7 @@ server {
         server_name hedgedoc.example.com;
 
         location / {
-                proxy_pass http://127.0.0.1:3000;
+                proxy_pass http://127.0.0.1:3000/;
                 proxy_set_header Host $host; 
                 proxy_set_header X-Real-IP $remote_addr; 
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; 
@@ -72,7 +72,7 @@ server {
         }
 
         location /socket.io/ {
-                proxy_pass http://127.0.0.1:3000;
+                proxy_pass http://127.0.0.1:3000/socket.io/;
                 proxy_set_header Host $host; 
                 proxy_set_header X-Real-IP $remote_addr; 
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; 


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
I tried it without and it did not work. So I guess the documentation has a little problem.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ ] Added implementation
- [ ] Added / updated tests
- [x] Added / updated documentation
- [ ] Added changelog snippet
- [ ] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
