### PR TITLE
feat(private-api): add get note metadata call

### DIFF
--- a/src/api/private/notes/notes.controller.ts
+++ b/src/api/private/notes/notes.controller.ts
@@ -20,6 +20,7 @@ import { SessionGuard } from '../../../identity/session.guard';
 import { ConsoleLoggerService } from '../../../logger/console-logger.service';
 import { MediaUploadDto } from '../../../media/media-upload.dto';
 import { MediaService } from '../../../media/media.service';
+import { NoteMetadataDto } from '../../../notes/note-metadata.dto';
 import { NoteDto } from '../../../notes/note.dto';
 import { Note } from '../../../notes/note.entity';
 import { NoteMediaDeletionDto } from '../../../notes/note.media-deletion.dto';
@@ -125,6 +126,16 @@ export class NotesController {
     await this.noteService.deleteNote(note);
     this.logger.debug('Successfully deleted ' + note.id, 'deleteNote');
     return;
+  }
+
+  @UseInterceptors(GetNoteInterceptor)
+  @Permissions(Permission.READ)
+  @Get(':noteIdOrAlias/metadata')
+  async getNoteMetadata(
+    @RequestUser() user: User,
+    @RequestNote() note: Note,
+  ): Promise<NoteMetadataDto> {
+    return await this.noteService.toNoteMetadataDto(note);
   }
 
   @Get(':noteIdOrAlias/revisions')

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -316,6 +316,8 @@ describe('Notes', () => {
       );
       // save the creation time
       const createDate = note.createdAt;
+      const revisions = await note.revisions;
+      const updatedDate = revisions[revisions.length - 1].createdAt;
       // wait one second
       await new Promise((r) => setTimeout(r, 1000));
       // update the note
@@ -324,7 +326,7 @@ describe('Notes', () => {
         .get('/api/v2/notes/test5a/metadata')
         .expect(200);
       expect(metadata.body.createdAt).toEqual(createDate.toISOString());
-      expect(metadata.body.updateTime).not.toEqual(createDate.toISOString());
+      expect(metadata.body.updatedAt).not.toEqual(updatedDate.toISOString());
     });
   });
 


### PR DESCRIPTION
### Component/Part
private api

### Description
This PR adds a get note metadata call to the private api.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #2478 
