### PR TITLE
docs: fixed link to history writeup on index page

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -8,13 +8,14 @@ it by visiting our [HedgeDoc demo server][hedgedoc-demo].
 
 It is inspired by Hackpad, Etherpad and similar collaborative editors. This
 project originated with the team at [HackMD](https://hackmd.io) and now forked
-into its own organization. [A longer write-up can be read in the history doc](history.md) or [you can have a look at an explanatory graph over at our website][hedgedoc-history].
+into its own organization. [A longer write-up can be read in the history doc](hedgedoc-history-details) or [you can have a look at an explanatory graph over at our website][hedgedoc-history].
 
 If you have any questions that aren't answered here, feel free to ask us on [Matrix][matrix.org-url], stop by our [community forums][hedgedoc-community] or have a look at our [FAQ][hedgedoc-faq].
 
 
 [hedgedoc-demo]: https://demo.hedgedoc.org
 [hedgedoc-history]: https://hedgedoc.org/history
+[hedgedoc-history-details]: https://hedgedoc.org/history/details
 [hedgedoc-faq]: /faq
 [matrix.org-url]: https://chat.hedgedoc.org
 [hedgedoc-community]: https://community.hedgedoc.org


### PR DESCRIPTION
### Component/Part
docs.

### Description
This PR fixes the link on the start page of the docs.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
