### PR TITLE
Add dark mode toggle in mobile view

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -1,4 +1,11 @@
 # Release Notes
+## <i class="fa fa-tag"></i> 1.x.x <i class="fa fa-calendar-o"></i> UNRELEASED
+
+### Enhancements
+- Add dark mode toggle in mobile view
+
+### Bugfixes
+
 
 ## <i class="fa fa-tag"></i> 1.9.4 <i class="fa fa-calendar-o"></i> 2022-07-10
 

--- a/public/views/hedgedoc/header.ejs
+++ b/public/views/hedgedoc/header.ejs
@@ -70,6 +70,11 @@
                 <li role="presentation"><a role="menuitem" class="ui-help" href="#" data-toggle="modal" data-target=".help-modal"><i class="fa fa-question-circle fa-fw"></i> Help</a>
                 </li>
             </ul>
+            <div class="btn-group" data-toggle="buttons">
+                <label class="btn ui-night" title="<%= __('Night Theme') %>">
+                    <input type="checkbox" name="night"><i class="fa fa-moon-o"></i>
+                </label>
+            </div>
             <a class="btn btn-link ui-mode">
                 <i class="fa fa-pencil"></i>
             </a>


### PR DESCRIPTION
### Component/Part
editor view

### Description
This PR adds a dark mode toggle for the mobile editor view.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #2534
