### PR TITLE
Fix crash in LDAP authentication

### DIFF
--- a/lib/web/auth/ldap/index.js
+++ b/lib/web/auth/ldap/index.js
@@ -8,18 +8,22 @@ const models = require('../../../models')
 const logger = require('../../../logger')
 const { urlencodedParser } = require('../../utils')
 const errors = require('../../../errors')
+const { cloneDeep } = require('lodash')
 
 const ldapAuth = module.exports = Router()
 
+// ldapauth-fork mutates the config object, so we need to make a clone of our deep-frozen config
+const mutableLdapConfig = cloneDeep(config.ldap)
+
 passport.use(new LDAPStrategy({
   server: {
-    url: config.ldap.url || null,
-    bindDN: config.ldap.bindDn || null,
-    bindCredentials: config.ldap.bindCredentials || null,
-    searchBase: config.ldap.searchBase || null,
-    searchFilter: config.ldap.searchFilter || null,
-    searchAttributes: config.ldap.searchAttributes || null,
-    tlsOptions: config.ldap.tlsOptions || null
+    url: mutableLdapConfig.url || null,
+    bindDN: mutableLdapConfig.bindDn || null,
+    bindCredentials: mutableLdapConfig.bindCredentials || null,
+    searchBase: mutableLdapConfig.searchBase || null,
+    searchFilter: mutableLdapConfig.searchFilter || null,
+    searchAttributes: mutableLdapConfig.searchAttributes || null,
+    tlsOptions: mutableLdapConfig.tlsOptions || null
   }
 }, function (user, done) {
   let uuid = user.uidNumber || user.uid || user.sAMAccountName || undefined

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -5,7 +5,7 @@
 - Add dark mode toggle in mobile view
 
 ### Bugfixes
-
+- Fix a crash when using LDAP authentication with custom search attributes (thanks to [@aboettger-tuhh](https://github.com/aboettger-tuhh) for reporting)
 
 ## <i class="fa fa-tag"></i> 1.9.4 <i class="fa fa-calendar-o"></i> 2022-07-10
 


### PR DESCRIPTION
### Component/Part
LDAP authentication

### Description
Since https://github.com/vesse/node-ldapauth-fork/commit/741a648df98d789856b3301d65103b74872fdeea, ldapauth-fork calls `push` on the attributes array.

Since we deep-freeze our config object in https://github.com/hedgedoc/hedgedoc/blob/master/lib/config/index.js#L200, this causes a crash when the config includes custom `searchAttributes`.

This commit fixes the crash by creating a mutable clone of the LDAP
config and passing that to the LDAP strategy.

Fixes https://github.com/hedgedoc/hedgedoc/issues/2561

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
https://github.com/hedgedoc/hedgedoc/issues/2561
