### PR TITLE
refactor: Rename group "everyone" to "guests"

### DIFF
--- a/docs/content/dev/2.0.md
+++ b/docs/content/dev/2.0.md
@@ -11,7 +11,7 @@ We intend to officially support and test these databases:
 
 ## Special Groups
 The software provides two special groups which have no explicit users:
-- `everyone` (Describing that everyone who wants to access a note can do if it is enabled in the config.)
+- `guests` (Describing that guest users who want to access a note can do if it is enabled in the config.)
 - `loggedIn` (Describing all users which are logged in)
 
 ## Deleting notes and revisions

--- a/docs/content/dev/db-schema.plantuml
+++ b/docs/content/dev/db-schema.plantuml
@@ -116,7 +116,7 @@ entity "group" {
   *name : text <<unique>>
   *displayName : text
   ' Is set to denote a special group
-  ' Special groups are used to map the old share settings like "everyone can edit"
+  ' Special groups are used to map the old share settings like "guests can edit"
   ' or "logged in users can view" to the group permission system
   *special : boolean
   }

--- a/src/groups/group-info.dto.ts
+++ b/src/groups/group-info.dto.ts
@@ -27,7 +27,7 @@ export class GroupInfoDto extends BaseDto {
 
   /**
    * True if this group must be specially handled
-   * Used for e.g. "everybody", "all logged in users"
+   * Used for e.g. "guests", "all logged in users"
    * @example false
    */
   @IsBoolean()

--- a/src/groups/group.entity.ts
+++ b/src/groups/group.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -28,7 +28,7 @@ export class Group {
 
   /**
    * Is set to denote a special group
-   * Special groups are used to map the old share settings like "everyone can edit"
+   * Special groups are used to map the old share settings like "guests can edit"
    * or "logged in users can view" to the group permission system
    */
   @Column()

--- a/src/groups/groups.special.ts
+++ b/src/groups/groups.special.ts
@@ -1,10 +1,10 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
 export enum SpecialGroup {
   LOGGED_IN = '_LOGGED_IN',
-  EVERYONE = '_EVERYONE',
+  GUESTS = '_GUESTS',
 }

--- a/src/permissions/permissions.service.spec.ts
+++ b/src/permissions/permissions.service.spec.ts
@@ -196,26 +196,26 @@ describe('PermissionsService', () => {
 
     (await note7.userPermissions).push(noteUserPermission2);
 
-    const everybody = {} as Group;
-    everybody.name = SpecialGroup.EVERYONE;
-    everybody.special = true;
-    const noteEverybodyRead = createNote(user1);
+    const guests = {} as Group;
+    guests.name = SpecialGroup.GUESTS;
+    guests.special = true;
+    const noteGuestsRead = createNote(user1);
 
     const noteGroupPermissionRead = {} as NoteGroupPermission;
-    noteGroupPermissionRead.group = everybody;
+    noteGroupPermissionRead.group = guests;
     noteGroupPermissionRead.canEdit = false;
-    noteGroupPermissionRead.note = noteEverybodyRead;
-    noteEverybodyRead.groupPermissions = Promise.resolve([
+    noteGroupPermissionRead.note = noteGuestsRead;
+    noteGuestsRead.groupPermissions = Promise.resolve([
       noteGroupPermissionRead,
     ]);
 
-    const noteEverybodyWrite = createNote(user1);
+    const noteGuestsWrite = createNote(user1);
 
     const noteGroupPermissionWrite = {} as NoteGroupPermission;
-    noteGroupPermissionWrite.group = everybody;
+    noteGroupPermissionWrite.group = guests;
     noteGroupPermissionWrite.canEdit = true;
-    noteGroupPermissionWrite.note = noteEverybodyWrite;
-    noteEverybodyWrite.groupPermissions = Promise.resolve([
+    noteGroupPermissionWrite.note = noteGuestsWrite;
+    noteGuestsWrite.groupPermissions = Promise.resolve([
       noteGroupPermissionWrite,
     ]);
 
@@ -228,8 +228,8 @@ describe('PermissionsService', () => {
       note5,
       note6,
       note7,
-      noteEverybodyRead,
-      noteEverybodyWrite,
+      noteGuestsRead,
+      noteGuestsWrite,
     ];
   }
 
@@ -326,12 +326,12 @@ describe('PermissionsService', () => {
   function createGroups(): { [id: string]: Group } {
     const result: { [id: string]: Group } = {};
 
-    const everybody: Group = Group.create(
-      SpecialGroup.EVERYONE,
-      SpecialGroup.EVERYONE,
+    const guests: Group = Group.create(
+      SpecialGroup.GUESTS,
+      SpecialGroup.GUESTS,
       true,
     ) as Group;
-    result[SpecialGroup.EVERYONE] = everybody;
+    result[SpecialGroup.GUESTS] = guests;
 
     const loggedIn = Group.create(
       SpecialGroup.LOGGED_IN,
@@ -383,12 +383,12 @@ describe('PermissionsService', () => {
       return NoteGroupPermission.create(group, {} as Note, write);
     }
 
-    const everybodyRead = createNoteGroupPermission(
-      groups[SpecialGroup.EVERYONE],
+    const guestsRead = createNoteGroupPermission(
+      groups[SpecialGroup.GUESTS],
       false,
     );
-    const everybodyWrite = createNoteGroupPermission(
-      groups[SpecialGroup.EVERYONE],
+    const guestsWrite = createNoteGroupPermission(
+      groups[SpecialGroup.GUESTS],
       true,
     );
 
@@ -440,7 +440,7 @@ describe('PermissionsService', () => {
     return [
       [user1groupRead, user1and2groupRead, user2and1groupRead, null], // group0: allow user1 to read via group
       [user2and1groupWrite, user1and2groupWrite, user1groupWrite, null], // group1: allow user1 to write via group
-      [everybodyRead, everybodyWrite, null], // group2: permissions of the special group everybody
+      [guestsRead, guestsWrite, null], // group2: permissions of the special group guests
       [loggedInRead, loggedInWrite, null], // group3: permissions of the special group loggedIn
       [user2groupWrite, user2groupRead, null], // group4: don't allow user1 to read or write via group
     ];
@@ -476,7 +476,7 @@ describe('PermissionsService', () => {
               }
 
               if (group2 !== null) {
-                // everybody group TODO config options
+                // guest group TODO config options
                 switch (guestPermission) {
                   case GuestPermission.CREATE_ALIAS:
                   case GuestPermission.CREATE:

--- a/src/permissions/permissions.service.ts
+++ b/src/permissions/permissions.service.ts
@@ -126,7 +126,7 @@ export class PermissionsService {
             return true;
           }
           if (
-            groupPermission.group.name == SpecialGroup.EVERYONE &&
+            groupPermission.group.name == SpecialGroup.GUESTS &&
             (groupPermission.canEdit || !wantEdit) &&
             guestsAllowed
           ) {

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -94,13 +94,13 @@ dataSource
       ]);
     }
     const createdUsers = await dataSource.manager.find(User);
-    const groupEveryone = Group.create('_EVERYONE', 'Everyone', true) as Group;
+    const groupGuests = Group.create('_GUESTS', 'Guests', true) as Group;
     const groupLoggedIn = Group.create(
       '_LOGGED_IN',
       'Logged-in users',
       true,
     ) as Group;
-    await dataSource.manager.save([groupEveryone, groupLoggedIn]);
+    await dataSource.manager.save([groupGuests, groupLoggedIn]);
 
     for (let i = 0; i < 3; i++) {
       if (i === 0) {
@@ -121,7 +121,7 @@ dataSource
 
       if (i === 1) {
         const readPermission = NoteGroupPermission.create(
-          groupEveryone,
+          groupGuests,
           notes[i],
           false,
         );

--- a/src/utils/createSpecialGroups.ts
+++ b/src/utils/createSpecialGroups.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,8 +15,8 @@ export async function setupSpecialGroups(
   const groupService = app.get<GroupsService>(GroupsService);
   try {
     await groupService.createGroup(
-      SpecialGroup.EVERYONE,
-      SpecialGroup.EVERYONE,
+      SpecialGroup.GUESTS,
+      SpecialGroup.GUESTS,
       true,
     );
     await groupService.createGroup(


### PR DESCRIPTION
Signed-off-by: Tilman Vatteroth <git@tilmanvatteroth.de>

### Component/Part
Special Groups

### Description
This PR renames the group "everyone" to "guests" because the term "everyone" is misleading.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
