### PR TITLE
feat: add default and create permissions to newly created notes 

### DIFF
--- a/docs/content/config/index.md
+++ b/docs/content/config/index.md
@@ -19,19 +19,29 @@ We also provide an `.env.example` file containing a minimal configuration in the
 
 ## General
 
-| environment variable     | default   | example                      | description                                                                                                                                            |
-|--------------------------|-----------|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `HD_DOMAIN`              | -         | `https://md.example.com`     | The URL the HedgeDoc instance runs on.                                                                                                                 |
-| `PORT`                   | 3000      |                              | The port the HedgeDoc instance runs on.                                                                                                                |
-| `HD_RENDERER_ORIGIN`     | HD_DOMAIN |                              | The URL the renderer runs on. If omitted this will be same as `HD_DOMAIN`.                                                                             |
-| `HD_LOGLEVEL`            | warn      |                              | The loglevel that should be used. Options are `error`, `warn`, `info`, `debug` or `trace`.                                                             |
-| `HD_FORBIDDEN_NOTE_IDS`  | -         | `notAllowed, alsoNotAllowed` | A list of note ids (separated by `,`), that are not allowed to be created or requested by anyone.                                                      |
-| `HD_MAX_DOCUMENT_LENGTH` | 100000    |                              | The maximum length of any one document. Changes to this will impact performance for your users.                                                        |
-| `HD_PERSIST_INTERVAL`    | 10        | `0`, `5`, `10`, `20`         | The time interval in **minutes** for the periodic note revision creation during realtime editing. `0` deactivates the periodic note revision creation. |
+| environment variable     | default   | example                     | description                                                                                                                                            |
+|--------------------------|-----------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `HD_DOMAIN`              | -         | `https://md.example.com`    | The URL the HedgeDoc instance runs on.                                                                                                                 |
+| `PORT`                   | 3000      |                             | The port the HedgeDoc instance runs on.                                                                                                                |
+| `HD_RENDERER_ORIGIN`     | HD_DOMAIN |                             | The URL the renderer runs on. If omitted this will be same as `HD_DOMAIN`.                                                                             |
+| `HD_LOGLEVEL`            | warn      |                             | The loglevel that should be used. Options are `error`, `warn`, `info`, `debug` or `trace`.                                                             |
+| `HD_FORBIDDEN_NOTE_IDS`  | -         | `notAllowed,alsoNotAllowed` | A list of note ids (separated by `,`), that are not allowed to be created or requested by anyone.                                                      |
+| `HD_MAX_DOCUMENT_LENGTH` | 100000    |                             | The maximum length of any one document. Changes to this will impact performance for your users.                                                        |
+| `HD_PERSIST_INTERVAL`    | 10        | `0`, `5`, `10`, `20`        | The time interval in **minutes** for the periodic note revision creation during realtime editing. `0` deactivates the periodic note revision creation. |
 
 ### Why should I want to run my renderer on a different (sub-)domain?
 
 If the renderer is provided by another domain, it's way harder to manipulate HedgeDoc or steal credentials from the rendered note content, because renderer and editor are more isolated. This increases the security of the software and greatly mitigates [XSS attacks](https://en.wikipedia.org/wiki/Cross-site_scripting). However, you can run HedgeDoc without this extra security, but we recommend using it if possible.
+
+## Notes
+
+| environment variable                     | default | example                           | description                                                                                                                                                                          |
+|------------------------------------------|---------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `HD_FORBIDDEN_NOTE_IDS`                  | -       | `notAllowed, alsoNotAllowed`      | A list of note ids (separated by `,`), that are not allowed to be created or requested by anyone.                                                                                    |
+| `HD_MAX_DOCUMENT_LENGTH`                 | 100000  |                                   | The maximum length of any one document. Changes to this will impact performance for your users.                                                                                      |
+| `HD_GUEST_ACCESS`                        | `write` | `deny`, `read`, `write`, `create` | Defines the maximum access level for guest users to the instance. If guest access is set lower than the "everyone" permission of a note then the note permission will be overridden. |
+| `HD_PERMISSION_LOGGED_IN_DEFAULT_ACCESS` | `write` | `none, read, write`               | The default permission for the "logged-in" group that is set on new notes.                                                                                                           |
+| `HD_PERMISSION_EVERYONE_DEFAULT_ACCESS`  | `read`  | `none, read, write`               | The default permission for the "everyone" group (logged-in & guest users), that is set on new notes created by logged-in users. Notes created by guests always set this to "write".  |
 
 ## Authentication
 

--- a/docs/content/dev/config.md
+++ b/docs/content/dev/config.md
@@ -8,7 +8,7 @@ NestJS - the framework we use - is reading the variables from the environment an
 
 ## How the config code works
 
-The config of HedgeDoc is split up into **eight** different modules:
+The config of HedgeDoc is split up into **nine** different modules:
 
 `app.config.ts`
 : General configuration of the app
@@ -33,6 +33,9 @@ The config of HedgeDoc is split up into **eight** different modules:
 
 `media.config.ts`
 : Where media files are being stored
+
+`note.config.ts`
+: Configuration for notes
 
 Each of those files (except `auth.config.ts` which is discussed later) consists of three parts:
 

--- a/src/config/default-access-permission.enum.ts
+++ b/src/config/default-access-permission.enum.ts
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export enum DefaultAccessPermission {
+  NONE = 'none',
+  READ = 'read',
+  WRITE = 'write',
+}
+
+export function getDefaultAccessPermissionOrdinal(
+  permission: DefaultAccessPermission,
+): number {
+  switch (permission) {
+    case DefaultAccessPermission.NONE:
+      return 0;
+    case DefaultAccessPermission.READ:
+      return 1;
+    case DefaultAccessPermission.WRITE:
+      return 2;
+    default:
+      throw Error('Unknown permission');
+  }
+}

--- a/src/config/guest_access.enum.ts
+++ b/src/config/guest_access.enum.ts
@@ -11,9 +11,7 @@ export enum GuestAccess {
   CREATE = 'create',
 }
 
-export function getGuestAccessOrdinal(
-  guestAccess: GuestAccess,
-): number {
+export function getGuestAccessOrdinal(guestAccess: GuestAccess): number {
   switch (guestAccess) {
     case GuestAccess.DENY:
       return 0;

--- a/src/config/guest_access.enum.ts
+++ b/src/config/guest_access.enum.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export enum GuestAccess {
+  DENY = 'deny',
+  READ = 'read',
+  WRITE = 'write',
+  CREATE = 'create',
+}
+
+export function getGuestAccessOrdinal(
+  guestAccess: GuestAccess,
+): number {
+  switch (guestAccess) {
+    case GuestAccess.DENY:
+      return 0;
+    case GuestAccess.READ:
+      return 1;
+    case GuestAccess.WRITE:
+      return 2;
+    case GuestAccess.CREATE:
+      return 3;
+    default:
+      throw Error('Unknown permission');
+  }
+}

--- a/src/config/mock/note.config.mock.ts
+++ b/src/config/mock/note.config.mock.ts
@@ -6,12 +6,21 @@
 import { ConfigFactoryKeyHost, registerAs } from '@nestjs/config';
 import { ConfigFactory } from '@nestjs/config/dist/interfaces';
 
+import { DefaultAccessPermission } from '../default-access-permission.enum';
+import { DefaultAccessPermission } from '../default-access-permission.enum';
 import { NoteConfig } from '../note.config';
+import { GuestAccess } from '../guest_access.enum';
 
 export function createDefaultMockNoteConfig(): NoteConfig {
   return {
     maxDocumentLength: 100000,
     forbiddenNoteIds: ['forbiddenNoteId'],
+    permissions: {
+      default: {
+        everyone: DefaultAccessPermission.READ,
+        loggedIn: DefaultAccessPermission.WRITE,
+      },
+    },
   };
 }
 

--- a/src/config/mock/note.config.mock.ts
+++ b/src/config/mock/note.config.mock.ts
@@ -7,9 +7,8 @@ import { ConfigFactoryKeyHost, registerAs } from '@nestjs/config';
 import { ConfigFactory } from '@nestjs/config/dist/interfaces';
 
 import { DefaultAccessPermission } from '../default-access-permission.enum';
-import { DefaultAccessPermission } from '../default-access-permission.enum';
-import { NoteConfig } from '../note.config';
 import { GuestAccess } from '../guest_access.enum';
+import { NoteConfig } from '../note.config';
 
 export function createDefaultMockNoteConfig(): NoteConfig {
   return {
@@ -21,6 +20,7 @@ export function createDefaultMockNoteConfig(): NoteConfig {
         loggedIn: DefaultAccessPermission.WRITE,
       },
     },
+    guestAccess: GuestAccess.CREATE,
   };
 }
 

--- a/src/config/mock/note.config.mock.ts
+++ b/src/config/mock/note.config.mock.ts
@@ -3,14 +3,22 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { registerAs } from '@nestjs/config';
+import { ConfigFactoryKeyHost, registerAs } from '@nestjs/config';
+import { ConfigFactory } from '@nestjs/config/dist/interfaces';
 
 import { NoteConfig } from '../note.config';
 
-export default registerAs(
-  'noteConfig',
-  (): NoteConfig => ({
+export function createDefaultMockNoteConfig(): NoteConfig {
+  return {
     maxDocumentLength: 100000,
     forbiddenNoteIds: ['forbiddenNoteId'],
-  }),
-);
+  };
+}
+
+export function registerNoteConfig(
+  noteConfig: NoteConfig,
+): ConfigFactory<NoteConfig> & ConfigFactoryKeyHost<NoteConfig> {
+  return registerAs('noteConfig', (): NoteConfig => noteConfig);
+}
+
+export default registerNoteConfig(createDefaultMockNoteConfig());

--- a/src/config/note.config.spec.ts
+++ b/src/config/note.config.spec.ts
@@ -5,6 +5,8 @@
  */
 import mockedEnv from 'mocked-env';
 
+import { DefaultAccessPermission } from './default-access-permission.enum';
+import { GuestAccess } from './guest_access.enum';
 import noteConfig from './note.config';
 
 describe('noteConfig', () => {
@@ -15,14 +17,19 @@ describe('noteConfig', () => {
   const negativeMaxDocumentLength = -123;
   const floatMaxDocumentLength = 2.71;
   const invalidMaxDocumentLength = 'not-a-max-document-length';
+  const guestAccess = GuestAccess.CREATE;
+  const wrongDefaultPermission = 'wrong';
 
   describe('correctly parses config', () => {
-    it('when given correct and complete environment variables', async () => {
+    it('when given correct and complete environment variables', () => {
       const restore = mockedEnv(
         {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
         {
@@ -33,6 +40,13 @@ describe('noteConfig', () => {
       expect(config.forbiddenNoteIds).toHaveLength(forbiddenNoteIds.length);
       expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
       expect(config.maxDocumentLength).toEqual(maxDocumentLength);
+      expect(config.permissions.default.everyone).toEqual(
+        DefaultAccessPermission.READ,
+      );
+      expect(config.permissions.default.loggedIn).toEqual(
+        DefaultAccessPermission.READ,
+      );
+      expect(config.guestAccess).toEqual(guestAccess);
       restore();
     });
 
@@ -41,6 +55,9 @@ describe('noteConfig', () => {
         {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
         {
@@ -50,24 +67,13 @@ describe('noteConfig', () => {
       const config = noteConfig();
       expect(config.forbiddenNoteIds).toHaveLength(0);
       expect(config.maxDocumentLength).toEqual(maxDocumentLength);
-      restore();
-    });
-
-    it('when no HD_MAX_DOCUMENT_LENGTH is set', () => {
-      const restore = mockedEnv(
-        {
-          /* eslint-disable @typescript-eslint/naming-convention */
-          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
-          /* eslint-enable @typescript-eslint/naming-convention */
-        },
-        {
-          clear: true,
-        },
+      expect(config.permissions.default.everyone).toEqual(
+        DefaultAccessPermission.READ,
       );
-      const config = noteConfig();
-      expect(config.forbiddenNoteIds).toHaveLength(forbiddenNoteIds.length);
-      expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
-      expect(config.maxDocumentLength).toEqual(100000);
+      expect(config.permissions.default.loggedIn).toEqual(
+        DefaultAccessPermission.READ,
+      );
+      expect(config.guestAccess).toEqual(guestAccess);
       restore();
     });
 
@@ -77,6 +83,9 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteId,
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
         {
@@ -87,9 +96,133 @@ describe('noteConfig', () => {
       expect(config.forbiddenNoteIds).toHaveLength(1);
       expect(config.forbiddenNoteIds[0]).toEqual(forbiddenNoteId);
       expect(config.maxDocumentLength).toEqual(maxDocumentLength);
+      expect(config.permissions.default.everyone).toEqual(
+        DefaultAccessPermission.READ,
+      );
+      expect(config.permissions.default.loggedIn).toEqual(
+        DefaultAccessPermission.READ,
+      );
+
+      expect(config.guestAccess).toEqual(guestAccess);
+      restore();
+    });
+
+    it('when no HD_MAX_DOCUMENT_LENGTH is set', () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      const config = noteConfig();
+      expect(config.forbiddenNoteIds).toHaveLength(forbiddenNoteIds.length);
+      expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
+      expect(config.maxDocumentLength).toEqual(100000);
+      expect(config.permissions.default.everyone).toEqual(
+        DefaultAccessPermission.READ,
+      );
+      expect(config.permissions.default.loggedIn).toEqual(
+        DefaultAccessPermission.READ,
+      );
+
+      expect(config.guestAccess).toEqual(guestAccess);
+      restore();
+    });
+
+    it('when no HD_PERMISSION_DEFAULT_EVERYONE is set', () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      const config = noteConfig();
+      expect(config.forbiddenNoteIds).toHaveLength(forbiddenNoteIds.length);
+      expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
+      expect(config.maxDocumentLength).toEqual(maxDocumentLength);
+      expect(config.permissions.default.everyone).toEqual(
+        DefaultAccessPermission.READ,
+      );
+      expect(config.permissions.default.loggedIn).toEqual(
+        DefaultAccessPermission.READ,
+      );
+
+      expect(config.guestAccess).toEqual(guestAccess);
+      restore();
+    });
+
+    it('when no HD_PERMISSION_DEFAULT_LOGGED_IN is set', () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      const config = noteConfig();
+      expect(config.forbiddenNoteIds).toHaveLength(forbiddenNoteIds.length);
+      expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
+      expect(config.maxDocumentLength).toEqual(maxDocumentLength);
+      expect(config.permissions.default.everyone).toEqual(
+        DefaultAccessPermission.READ,
+      );
+      expect(config.permissions.default.loggedIn).toEqual(
+        DefaultAccessPermission.WRITE,
+      );
+
+      expect(config.guestAccess).toEqual(guestAccess);
+      restore();
+    });
+
+    it('when no HD_GUEST_ACCESS is set', () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      const config = noteConfig();
+      expect(config.forbiddenNoteIds).toHaveLength(forbiddenNoteIds.length);
+      expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
+      expect(config.maxDocumentLength).toEqual(maxDocumentLength);
+      expect(config.permissions.default.everyone).toEqual(
+        DefaultAccessPermission.READ,
+      );
+      expect(config.permissions.default.loggedIn).toEqual(
+        DefaultAccessPermission.WRITE,
+      );
+
+      expect(config.guestAccess).toEqual(GuestAccess.WRITE);
       restore();
     });
   });
+
   describe('throws error', () => {
     it('when given a non-valid HD_FORBIDDEN_NOTE_IDS', async () => {
       const restore = mockedEnv(
@@ -97,6 +230,9 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: invalidforbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
         {
@@ -115,6 +251,9 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: negativeMaxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
         {
@@ -133,6 +272,9 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: floatMaxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
         {
@@ -151,6 +293,9 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: invalidMaxDocumentLength,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
         {
@@ -159,6 +304,153 @@ describe('noteConfig', () => {
       );
       expect(() => noteConfig()).toThrow(
         '"HD_MAX_DOCUMENT_LENGTH" must be a number',
+      );
+      restore();
+    });
+
+    it('when given a non-valid HD_PERMISSION_DEFAULT_EVERYONE', async () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: wrongDefaultPermission,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      expect(() => noteConfig()).toThrow(
+        '"HD_PERMISSION_DEFAULT_EVERYONE" must be one of [none, read, write]',
+      );
+      restore();
+    });
+
+    it('when given a non-valid HD_PERMISSION_DEFAULT_LOGGED_IN', async () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: wrongDefaultPermission,
+          HD_GUEST_ACCESS: guestAccess,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      expect(() => noteConfig()).toThrow(
+        '"HD_PERMISSION_DEFAULT_LOGGED_IN" must be one of [none, read, write]',
+      );
+      restore();
+    });
+
+    it('when given a non-valid HD_GUEST_ACCESS', async () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: wrongDefaultPermission,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      expect(() => noteConfig()).toThrow(
+        '"HD_GUEST_ACCESS" must be one of [deny, read, write, create]',
+      );
+      restore();
+    });
+
+    it('when HD_GUEST_ACCESS is set to deny and HD_PERMISSION_DEFAULT_EVERYONE is set', async () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: 'deny',
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      expect(() => noteConfig()).toThrow(
+        `'HD_GUEST_ACCESS' is set to 'deny', but 'HD_PERMISSION_DEFAULT_EVERYONE' is also configured. Please remove 'HD_PERMISSION_DEFAULT_EVERYONE'.`,
+      );
+      restore();
+    });
+
+    it('when HD_PERMISSION_DEFAULT_EVERYONE is set to write, but HD_PERMISSION_DEFAULT_LOGGED_IN is set to read', async () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.WRITE,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_GUEST_ACCESS: guestAccess,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      expect(() => noteConfig()).toThrow(
+        `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${DefaultAccessPermission.WRITE}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${DefaultAccessPermission.READ}'. This gives everyone greater permissions than logged-in users which is not allowed.`,
+      );
+      restore();
+    });
+
+    it('when HD_PERMISSION_DEFAULT_EVERYONE is set to write, but HD_PERMISSION_DEFAULT_LOGGED_IN is set to none', async () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.WRITE,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.NONE,
+          HD_GUEST_ACCESS: guestAccess,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      expect(() => noteConfig()).toThrow(
+        `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${DefaultAccessPermission.WRITE}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${DefaultAccessPermission.NONE}'. This gives everyone greater permissions than logged-in users which is not allowed.`,
+      );
+      restore();
+    });
+
+    it('when HD_PERMISSION_DEFAULT_EVERYONE is set to read, but HD_PERMISSION_DEFAULT_LOGGED_IN is set to none', async () => {
+      const restore = mockedEnv(
+        {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
+          HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.NONE,
+          HD_GUEST_ACCESS: guestAccess,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        {
+          clear: true,
+        },
+      );
+      expect(() => noteConfig()).toThrow(
+        `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${DefaultAccessPermission.READ}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${DefaultAccessPermission.NONE}'. This gives everyone greater permissions than logged-in users which is not allowed.`,
       );
       restore();
     });

--- a/src/config/note.config.ts
+++ b/src/config/note.config.ts
@@ -6,14 +6,26 @@
 import { registerAs } from '@nestjs/config';
 import * as Joi from 'joi';
 
+import {
+  DefaultAccessPermission,
+  getDefaultAccessPermissionOrdinal,
+} from './default-access-permission.enum';
+import { GuestAccess } from './guest_access.enum';
 import { buildErrorMessage, parseOptionalNumber, toArrayConfig } from './utils';
 
 export interface NoteConfig {
   forbiddenNoteIds: string[];
   maxDocumentLength: number;
+  guestAccess: GuestAccess;
+  permissions: {
+    default: {
+      everyone: DefaultAccessPermission;
+      loggedIn: DefaultAccessPermission;
+    };
+  };
 }
 
-const schema = Joi.object({
+const schema = Joi.object<NoteConfig>({
   forbiddenNoteIds: Joi.array()
     .items(Joi.string())
     .optional()
@@ -25,7 +37,51 @@ const schema = Joi.object({
     .integer()
     .optional()
     .label('HD_MAX_DOCUMENT_LENGTH'),
+  guestAccess: Joi.string()
+    .valid(...Object.values(GuestAccess))
+    .optional()
+    .default(GuestAccess.WRITE)
+    .label('HD_GUEST_ACCESS'),
+  permissions: {
+    default: {
+      everyone: Joi.string()
+        .valid(...Object.values(DefaultAccessPermission))
+        .optional()
+        .default(DefaultAccessPermission.READ)
+        .label('HD_PERMISSION_DEFAULT_EVERYONE'),
+      loggedIn: Joi.string()
+        .valid(...Object.values(DefaultAccessPermission))
+        .optional()
+        .default(DefaultAccessPermission.WRITE)
+        .label('HD_PERMISSION_DEFAULT_LOGGED_IN'),
+    },
+  },
 });
+
+function checkEveryoneConfigIsConsistent(config: NoteConfig): void {
+  const everyoneDefaultSet =
+    process.env.HD_PERMISSION_DEFAULT_EVERYONE !== undefined;
+  if (config.guestAccess === GuestAccess.DENY && everyoneDefaultSet) {
+    throw new Error(
+      `'HD_GUEST_ACCESS' is set to '${config.guestAccess}', but 'HD_PERMISSION_DEFAULT_EVERYONE' is also configured. Please remove 'HD_PERMISSION_DEFAULT_EVERYONE'.`,
+    );
+  }
+}
+
+function checkLoggedInUsersHaveHigherDefaultPermissionsThanGuests(
+  config: NoteConfig,
+): void {
+  const everyone = config.permissions.default.everyone;
+  const loggedIn = config.permissions.default.loggedIn;
+  if (
+    getDefaultAccessPermissionOrdinal(everyone) >
+    getDefaultAccessPermissionOrdinal(loggedIn)
+  ) {
+    throw new Error(
+      `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${everyone}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${loggedIn}'. This gives everyone greater permissions than logged-in users which is not allowed.`,
+    );
+  }
+}
 
 export default registerAs('noteConfig', () => {
   const noteConfig = schema.validate(
@@ -34,7 +90,14 @@ export default registerAs('noteConfig', () => {
       maxDocumentLength: parseOptionalNumber(
         process.env.HD_MAX_DOCUMENT_LENGTH,
       ),
-    },
+      guestAccess: process.env.HD_GUEST_ACCESS,
+      permissions: {
+        default: {
+          everyone: process.env.HD_PERMISSION_DEFAULT_EVERYONE,
+          loggedIn: process.env.HD_PERMISSION_DEFAULT_LOGGED_IN,
+        },
+      },
+    } as NoteConfig,
     {
       abortEarly: false,
       presence: 'required',
@@ -46,5 +109,8 @@ export default registerAs('noteConfig', () => {
     );
     throw new Error(buildErrorMessage(errorMessages));
   }
-  return noteConfig.value as NoteConfig;
+  const config = noteConfig.value;
+  checkEveryoneConfigIsConsistent(config);
+  checkLoggedInUsersHaveHigherDefaultPermissionsThanGuests(config);
+  return config;
 });

--- a/src/frontend-config/frontend-config.dto.ts
+++ b/src/frontend-config/frontend-config.dto.ts
@@ -14,6 +14,7 @@ import {
 } from 'class-validator';
 import { URL } from 'url';
 
+import { GuestAccess } from '../config/guest_access.enum';
 import { ServerVersion } from '../monitoring/server-status.dto';
 import { BaseDto } from '../utils/base.dto.';
 
@@ -140,10 +141,10 @@ export class IframeCommunicationDto extends BaseDto {
 
 export class FrontendConfigDto extends BaseDto {
   /**
-   * Is anonymous usage of the instance allowed?
+   * Maximum access level for guest users
    */
-  @IsBoolean()
-  allowAnonymous: boolean;
+  @IsString()
+  guestAccess: GuestAccess;
 
   /**
    * Are users allowed to register on this instance?

--- a/src/frontend-config/frontend-config.service.spec.ts
+++ b/src/frontend-config/frontend-config.service.spec.ts
@@ -13,6 +13,7 @@ import { CustomizationConfig } from '../config/customization.config';
 import { DefaultAccessPermission } from '../config/default-access-permission.enum';
 import { ExternalServicesConfig } from '../config/external-services.config';
 import { GitlabScope, GitlabVersion } from '../config/gitlab.enum';
+import { GuestAccess } from '../config/guest_access.enum';
 import { Loglevel } from '../config/loglevel.enum';
 import { NoteConfig } from '../config/note.config';
 import { LoggerModule } from '../logger/logger.module';
@@ -192,7 +193,7 @@ describe('FrontendConfigService', () => {
                   return {
                     forbiddenNoteIds: [],
                     maxDocumentLength: 200,
-                    guestAccess: true,
+                    guestAccess: GuestAccess.CREATE,
                     permissions: {
                       default: {
                         everyone: DefaultAccessPermission.READ,
@@ -358,7 +359,7 @@ describe('FrontendConfigService', () => {
                 const noteConfig: NoteConfig = {
                   forbiddenNoteIds: [],
                   maxDocumentLength: maxDocumentLength,
-                  guestAccess: true,
+                  guestAccess: GuestAccess.CREATE,
                   permissions: {
                     default: {
                       everyone: DefaultAccessPermission.READ,
@@ -392,7 +393,7 @@ describe('FrontendConfigService', () => {
                 const service = module.get(FrontendConfigService);
                 const config = await service.getFrontendConfig();
                 expect(config.allowRegister).toEqual(enableRegister);
-                expect(config.allowAnonymous).toEqual(noteConfig.guestAccess);
+                expect(config.guestAccess).toEqual(noteConfig.guestAccess);
                 expect(config.branding.name).toEqual(customName);
                 expect(config.branding.logo).toEqual(
                   customLogo ? new URL(customLogo) : undefined,

--- a/src/frontend-config/frontend-config.service.spec.ts
+++ b/src/frontend-config/frontend-config.service.spec.ts
@@ -10,6 +10,7 @@ import { URL } from 'url';
 import { AppConfig } from '../config/app.config';
 import { AuthConfig } from '../config/auth.config';
 import { CustomizationConfig } from '../config/customization.config';
+import { DefaultAccessPermission } from '../config/default-access-permission.enum';
 import { ExternalServicesConfig } from '../config/external-services.config';
 import { GitlabScope, GitlabVersion } from '../config/gitlab.enum';
 import { Loglevel } from '../config/loglevel.enum';
@@ -191,7 +192,14 @@ describe('FrontendConfigService', () => {
                   return {
                     forbiddenNoteIds: [],
                     maxDocumentLength: 200,
-                  };
+                    guestAccess: true,
+                    permissions: {
+                      default: {
+                        everyone: DefaultAccessPermission.READ,
+                        loggedIn: DefaultAccessPermission.WRITE,
+                      },
+                    },
+                  } as NoteConfig;
                 }),
               ],
             }),
@@ -350,6 +358,13 @@ describe('FrontendConfigService', () => {
                 const noteConfig: NoteConfig = {
                   forbiddenNoteIds: [],
                   maxDocumentLength: maxDocumentLength,
+                  guestAccess: true,
+                  permissions: {
+                    default: {
+                      everyone: DefaultAccessPermission.READ,
+                      loggedIn: DefaultAccessPermission.WRITE,
+                    },
+                  },
                 };
                 const module: TestingModule = await Test.createTestingModule({
                   imports: [
@@ -377,8 +392,7 @@ describe('FrontendConfigService', () => {
                 const service = module.get(FrontendConfigService);
                 const config = await service.getFrontendConfig();
                 expect(config.allowRegister).toEqual(enableRegister);
-
-                expect(config.allowAnonymous).toEqual(false);
+                expect(config.allowAnonymous).toEqual(noteConfig.guestAccess);
                 expect(config.branding.name).toEqual(customName);
                 expect(config.branding.logo).toEqual(
                   customLogo ? new URL(customLogo) : undefined,

--- a/src/frontend-config/frontend-config.service.ts
+++ b/src/frontend-config/frontend-config.service.ts
@@ -46,7 +46,7 @@ export class FrontendConfigService {
 
   async getFrontendConfig(): Promise<FrontendConfigDto> {
     return {
-      allowAnonymous: this.noteConfig.guestAccess,
+      guestAccess: this.noteConfig.guestAccess,
       allowRegister: this.authConfig.local.enableRegister,
       authProviders: this.getAuthProviders(),
       branding: this.getBranding(),

--- a/src/frontend-config/frontend-config.service.ts
+++ b/src/frontend-config/frontend-config.service.ts
@@ -46,8 +46,7 @@ export class FrontendConfigService {
 
   async getFrontendConfig(): Promise<FrontendConfigDto> {
     return {
-      // ToDo: use actual value here
-      allowAnonymous: false,
+      allowAnonymous: this.noteConfig.guestAccess,
       allowRegister: this.authConfig.local.enableRegister,
       authProviders: this.getAuthProviders(),
       branding: this.getBranding(),

--- a/src/groups/groups.service.spec.ts
+++ b/src/groups/groups.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -13,6 +13,7 @@ import { AlreadyInDBError, NotInDBError } from '../errors/errors';
 import { LoggerModule } from '../logger/logger.module';
 import { Group } from './group.entity';
 import { GroupsService } from './groups.service';
+import { SpecialGroup } from './groups.special';
 
 describe('GroupsService', () => {
   let service: GroupsService;
@@ -87,6 +88,17 @@ describe('GroupsService', () => {
         NotInDBError,
       );
     });
+  });
+
+  it('getEveryoneGroup return EVERYONE group', async () => {
+    const spy = jest.spyOn(service, 'getGroupByName').mockImplementation();
+    await service.getEveryoneGroup();
+    expect(spy).toHaveBeenCalledWith(SpecialGroup.EVERYONE);
+  });
+  it('getLoggedInGroup return LOGGED_IN group', async () => {
+    const spy = jest.spyOn(service, 'getGroupByName').mockImplementation();
+    await service.getLoggedInGroup();
+    expect(spy).toHaveBeenCalledWith(SpecialGroup.LOGGED_IN);
   });
 
   describe('toGroupDto', () => {

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -11,6 +11,7 @@ import { AlreadyInDBError, NotInDBError } from '../errors/errors';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
 import { GroupInfoDto } from './group-info.dto';
 import { Group } from './group.entity';
+import { SpecialGroup } from './groups.special';
 
 @Injectable()
 export class GroupsService {
@@ -64,6 +65,22 @@ export class GroupsService {
       throw new NotInDBError(`Group with name '${name}' not found`);
     }
     return group;
+  }
+
+  /**
+   * Get the group object for the everyone special group.
+   * @return {Group} the EVERYONE group
+   */
+  getEveryoneGroup(): Promise<Group> {
+    return this.getGroupByName(SpecialGroup.EVERYONE);
+  }
+
+  /**
+   * Get the group object for the logged-in special group.
+   * @return {Group} the LOGGED_IN group
+   */
+  getLoggedInGroup(): Promise<Group> {
+    return this.getGroupByName(SpecialGroup.LOGGED_IN);
   }
 
   /**

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -235,6 +235,7 @@ describe('NotesService', () => {
 
       it('with no note', async () => {
         const createQueryBuilder = {
+          leftJoinAndSelect: () => createQueryBuilder,
           where: () => createQueryBuilder,
           getMany: async () => {
             return null;
@@ -251,6 +252,7 @@ describe('NotesService', () => {
 
       it('with one note', async () => {
         const createQueryBuilder = {
+          leftJoinAndSelect: () => createQueryBuilder,
           where: () => createQueryBuilder,
           getMany: async () => {
             return [note];
@@ -267,6 +269,7 @@ describe('NotesService', () => {
 
       it('with multiple note', async () => {
         const createQueryBuilder = {
+          leftJoinAndSelect: () => createQueryBuilder,
           where: () => createQueryBuilder,
           getMany: async () => {
             return [note, note];

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -63,6 +63,13 @@ export class NotesService {
   async getUserNotes(user: User): Promise<Note[]> {
     const notes = await this.noteRepository
       .createQueryBuilder('note')
+      .leftJoinAndSelect('note.aliases', 'alias')
+      .leftJoinAndSelect('note.owner', 'owner')
+      .leftJoinAndSelect('note.groupPermissions', 'group_permission')
+      .leftJoinAndSelect('group_permission.group', 'group')
+      .leftJoinAndSelect('note.userPermissions', 'user_permission')
+      .leftJoinAndSelect('user_permission.user', 'user')
+      .leftJoinAndSelect('note.tags', 'tag')
       .where('note.owner = :user', { user: user.id })
       .getMany();
     if (notes === null) {
@@ -275,8 +282,6 @@ export class NotesService {
     //TODO: Calculate patch
     revisions.push(Revision.create(noteContent, noteContent, note) as Revision);
     note.revisions = Promise.resolve(revisions);
-    note.userPermissions = Promise.resolve([]);
-    note.groupPermissions = Promise.resolve([]);
     return await this.noteRepository.save(note);
   }
 

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { Optional } from '@mrdrogdrog/optional';
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -14,8 +15,8 @@ import {
   ForbiddenIdError,
   NotInDBError,
 } from '../errors/errors';
+import { Group } from '../groups/group.entity';
 import { GroupsService } from '../groups/groups.service';
-import { SpecialGroup } from '../groups/groups.special';
 import { HistoryEntry } from '../history/history-entry.entity';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
 import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
@@ -63,13 +64,6 @@ export class NotesService {
   async getUserNotes(user: User): Promise<Note[]> {
     const notes = await this.noteRepository
       .createQueryBuilder('note')
-      .leftJoinAndSelect('note.aliases', 'alias')
-      .leftJoinAndSelect('note.owner', 'owner')
-      .leftJoinAndSelect('note.groupPermissions', 'group_permission')
-      .leftJoinAndSelect('group_permission.group', 'group')
-      .leftJoinAndSelect('note.userPermissions', 'user_permission')
-      .leftJoinAndSelect('user_permission.user', 'user')
-      .leftJoinAndSelect('note.tags', 'tag')
       .where('note.owner = :user', { user: user.id })
       .getMany();
     if (notes === null) {

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -7,6 +7,7 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
+import { DefaultAccessPermission } from '../config/default-access-permission.enum';
 import noteConfiguration, { NoteConfig } from '../config/note.config';
 import {
   AlreadyInDBError,
@@ -14,8 +15,10 @@ import {
   NotInDBError,
 } from '../errors/errors';
 import { GroupsService } from '../groups/groups.service';
+import { SpecialGroup } from '../groups/groups.special';
 import { HistoryEntry } from '../history/history-entry.entity';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
+import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
 import { RealtimeNoteStore } from '../realtime/realtime-note/realtime-note-store.service';
 import { RealtimeNoteService } from '../realtime/realtime-note/realtime-note.service';
 import { Revision } from '../revisions/revision.entity';

--- a/src/permissions/note-group-permission.entity.ts
+++ b/src/permissions/note-group-permission.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/permissions/permissions.enum.ts
+++ b/src/permissions/permissions.enum.ts
@@ -1,11 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
- *
- * SPDX-License-Identifier: AGPL-3.0-only
- */
-
-/*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/permissions/permissions.service.spec.ts
+++ b/src/permissions/permissions.service.spec.ts
@@ -10,10 +10,16 @@ import { DataSource, EntityManager, Repository } from 'typeorm';
 
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
+import { DefaultAccessPermission } from '../config/default-access-permission.enum';
+import { GuestAccess } from '../config/guest_access.enum';
 import appConfigMock from '../config/mock/app.config.mock';
 import authConfigMock from '../config/mock/auth.config.mock';
 import databaseConfigMock from '../config/mock/database.config.mock';
-import noteConfigMock from '../config/mock/note.config.mock';
+import {
+  createDefaultMockNoteConfig,
+  registerNoteConfig,
+} from '../config/mock/note.config.mock';
+import { NoteConfig } from '../config/note.config';
 import { PermissionsUpdateInconsistentError } from '../errors/errors';
 import { Group } from '../groups/group.entity';
 import { GroupsModule } from '../groups/groups.module';
@@ -36,7 +42,7 @@ import { UsersModule } from '../users/users.module';
 import { NoteGroupPermission } from './note-group-permission.entity';
 import { NoteUserPermission } from './note-user-permission.entity';
 import { PermissionsModule } from './permissions.module';
-import { GuestPermission, PermissionsService } from './permissions.service';
+import { PermissionsService } from './permissions.service';
 
 describe('PermissionsService', () => {
   let service: PermissionsService;
@@ -44,6 +50,7 @@ describe('PermissionsService', () => {
   let noteRepo: Repository<Note>;
   let userRepo: Repository<User>;
   let groupRepo: Repository<Group>;
+  const noteMockConfig: NoteConfig = createDefaultMockNoteConfig();
 
   beforeAll(async () => {
     /**
@@ -98,7 +105,7 @@ describe('PermissionsService', () => {
             appConfigMock,
             databaseConfigMock,
             authConfigMock,
-            noteConfigMock,
+            registerNoteConfig(noteMockConfig),
           ],
         }),
         GroupsModule,
@@ -199,8 +206,11 @@ describe('PermissionsService', () => {
     const everybody = {} as Group;
     everybody.name = SpecialGroup.EVERYONE;
     everybody.special = true;
-    const noteEverybodyRead = createNote(user1);
 
+    const noteEverybodyNone = createNote(user1);
+    noteEverybodyNone.groupPermissions = Promise.resolve([]);
+
+    const noteEverybodyRead = createNote(user1);
     const noteGroupPermissionRead = {} as NoteGroupPermission;
     noteGroupPermissionRead.group = Promise.resolve(everybody);
     noteGroupPermissionRead.canEdit = false;
@@ -210,7 +220,6 @@ describe('PermissionsService', () => {
     ]);
 
     const noteEverybodyWrite = createNote(user1);
-
     const noteGroupPermissionWrite = {} as NoteGroupPermission;
     noteGroupPermissionWrite.group = Promise.resolve(everybody);
     noteGroupPermissionWrite.canEdit = true;
@@ -230,23 +239,21 @@ describe('PermissionsService', () => {
       note7,
       noteEverybodyRead,
       noteEverybodyWrite,
+      noteEverybodyNone,
     ];
   }
 
   describe('mayRead works with', () => {
     it('Owner', async () => {
-      service.guestPermission = GuestPermission.DENY;
       expect(await service.mayRead(user1, notes[0])).toBeTruthy();
       expect(await service.mayRead(user1, notes[7])).toBeFalsy();
     });
     it('userPermission read', async () => {
-      service.guestPermission = GuestPermission.DENY;
       expect(await service.mayRead(user1, notes[1])).toBeTruthy();
       expect(await service.mayRead(user1, notes[2])).toBeTruthy();
       expect(await service.mayRead(user1, notes[3])).toBeTruthy();
     });
     it('userPermission write', async () => {
-      service.guestPermission = GuestPermission.DENY;
       expect(await service.mayRead(user1, notes[4])).toBeTruthy();
       expect(await service.mayRead(user1, notes[5])).toBeTruthy();
       expect(await service.mayRead(user1, notes[6])).toBeTruthy();
@@ -254,59 +261,153 @@ describe('PermissionsService', () => {
     });
 
     describe('guest permission', () => {
-      it('CREATE_ALIAS', async () => {
-        service.guestPermission = GuestPermission.CREATE_ALIAS;
-        expect(await service.mayRead(null, notes[8])).toBeTruthy();
+      beforeEach(() => {
+        noteMockConfig.permissions.default.loggedIn =
+          DefaultAccessPermission.WRITE;
+        noteMockConfig.permissions.default.everyone =
+          DefaultAccessPermission.WRITE;
       });
-      it('CREATE', async () => {
-        service.guestPermission = GuestPermission.CREATE;
-        expect(await service.mayRead(null, notes[8])).toBeTruthy();
+      describe('with guest access deny', () => {
+        beforeEach(() => {
+          noteMockConfig.guestAccess = GuestAccess.DENY;
+        });
+        it('guest permission none', async () => {
+          expect(await service.mayRead(null, notes[10])).toBeFalsy();
+        });
+        it('guest permission read', async () => {
+          expect(await service.mayRead(null, notes[8])).toBeFalsy();
+        });
+        it('guest permission write', async () => {
+          expect(await service.mayRead(null, notes[9])).toBeFalsy();
+        });
       });
-      it('WRITE', async () => {
-        service.guestPermission = GuestPermission.WRITE;
-        expect(await service.mayRead(null, notes[8])).toBeTruthy();
+      describe('with guest access read', () => {
+        beforeEach(() => {
+          noteMockConfig.guestAccess = GuestAccess.READ;
+        });
+        it('guest permission none', async () => {
+          expect(await service.mayRead(null, notes[10])).toBeFalsy();
+        });
+        it('guest permission read', async () => {
+          expect(await service.mayRead(null, notes[8])).toBeTruthy();
+        });
+        it('guest permission write', async () => {
+          expect(await service.mayRead(null, notes[9])).toBeTruthy();
+        });
       });
-      it('READ', async () => {
-        service.guestPermission = GuestPermission.READ;
-        expect(await service.mayRead(null, notes[8])).toBeTruthy();
+      describe('with guest access write', () => {
+        beforeEach(() => {
+          noteMockConfig.guestAccess = GuestAccess.WRITE;
+        });
+        it('guest permission none', async () => {
+          expect(await service.mayRead(null, notes[10])).toBeFalsy();
+        });
+        it('guest permission read', async () => {
+          expect(await service.mayRead(null, notes[8])).toBeTruthy();
+        });
+        it('guest permission write', async () => {
+          expect(await service.mayRead(null, notes[9])).toBeTruthy();
+        });
+      });
+      describe('with guest access create', () => {
+        beforeEach(() => {
+          noteMockConfig.guestAccess = GuestAccess.CREATE;
+        });
+        it('guest permission none', async () => {
+          expect(await service.mayRead(null, notes[10])).toBeFalsy();
+        });
+        it('guest permission read', async () => {
+          expect(await service.mayRead(null, notes[8])).toBeTruthy();
+        });
+        it('guest permission write', async () => {
+          expect(await service.mayRead(null, notes[9])).toBeTruthy();
+        });
       });
     });
   });
+
   describe('mayWrite works with', () => {
     it('Owner', async () => {
-      service.guestPermission = GuestPermission.DENY;
       expect(await service.mayWrite(user1, notes[0])).toBeTruthy();
       expect(await service.mayWrite(user1, notes[7])).toBeFalsy();
     });
     it('userPermission read', async () => {
-      service.guestPermission = GuestPermission.DENY;
       expect(await service.mayWrite(user1, notes[1])).toBeFalsy();
       expect(await service.mayWrite(user1, notes[2])).toBeFalsy();
       expect(await service.mayWrite(user1, notes[3])).toBeFalsy();
     });
     it('userPermission write', async () => {
-      service.guestPermission = GuestPermission.DENY;
       expect(await service.mayWrite(user1, notes[4])).toBeTruthy();
       expect(await service.mayWrite(user1, notes[5])).toBeTruthy();
       expect(await service.mayWrite(user1, notes[6])).toBeTruthy();
       expect(await service.mayWrite(user1, notes[7])).toBeFalsy();
     });
     describe('guest permission', () => {
-      it('CREATE_ALIAS', async () => {
-        service.guestPermission = GuestPermission.CREATE_ALIAS;
-        expect(await service.mayWrite(null, notes[9])).toBeTruthy();
+      beforeEach(() => {
+        noteMockConfig.permissions.default.loggedIn =
+          DefaultAccessPermission.WRITE;
+        noteMockConfig.permissions.default.everyone =
+          DefaultAccessPermission.WRITE;
       });
-      it('CREATE', async () => {
-        service.guestPermission = GuestPermission.CREATE;
-        expect(await service.mayWrite(null, notes[9])).toBeTruthy();
+
+      describe('with guest access deny', () => {
+        beforeEach(() => {
+          noteMockConfig.guestAccess = GuestAccess.DENY;
+        });
+        it('guest permission none', async () => {
+          expect(await service.mayWrite(null, notes[10])).toBeFalsy();
+        });
+        it('guest permission read', async () => {
+          expect(await service.mayWrite(null, notes[8])).toBeFalsy();
+        });
+        it('guest permission write', async () => {
+          expect(await service.mayWrite(null, notes[9])).toBeFalsy();
+        });
       });
-      it('WRITE', async () => {
-        service.guestPermission = GuestPermission.WRITE;
-        expect(await service.mayWrite(null, notes[9])).toBeTruthy();
+
+      describe('with guest access read', () => {
+        beforeEach(() => {
+          noteMockConfig.guestAccess = GuestAccess.READ;
+        });
+        it('guest permission none', async () => {
+          expect(await service.mayWrite(null, notes[10])).toBeFalsy();
+        });
+        it('guest permission read', async () => {
+          expect(await service.mayWrite(null, notes[8])).toBeFalsy();
+        });
+        it('guest permission write', async () => {
+          expect(await service.mayWrite(null, notes[9])).toBeFalsy();
+        });
       });
-      it('READ', async () => {
-        service.guestPermission = GuestPermission.READ;
-        expect(await service.mayWrite(null, notes[9])).toBeFalsy();
+
+      describe('with guest access write', () => {
+        beforeEach(() => {
+          noteMockConfig.guestAccess = GuestAccess.WRITE;
+        });
+        it('guest permission none', async () => {
+          expect(await service.mayWrite(null, notes[10])).toBeFalsy();
+        });
+        it('guest permission read', async () => {
+          expect(await service.mayWrite(null, notes[8])).toBeFalsy();
+        });
+        it('guest permission write', async () => {
+          expect(await service.mayWrite(null, notes[9])).toBeTruthy();
+        });
+      });
+
+      describe('with guest access create', () => {
+        beforeEach(() => {
+          noteMockConfig.guestAccess = GuestAccess.CREATE;
+        });
+        it('guest permission none', async () => {
+          expect(await service.mayWrite(null, notes[10])).toBeFalsy();
+        });
+        it('guest permission read', async () => {
+          expect(await service.mayWrite(null, notes[8])).toBeFalsy();
+        });
+        it('guest permission write', async () => {
+          expect(await service.mayWrite(null, notes[9])).toBeTruthy();
+        });
       });
     });
   });
@@ -326,19 +427,17 @@ describe('PermissionsService', () => {
   function createGroups(): { [id: string]: Group } {
     const result: { [id: string]: Group } = {};
 
-    const everybody: Group = Group.create(
+    result[SpecialGroup.EVERYONE] = Group.create(
       SpecialGroup.EVERYONE,
       SpecialGroup.EVERYONE,
       true,
     ) as Group;
-    result[SpecialGroup.EVERYONE] = everybody;
 
-    const loggedIn = Group.create(
+    result[SpecialGroup.LOGGED_IN] = Group.create(
       SpecialGroup.LOGGED_IN,
       SpecialGroup.LOGGED_IN,
       true,
     ) as Group;
-    result[SpecialGroup.LOGGED_IN] = loggedIn;
 
     const user1group = Group.create('user1group', 'user1group', false) as Group;
     user1group.members = Promise.resolve([user1]);
@@ -370,7 +469,7 @@ describe('PermissionsService', () => {
   /*
    * Create all GroupPermissions: For each group two GroupPermissions are created one with read permission and one with write permission.
    */
-  function createAllNoteGroupPermissions(): NoteGroupPermission[][] {
+  function createAllNoteGroupPermissions(): (NoteGroupPermission | null)[][] {
     const groups = createGroups();
 
     /*
@@ -450,7 +549,7 @@ describe('PermissionsService', () => {
    * creates the matrix multiplication of group0 to group4 of createAllNoteGroupPermissions
    */
   function createNoteGroupPermissionsCombinations(
-    guestPermission: GuestPermission,
+    everyoneDefaultPermission: DefaultAccessPermission,
   ): NoteGroupPermissionWithResultForUser[] {
     // for logged in users
     const noteGroupPermissions = createAllNoteGroupPermissions();
@@ -476,16 +575,15 @@ describe('PermissionsService', () => {
               }
 
               if (group2 !== null) {
-                // everybody group TODO config options
-                switch (guestPermission) {
-                  case GuestPermission.CREATE_ALIAS:
-                  case GuestPermission.CREATE:
-                  case GuestPermission.WRITE:
-                    writePermission = writePermission || group2.canEdit;
-                    readPermission = true;
-                    break;
-                  case GuestPermission.READ:
-                    readPermission = true;
+                if (
+                  everyoneDefaultPermission === DefaultAccessPermission.WRITE
+                ) {
+                  writePermission = writePermission || group2.canEdit;
+                  readPermission = true;
+                } else if (
+                  everyoneDefaultPermission === DefaultAccessPermission.READ
+                ) {
+                  readPermission = true;
                 }
                 insert.push(group2);
               }
@@ -558,9 +656,9 @@ describe('PermissionsService', () => {
   }
 
   describe('check if groups work with', () => {
-    const guestPermission = GuestPermission.WRITE;
-    const rawPermissions =
-      createNoteGroupPermissionsCombinations(guestPermission);
+    const rawPermissions = createNoteGroupPermissionsCombinations(
+      DefaultAccessPermission.WRITE,
+    );
     const permissions = permuteNoteGroupPermissions(rawPermissions);
     let i = 0;
     for (const permission of permissions) {
@@ -571,13 +669,11 @@ describe('PermissionsService', () => {
         permissionString += ` ${perm.id}:${String(perm.canEdit)}`;
       }
       it(`mayWrite - test #${i}:${permissionString}`, async () => {
-        service.guestPermission = guestPermission;
         expect(await service.mayWrite(user1, note)).toEqual(
           permission.allowsWrite,
         );
       });
       it(`mayRead - test #${i}:${permissionString}`, async () => {
-        service.guestPermission = guestPermission;
         expect(await service.mayRead(user1, note)).toEqual(
           permission.allowsRead,
         );
@@ -586,40 +682,33 @@ describe('PermissionsService', () => {
     }
   });
 
-  describe('mayCreate works for', () => {
-    it('logged in', () => {
-      service.guestPermission = GuestPermission.DENY;
+  describe('mayCreate', () => {
+    it('allows creation for logged in', () => {
       expect(service.mayCreate(user1)).toBeTruthy();
     });
-    it('guest denied', () => {
-      service.guestPermission = GuestPermission.DENY;
-      expect(service.mayCreate(null)).toBeFalsy();
-    });
-    it('guest read', () => {
-      service.guestPermission = GuestPermission.READ;
-      expect(service.mayCreate(null)).toBeFalsy();
-    });
-    it('guest write', () => {
-      service.guestPermission = GuestPermission.WRITE;
-      expect(service.mayCreate(null)).toBeFalsy();
-    });
-    it('guest create', () => {
-      service.guestPermission = GuestPermission.CREATE;
+    it('allows creation of notes for guests with permission', () => {
+      noteMockConfig.guestAccess = GuestAccess.CREATE;
+      noteMockConfig.permissions.default.loggedIn =
+        DefaultAccessPermission.WRITE;
+      noteMockConfig.permissions.default.everyone =
+        DefaultAccessPermission.WRITE;
       expect(service.mayCreate(null)).toBeTruthy();
     });
-    it('guest create alias', () => {
-      service.guestPermission = GuestPermission.CREATE_ALIAS;
-      expect(service.mayCreate(null)).toBeTruthy();
+    it('denies creation of notes for guests without permission', () => {
+      noteMockConfig.guestAccess = GuestAccess.WRITE;
+      noteMockConfig.permissions.default.loggedIn =
+        DefaultAccessPermission.WRITE;
+      noteMockConfig.permissions.default.everyone =
+        DefaultAccessPermission.WRITE;
+      expect(service.mayCreate(null)).toBeFalsy();
     });
   });
 
   describe('isOwner works', () => {
     it('for positive case', async () => {
-      service.guestPermission = GuestPermission.DENY;
       expect(await service.isOwner(user1, notes[0])).toBeTruthy();
     });
     it('for negative case', async () => {
-      service.guestPermission = GuestPermission.DENY;
       expect(await service.isOwner(user1, notes[1])).toBeFalsy();
     });
   });

--- a/src/permissions/permissions.service.ts
+++ b/src/permissions/permissions.service.ts
@@ -39,29 +39,47 @@ export class PermissionsService {
   ) {}
 
   public guestPermission: GuestPermission; // TODO change to configOption
-  async mayRead(user: User | null, note: Note): Promise<boolean> {
-    if (await this.isOwner(user, note)) return true;
 
-    if (await this.hasPermissionUser(user, note, false)) return true;
-
-    // noinspection RedundantIfStatementJS
-    if (await this.hasPermissionGroup(user, note, false)) return true;
-
-    return false;
+  /**
+   * Checks if the given {@link User} is allowed to read the given {@link Note}.
+   *
+   * @async
+   * @param {User} user - The user whose permission should be checked. Value is null if guest access should be checked
+   * @param {Note} note - The note for which the permission should be checked
+   * @return if the user is allowed to read the note
+   */
+  public async mayRead(user: User | null, note: Note): Promise<boolean> {
+    return (
+      (await this.isOwner(user, note)) ||
+      (await this.hasPermissionUser(user, note, false)) ||
+      (await this.hasPermissionGroup(user, note, false))
+    );
   }
 
-  async mayWrite(user: User | null, note: Note): Promise<boolean> {
-    if (await this.isOwner(user, note)) return true;
-
-    if (await this.hasPermissionUser(user, note, true)) return true;
-
-    // noinspection RedundantIfStatementJS
-    if (await this.hasPermissionGroup(user, note, true)) return true;
-
-    return false;
+  /**
+   * Checks if the given {@link User} is allowed to edit the given {@link Note}.
+   *
+   * @async
+   * @param {User} user - The user whose permission should be checked
+   * @param {Note} note - The note for which the permission should be checked. Value is null if guest access should be checked
+   * @return if the user is allowed to edit the note
+   */
+  public async mayWrite(user: User | null, note: Note): Promise<boolean> {
+    return (
+      (await this.isOwner(user, note)) ||
+      (await this.hasPermissionUser(user, note, true)) ||
+      (await this.hasPermissionGroup(user, note, true))
+    );
   }
 
-  mayCreate(user: User | null): boolean {
+  /**
+   * Checks if the given {@link User} is allowed to create notes.
+   *
+   * @async
+   * @param {User} user - The user whose permission should be checked. Value is null if guest access should be checked
+   * @return if the user is allowed to create notes
+   */
+  public mayCreate(user: User | null): boolean {
     if (user) {
       return true;
     } else {

--- a/test/private-api/notes.e2e-spec.ts
+++ b/test/private-api/notes.e2e-spec.ts
@@ -414,6 +414,12 @@ describe('Notes', () => {
         user2,
         alias,
       );
+      // Redact default read permissions
+      const note = await testSetup.notesService.getNoteByIdOrAlias(alias);
+      const everyone = await testSetup.groupService.getEveryoneGroup();
+      const loggedin = await testSetup.groupService.getLoggedInGroup();
+      await testSetup.permissionsService.removeGroupPermission(note, everyone);
+      await testSetup.permissionsService.removeGroupPermission(note, loggedin);
       await agent
         .get(`/api/private/notes/${alias}/media/`)
         .expect('Content-Type', /json/)

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -189,7 +189,6 @@ describe('Notes', () => {
       const note = await testSetup.notesService.createNote(
         content,
         user,
-
         'test3',
       );
       const updateNotePermission = new NotePermissionsUpdateDto();
@@ -465,6 +464,12 @@ describe('Notes', () => {
         user2,
         alias,
       );
+      // Redact default read permissions
+      const note = await testSetup.notesService.getNoteByIdOrAlias(alias);
+      const everyone = await testSetup.groupService.getEveryoneGroup();
+      const loggedin = await testSetup.groupService.getLoggedInGroup();
+      await testSetup.permissionsService.removeGroupPermission(note, everyone);
+      await testSetup.permissionsService.removeGroupPermission(note, loggedin);
       await request(testSetup.app.getHttpServer())
         .get(`/api/v2/notes/${alias}/media/`)
         .expect('Content-Type', /json/)


### PR DESCRIPTION
### Component/Part
note services

### Description
This PR adds the default permissions to newly created notes.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x