### PR TITLE
refactor: Split methods `getAuthTokenAndValidate` and `createTokenForUser`

### DIFF
--- a/src/api/private/tokens/tokens.controller.ts
+++ b/src/api/private/tokens/tokens.controller.ts
@@ -53,7 +53,7 @@ export class TokensController {
     @Body() createDto: AuthTokenCreateDto,
     @RequestUser() user: User,
   ): Promise<AuthTokenWithSecretDto> {
-    return await this.authService.createTokenForUser(
+    return await this.authService.addToken(
       user,
       createDto.label,
       createDto.validUntil,

--- a/src/auth/auth-token.entity.ts
+++ b/src/auth/auth-token.entity.ts
@@ -48,16 +48,16 @@ export class AuthToken {
     keyId: string,
     user: User,
     label: string,
-    accessToken: string,
+    tokenString: string,
     validUntil: Date,
   ): Omit<AuthToken, 'id' | 'createdAt'> {
-    const newToken = new AuthToken();
-    newToken.keyId = keyId;
-    newToken.user = Promise.resolve(user);
-    newToken.label = label;
-    newToken.accessTokenHash = accessToken;
-    newToken.validUntil = validUntil;
-    newToken.lastUsedAt = null;
-    return newToken;
+    const token = new AuthToken();
+    token.keyId = keyId;
+    token.user = Promise.resolve(user);
+    token.label = label;
+    token.accessTokenHash = tokenString;
+    token.validUntil = validUntil;
+    token.lastUsedAt = null;
+    return token;
   }
 }

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -343,7 +343,7 @@ export class TestSetupBuilder {
       // create auth tokens
       this.testSetup.authTokens = await Promise.all(
         this.testSetup.users.map(async (user) => {
-          return await this.testSetup.authService.createTokenForUser(
+          return await this.testSetup.authService.addToken(
             user,
             'test',
             new Date().getTime() + 60 * 60 * 1000,


### PR DESCRIPTION
### Component/Part
auth service

### Description
Refactoring

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
