### PR TITLE
Replace embedding regex with more specific ones

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -3,6 +3,7 @@
 
 ### Enhancements
 - Add dark mode toggle in mobile view
+- Replace embedding shortcode regexes with more specific ones to safeguard against xss attacks
 
 ### Bugfixes
 - Fix a crash when using LDAP authentication with custom search attributes (thanks to [@aboettger-tuhh](https://github.com/aboettger-tuhh) for reporting)

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1119,7 +1119,7 @@ md.renderer.rules.fence = (tokens, idx, options, env, self) => {
 // youtube
 const youtubePlugin = new Plugin(
   // regexp to match
-  /{%youtube\s*([\d\D]*?)\s*%}/,
+  /{%youtube\s*([\w-]{11})\s*%}/,
 
   (match, utils) => {
     const videoid = match[1]
@@ -1137,7 +1137,7 @@ const youtubePlugin = new Plugin(
 // vimeo
 const vimeoPlugin = new Plugin(
   // regexp to match
-  /{%vimeo\s*([\d\D]*?)\s*%}/,
+  /{%vimeo\s*(\d{6,11})\s*%}/,
 
   (match, utils) => {
     const videoid = match[1]
@@ -1152,7 +1152,7 @@ const vimeoPlugin = new Plugin(
 // gist
 const gistPlugin = new Plugin(
   // regexp to match
-  /{%gist\s*([\d\D]*?)\s*%}/,
+  /{%gist\s*(\w+\/\w+)\s*%}/,
 
   (match, utils) => {
     const gistid = match[1]
@@ -1170,7 +1170,7 @@ const tocPlugin = new Plugin(
 // slideshare
 const slidesharePlugin = new Plugin(
   // regexp to match
-  /{%slideshare\s*([\d\D]*?)\s*%}/,
+  /{%slideshare\s*(\w+\/[\w-]+)\s*%}/,
 
   (match, utils) => {
     const slideshareid = match[1]
@@ -1182,7 +1182,7 @@ const slidesharePlugin = new Plugin(
 // speakerdeck
 const speakerdeckPlugin = new Plugin(
   // regexp to match
-  /{%speakerdeck\s*([\d\D]*?)\s*%}/,
+  /{%speakerdeck\s*(\w+\/[\w-]+)\s*%}/,
 
   (match, utils) => {
     const speakerdeckid = match[1]


### PR DESCRIPTION
### Component/Part
Regex for short code detection of embeddings

### Description
This PR replaces embedding shortcode regexes with more specific ones to safeguard against xss attacks.

### Steps

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Additional Information
I used the regex from the new frontend.