### PR TITLE
Convert history attribute in user table to long text

### DIFF
--- a/lib/migrations/20220901102800-convert-history-to-longtext.js
+++ b/lib/migrations/20220901102800-convert-history-to-longtext.js
@@ -5,5 +5,11 @@ module.exports = {
     return queryInterface.changeColumn('Users', 'history', {
       type: Sequelize.TEXT('long')
     })
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.changeColumn('Users', 'history', {
+      type: Sequelize.TEXT
+    })
   }
 }

--- a/lib/migrations/20220901102800-convert-history-to-longtext.js
+++ b/lib/migrations/20220901102800-convert-history-to-longtext.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.changeColumn('Users', 'history', {
+      type: Sequelize.TEXT('long')
+    })
+  }
+}

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -23,7 +23,7 @@ module.exports = function (sequelize, DataTypes) {
       type: DataTypes.TEXT
     },
     history: {
-      type: DataTypes.TEXT
+      type: DataTypes.TEXT('long')
     },
     accessToken: {
       type: DataTypes.TEXT

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -7,6 +7,7 @@
 
 ### Bugfixes
 - Fix a crash when using LDAP authentication with custom search attributes (thanks to [@aboettger-tuhh](https://github.com/aboettger-tuhh) for reporting)
+- Fix crash caused by a long note history when the MySQL database is used
 
 ## <i class="fa fa-tag"></i> 1.9.4 <i class="fa fa-calendar-o"></i> 2022-07-10
 


### PR DESCRIPTION
### Component/Part
Database scheme

### Description
This PR changes the data type of the history attribute in the user table to long text.

When using mysql the normal text attribute has a fixed size. When this size is reached then the json will be cut off and becomes invalid. The problem doesn't occur when using postgres or sqlite because they already have variable length.

### Steps

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #2623 
