### PR TITLE
Remove composite primary keys

### DIFF
--- a/src/history/history-entry.entity.ts
+++ b/src/history/history-entry.entity.ts
@@ -23,13 +23,13 @@ export class HistoryEntry {
 
   @ManyToOne((_) => User, (user) => user.historyEntries, {
     onDelete: 'CASCADE',
-    orphanedRowAction: 'delete', // This ensures the whole row is deleted when the Entry stops being referenced
+    orphanedRowAction: 'delete', // This ensures the row of the history entry is deleted when no user references it anymore
   })
   user: Promise<User>;
 
   @ManyToOne((_) => Note, (note) => note.historyEntries, {
     onDelete: 'CASCADE',
-    orphanedRowAction: 'delete', // This ensures the whole row is deleted when the Entry stops being referenced
+    orphanedRowAction: 'delete', // This ensures the row of the history entry is deleted when no note references it anymore
   })
   note: Promise<Note>;
 

--- a/src/history/history.service.spec.ts
+++ b/src/history/history.service.spec.ts
@@ -178,10 +178,12 @@ describe('HistoryService', () => {
           Note.create(user, alias) as Note,
           user,
         );
-        expect(await createHistoryEntry.note.aliases).toHaveLength(1);
-        expect((await createHistoryEntry.note.aliases)[0].name).toEqual(alias);
-        expect(await createHistoryEntry.note.owner).toEqual(user);
-        expect(createHistoryEntry.user).toEqual(user);
+        expect(await (await createHistoryEntry.note).aliases).toHaveLength(1);
+        expect((await (await createHistoryEntry.note).aliases)[0].name).toEqual(
+          alias,
+        );
+        expect(await (await createHistoryEntry.note).owner).toEqual(user);
+        expect(await createHistoryEntry.user).toEqual(user);
         expect(createHistoryEntry.pinStatus).toEqual(false);
       });
 
@@ -196,10 +198,12 @@ describe('HistoryService', () => {
           Note.create(user, alias) as Note,
           user,
         );
-        expect(await createHistoryEntry.note.aliases).toHaveLength(1);
-        expect((await createHistoryEntry.note.aliases)[0].name).toEqual(alias);
-        expect(await createHistoryEntry.note.owner).toEqual(user);
-        expect(createHistoryEntry.user).toEqual(user);
+        expect(await (await createHistoryEntry.note).aliases).toHaveLength(1);
+        expect((await (await createHistoryEntry.note).aliases)[0].name).toEqual(
+          alias,
+        );
+        expect(await (await createHistoryEntry.note).owner).toEqual(user);
+        expect(await createHistoryEntry.user).toEqual(user);
         expect(createHistoryEntry.pinStatus).toEqual(false);
         expect(createHistoryEntry.updatedAt.getTime()).toBeGreaterThanOrEqual(
           historyEntry.updatedAt.getTime(),
@@ -231,10 +235,12 @@ describe('HistoryService', () => {
             pinStatus: true,
           },
         );
-        expect(await updatedHistoryEntry.note.aliases).toHaveLength(1);
-        expect((await updatedHistoryEntry.note.aliases)[0].name).toEqual(alias);
-        expect(await updatedHistoryEntry.note.owner).toEqual(user);
-        expect(updatedHistoryEntry.user).toEqual(user);
+        expect(await (await updatedHistoryEntry.note).aliases).toHaveLength(1);
+        expect(
+          (await (await updatedHistoryEntry.note).aliases)[0].name,
+        ).toEqual(alias);
+        expect(await (await updatedHistoryEntry.note).owner).toEqual(user);
+        expect(await updatedHistoryEntry.user).toEqual(user);
         expect(updatedHistoryEntry.pinStatus).toEqual(true);
       });
 
@@ -357,13 +363,13 @@ describe('HistoryService', () => {
         remove: jest
           .fn()
           .mockImplementationOnce(async (entry: HistoryEntry) => {
-            expect(await entry.note.aliases).toHaveLength(1);
-            expect((await entry.note.aliases)[0].name).toEqual(alias);
+            expect(await (await entry.note).aliases).toHaveLength(1);
+            expect((await (await entry.note).aliases)[0].name).toEqual(alias);
             expect(entry.pinStatus).toEqual(false);
           }),
-        save: jest.fn().mockImplementationOnce((entry: HistoryEntry) => {
-          expect(entry.note.aliases).toEqual(
-            newlyCreatedHistoryEntry.note.aliases,
+        save: jest.fn().mockImplementationOnce(async (entry: HistoryEntry) => {
+          expect((await entry.note).aliases).toEqual(
+            (await newlyCreatedHistoryEntry.note).aliases,
           );
           expect(entry.pinStatus).toEqual(newlyCreatedHistoryEntry.pinStatus);
           expect(entry.updatedAt).toEqual(newlyCreatedHistoryEntry.updatedAt);

--- a/src/history/history.service.ts
+++ b/src/history/history.service.ts
@@ -177,8 +177,8 @@ export class HistoryService {
     return {
       identifier: await getIdentifier(entry),
       lastVisitedAt: entry.updatedAt,
-      tags: await this.notesService.toTagList(entry.note),
-      title: entry.note.title ?? '',
+      tags: await this.notesService.toTagList(await entry.note),
+      title: (await entry.note).title ?? '',
       pinStatus: entry.pinStatus,
     };
   }

--- a/src/history/utils.ts
+++ b/src/history/utils.ts
@@ -7,13 +7,13 @@ import { getPrimaryAlias } from '../notes/utils';
 import { HistoryEntry } from './history-entry.entity';
 
 export async function getIdentifier(entry: HistoryEntry): Promise<string> {
-  const aliases = await entry.note.aliases;
+  const aliases = await (await entry.note).aliases;
   if (!aliases || aliases.length === 0) {
-    return entry.note.publicId;
+    return (await entry.note).publicId;
   }
-  const primaryAlias = await getPrimaryAlias(entry.note);
+  const primaryAlias = await getPrimaryAlias(await entry.note);
   if (primaryAlias === undefined) {
-    return entry.note.publicId;
+    return (await entry.note).publicId;
   }
   return primaryAlias;
 }

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -313,7 +313,7 @@ describe('NotesService', () => {
         expect(revisions).toHaveLength(1);
         expect(revisions[0].content).toEqual(content);
         expect(await newNote.historyEntries).toHaveLength(1);
-        expect((await newNote.historyEntries)[0].user).toEqual(user);
+        expect(await (await newNote.historyEntries)[0].user).toEqual(user);
         expect(await newNote.userPermissions).toHaveLength(0);
         expect(await newNote.groupPermissions).toHaveLength(0);
         expect(await newNote.tags).toHaveLength(0);
@@ -338,7 +338,7 @@ describe('NotesService', () => {
         expect(revisions).toHaveLength(1);
         expect(revisions[0].content).toEqual(content);
         expect(await newNote.historyEntries).toHaveLength(1);
-        expect((await newNote.historyEntries)[0].user).toEqual(user);
+        expect(await (await newNote.historyEntries)[0].user).toEqual(user);
         expect(await newNote.userPermissions).toHaveLength(0);
         expect(await newNote.groupPermissions).toHaveLength(0);
         expect(await newNote.tags).toHaveLength(0);

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -57,6 +57,8 @@ describe('NotesService', () => {
     const content = 'testContent';
     jest
       .spyOn(noteRepo, 'save')
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       .mockImplementation(async (note: Note): Promise<Note> => note);
     const note = await service.createNote(content, null);
     const revisions = await note.revisions;
@@ -94,19 +96,17 @@ describe('NotesService', () => {
     note.owner = Promise.resolve(user);
     note.userPermissions = Promise.resolve([
       {
-        noteId: note.id,
-        note: note,
-        userId: user.id,
-        user: user,
+        id: 1,
+        note: Promise.resolve(note),
+        user: Promise.resolve(user),
         canEdit: true,
       },
     ]);
     note.groupPermissions = Promise.resolve([
       {
-        noteId: note.id,
-        note: note,
-        groupId: group.id,
-        group: group,
+        id: 1,
+        note: Promise.resolve(note),
+        group: Promise.resolve(group),
         canEdit: true,
       },
     ]);
@@ -291,6 +291,8 @@ describe('NotesService', () => {
       beforeEach(() => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementation(async (note: Note): Promise<Note> => note);
       });
       it('without alias, without owner', async () => {
@@ -368,6 +370,8 @@ describe('NotesService', () => {
       const content = 'testContent';
       jest
         .spyOn(noteRepo, 'save')
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         .mockImplementation(async (note: Note): Promise<Note> => note);
       const newNote = await service.createNote(content, null);
       const revisions = await newNote.revisions;

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -285,14 +285,18 @@ export class NotesService {
     const groupPermissions = await note.groupPermissions;
     return {
       owner: owner ? owner.username : null,
-      sharedToUsers: userPermissions.map((noteUserPermission) => ({
-        username: noteUserPermission.user.username,
-        canEdit: noteUserPermission.canEdit,
-      })),
-      sharedToGroups: groupPermissions.map((noteGroupPermission) => ({
-        groupName: noteGroupPermission.group.name,
-        canEdit: noteGroupPermission.canEdit,
-      })),
+      sharedToUsers: await Promise.all(
+        userPermissions.map(async (noteUserPermission) => ({
+          username: (await noteUserPermission.user).username,
+          canEdit: noteUserPermission.canEdit,
+        })),
+      ),
+      sharedToGroups: await Promise.all(
+        groupPermissions.map(async (noteGroupPermission) => ({
+          groupName: (await noteGroupPermission.group).name,
+          canEdit: noteGroupPermission.canEdit,
+        })),
+      ),
     };
   }
 

--- a/src/permissions/note-group-permission.entity.ts
+++ b/src/permissions/note-group-permission.entity.ts
@@ -22,13 +22,13 @@ export class NoteGroupPermission {
 
   @ManyToOne((_) => Group, {
     onDelete: 'CASCADE', // This deletes the NoteGroupPermission, when the associated Group is deleted
-    orphanedRowAction: 'delete', // This ensures the whole row is deleted when the Permission stops being referenced
+    orphanedRowAction: 'delete', // This ensures the row of the NoteGroupPermission is deleted when no group references it anymore
   })
   group: Promise<Group>;
 
   @ManyToOne((_) => Note, (note) => note.groupPermissions, {
     onDelete: 'CASCADE', // This deletes the NoteGroupPermission, when the associated Note is deleted
-    orphanedRowAction: 'delete', // This ensures the whole row is deleted when the Permission stops being referenced
+    orphanedRowAction: 'delete', // This ensures the row of the NoteGroupPermission is deleted when no note references it anymore
   })
   note: Promise<Note>;
 

--- a/src/permissions/note-user-permission.entity.ts
+++ b/src/permissions/note-user-permission.entity.ts
@@ -3,37 +3,34 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
 import { Note } from '../notes/note.entity';
 import { User } from '../users/user.entity';
 
 @Entity()
+@Index(['user', 'note'], { unique: true })
 export class NoteUserPermission {
-  /**
-   * The `user` and `note` properties cannot be converted to promises
-   * (to lazy-load them), as TypeORM gets confused about lazy composite
-   * primary keys.
-   * See https://github.com/typeorm/typeorm/issues/6908
-   */
-
-  @PrimaryColumn()
-  userId: number;
+  @PrimaryGeneratedColumn()
+  id: number;
 
   @ManyToOne((_) => User, {
     onDelete: 'CASCADE', // This deletes the NoteUserPermission, when the associated Note is deleted
     orphanedRowAction: 'delete', // This ensures the whole row is deleted when the Permission stops being referenced
   })
-  user: User;
-
-  @PrimaryColumn()
-  noteId: number;
+  user: Promise<User>;
 
   @ManyToOne((_) => Note, (note) => note.userPermissions, {
     onDelete: 'CASCADE', // This deletes the NoteUserPermission, when the associated Note is deleted
     orphanedRowAction: 'delete', // This ensures the whole row is deleted when the Permission stops being referenced
   })
-  note: Note;
+  note: Promise<Note>;
 
   @Column()
   canEdit: boolean;
@@ -47,8 +44,8 @@ export class NoteUserPermission {
     canEdit: boolean,
   ): NoteUserPermission {
     const userPermission = new NoteUserPermission();
-    userPermission.user = user;
-    userPermission.note = note;
+    userPermission.user = Promise.resolve(user);
+    userPermission.note = Promise.resolve(note);
     userPermission.canEdit = canEdit;
     return userPermission;
   }

--- a/src/permissions/note-user-permission.entity.ts
+++ b/src/permissions/note-user-permission.entity.ts
@@ -22,13 +22,13 @@ export class NoteUserPermission {
 
   @ManyToOne((_) => User, {
     onDelete: 'CASCADE', // This deletes the NoteUserPermission, when the associated Note is deleted
-    orphanedRowAction: 'delete', // This ensures the whole row is deleted when the Permission stops being referenced
+    orphanedRowAction: 'delete', // This ensures the row of the NoteUserPermission is deleted when no user references it anymore
   })
   user: Promise<User>;
 
   @ManyToOne((_) => Note, (note) => note.userPermissions, {
     onDelete: 'CASCADE', // This deletes the NoteUserPermission, when the associated Note is deleted
-    orphanedRowAction: 'delete', // This ensures the whole row is deleted when the Permission stops being referenced
+    orphanedRowAction: 'delete', // This ensures the row of the NoteUserPermission is deleted when no note references it anymore
   })
   note: Promise<Note>;
 

--- a/src/permissions/permissions.service.spec.ts
+++ b/src/permissions/permissions.service.spec.ts
@@ -168,14 +168,14 @@ describe('PermissionsService', () => {
     const note6 = createNote(user2);
     const note7 = createNote(user2);
     const noteUserPermission1 = {} as NoteUserPermission;
-    noteUserPermission1.user = user1;
+    noteUserPermission1.user = Promise.resolve(user1);
     const noteUserPermission2 = {} as NoteUserPermission;
-    noteUserPermission2.user = user2;
+    noteUserPermission2.user = Promise.resolve(user2);
     const noteUserPermission3 = {} as NoteUserPermission;
-    noteUserPermission3.user = user1;
+    noteUserPermission3.user = Promise.resolve(user1);
     noteUserPermission3.canEdit = true;
     const noteUserPermission4 = {} as NoteUserPermission;
-    noteUserPermission4.user = user2;
+    noteUserPermission4.user = Promise.resolve(user2);
     noteUserPermission4.canEdit = true;
 
     (await note1.userPermissions).push(noteUserPermission1);
@@ -202,9 +202,9 @@ describe('PermissionsService', () => {
     const noteEverybodyRead = createNote(user1);
 
     const noteGroupPermissionRead = {} as NoteGroupPermission;
-    noteGroupPermissionRead.group = everybody;
+    noteGroupPermissionRead.group = Promise.resolve(everybody);
     noteGroupPermissionRead.canEdit = false;
-    noteGroupPermissionRead.note = noteEverybodyRead;
+    noteGroupPermissionRead.note = Promise.resolve(noteEverybodyRead);
     noteEverybodyRead.groupPermissions = Promise.resolve([
       noteGroupPermissionRead,
     ]);
@@ -212,9 +212,9 @@ describe('PermissionsService', () => {
     const noteEverybodyWrite = createNote(user1);
 
     const noteGroupPermissionWrite = {} as NoteGroupPermission;
-    noteGroupPermissionWrite.group = everybody;
+    noteGroupPermissionWrite.group = Promise.resolve(everybody);
     noteGroupPermissionWrite.canEdit = true;
-    noteGroupPermissionWrite.note = noteEverybodyWrite;
+    noteGroupPermissionWrite.note = Promise.resolve(noteEverybodyWrite);
     noteEverybodyWrite.groupPermissions = Promise.resolve([
       noteGroupPermissionWrite,
     ]);
@@ -568,7 +568,7 @@ describe('PermissionsService', () => {
       note.groupPermissions = Promise.resolve(permission.permissions);
       let permissionString = '';
       for (const perm of permission.permissions) {
-        permissionString += ` ${perm.group.name}:${String(perm.canEdit)}`;
+        permissionString += ` ${perm.id}:${String(perm.canEdit)}`;
       }
       it(`mayWrite - test #${i}:${permissionString}`, async () => {
         service.guestPermission = guestPermission;
@@ -642,6 +642,8 @@ describe('PermissionsService', () => {
       it('with empty GroupPermissions and with empty UserPermissions', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -655,6 +657,8 @@ describe('PermissionsService', () => {
       it('with empty GroupPermissions and with new UserPermissions', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -664,9 +668,9 @@ describe('PermissionsService', () => {
           sharedToGroups: [],
         });
         expect(await savedNote.userPermissions).toHaveLength(1);
-        expect((await savedNote.userPermissions)[0].user.username).toEqual(
-          userPermissionUpdate.username,
-        );
+        expect(
+          (await (await savedNote.userPermissions)[0].user).username,
+        ).toEqual(userPermissionUpdate.username);
         expect((await savedNote.userPermissions)[0].canEdit).toEqual(
           userPermissionUpdate.canEdit,
         );
@@ -676,15 +680,16 @@ describe('PermissionsService', () => {
         const noteWithPreexistingPermissions: Note = { ...note };
         noteWithPreexistingPermissions.userPermissions = Promise.resolve([
           {
-            noteId: 4711,
-            note: noteWithPreexistingPermissions,
-            userId: 4711,
-            user: user,
+            id: 1,
+            note: Promise.resolve(noteWithPreexistingPermissions),
+            user: Promise.resolve(user),
             canEdit: !userPermissionUpdate.canEdit,
           },
         ]);
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -694,9 +699,9 @@ describe('PermissionsService', () => {
           sharedToGroups: [],
         });
         expect(await savedNote.userPermissions).toHaveLength(1);
-        expect((await savedNote.userPermissions)[0].user.username).toEqual(
-          userPermissionUpdate.username,
-        );
+        expect(
+          (await (await savedNote.userPermissions)[0].user).username,
+        ).toEqual(userPermissionUpdate.username);
         expect((await savedNote.userPermissions)[0].canEdit).toEqual(
           userPermissionUpdate.canEdit,
         );
@@ -705,6 +710,8 @@ describe('PermissionsService', () => {
       it('with new GroupPermissions and with empty UserPermissions', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -714,9 +721,9 @@ describe('PermissionsService', () => {
           sharedToGroups: [groupPermissionUpdate],
         });
         expect(await savedNote.userPermissions).toHaveLength(0);
-        expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpdate.groupName,
-        );
+        expect(
+          (await (await savedNote.groupPermissions)[0].group).name,
+        ).toEqual(groupPermissionUpdate.groupName);
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpdate.canEdit,
         );
@@ -724,6 +731,8 @@ describe('PermissionsService', () => {
       it('with new GroupPermissions and with new UserPermissions', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -733,15 +742,15 @@ describe('PermissionsService', () => {
           sharedToUsers: [userPermissionUpdate],
           sharedToGroups: [groupPermissionUpdate],
         });
-        expect((await savedNote.userPermissions)[0].user.username).toEqual(
-          userPermissionUpdate.username,
-        );
+        expect(
+          (await (await savedNote.userPermissions)[0].user).username,
+        ).toEqual(userPermissionUpdate.username);
         expect((await savedNote.userPermissions)[0].canEdit).toEqual(
           userPermissionUpdate.canEdit,
         );
-        expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpdate.groupName,
-        );
+        expect(
+          (await (await savedNote.groupPermissions)[0].group).name,
+        ).toEqual(groupPermissionUpdate.groupName);
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpdate.canEdit,
         );
@@ -750,15 +759,16 @@ describe('PermissionsService', () => {
         const noteWithUserPermission: Note = { ...note };
         noteWithUserPermission.userPermissions = Promise.resolve([
           {
-            noteId: 4711,
-            note: noteWithUserPermission,
-            userId: 4711,
-            user: user,
+            id: 1,
+            note: Promise.resolve(noteWithUserPermission),
+            user: Promise.resolve(user),
             canEdit: !userPermissionUpdate.canEdit,
           },
         ]);
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -771,15 +781,15 @@ describe('PermissionsService', () => {
             sharedToGroups: [groupPermissionUpdate],
           },
         );
-        expect((await savedNote.userPermissions)[0].user.username).toEqual(
-          userPermissionUpdate.username,
-        );
+        expect(
+          (await (await savedNote.userPermissions)[0].user).username,
+        ).toEqual(userPermissionUpdate.username);
         expect((await savedNote.userPermissions)[0].canEdit).toEqual(
           userPermissionUpdate.canEdit,
         );
-        expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpdate.groupName,
-        );
+        expect(
+          (await (await savedNote.groupPermissions)[0].group).name,
+        ).toEqual(groupPermissionUpdate.groupName);
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpdate.canEdit,
         );
@@ -788,16 +798,17 @@ describe('PermissionsService', () => {
         const noteWithPreexistingPermissions: Note = { ...note };
         noteWithPreexistingPermissions.groupPermissions = Promise.resolve([
           {
-            noteId: 4711,
-            note: noteWithPreexistingPermissions,
-            groupId: 0,
-            group: group,
+            id: 1,
+            note: Promise.resolve(noteWithPreexistingPermissions),
+            group: Promise.resolve(group),
             canEdit: !groupPermissionUpdate.canEdit,
           },
         ]);
         jest.spyOn(groupRepo, 'findOne').mockResolvedValueOnce(group);
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -809,9 +820,9 @@ describe('PermissionsService', () => {
           },
         );
         expect(await savedNote.userPermissions).toHaveLength(0);
-        expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpdate.groupName,
-        );
+        expect(
+          (await (await savedNote.groupPermissions)[0].group).name,
+        ).toEqual(groupPermissionUpdate.groupName);
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpdate.canEdit,
         );
@@ -820,15 +831,16 @@ describe('PermissionsService', () => {
         const noteWithPreexistingPermissions: Note = { ...note };
         noteWithPreexistingPermissions.groupPermissions = Promise.resolve([
           {
-            noteId: 4711,
-            note: noteWithPreexistingPermissions,
-            groupId: 0,
-            group: group,
+            id: 1,
+            note: Promise.resolve(noteWithPreexistingPermissions),
+            group: Promise.resolve(group),
             canEdit: !groupPermissionUpdate.canEdit,
           },
         ]);
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -841,15 +853,15 @@ describe('PermissionsService', () => {
             sharedToGroups: [groupPermissionUpdate],
           },
         );
-        expect((await savedNote.userPermissions)[0].user.username).toEqual(
-          userPermissionUpdate.username,
-        );
+        expect(
+          (await (await savedNote.userPermissions)[0].user).username,
+        ).toEqual(userPermissionUpdate.username);
         expect((await savedNote.userPermissions)[0].canEdit).toEqual(
           userPermissionUpdate.canEdit,
         );
-        expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpdate.groupName,
-        );
+        expect(
+          (await (await savedNote.groupPermissions)[0].group).name,
+        ).toEqual(groupPermissionUpdate.groupName);
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpdate.canEdit,
         );
@@ -858,24 +870,24 @@ describe('PermissionsService', () => {
         const noteWithPreexistingPermissions: Note = { ...note };
         noteWithPreexistingPermissions.groupPermissions = Promise.resolve([
           {
-            noteId: 4711,
-            note: noteWithPreexistingPermissions,
-            groupId: 0,
-            group: group,
+            id: 1,
+            note: Promise.resolve(noteWithPreexistingPermissions),
+            group: Promise.resolve(group),
             canEdit: !groupPermissionUpdate.canEdit,
           },
         ]);
         noteWithPreexistingPermissions.userPermissions = Promise.resolve([
           {
-            noteId: 4711,
-            note: noteWithPreexistingPermissions,
-            userId: 4711,
-            user: user,
+            id: 1,
+            note: Promise.resolve(noteWithPreexistingPermissions),
+            user: Promise.resolve(user),
             canEdit: !userPermissionUpdate.canEdit,
           },
         ]);
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -888,15 +900,15 @@ describe('PermissionsService', () => {
             sharedToGroups: [groupPermissionUpdate],
           },
         );
-        expect((await savedNote.userPermissions)[0].user.username).toEqual(
-          userPermissionUpdate.username,
-        );
+        expect(
+          (await (await savedNote.userPermissions)[0].user).username,
+        ).toEqual(userPermissionUpdate.username);
         expect((await savedNote.userPermissions)[0].canEdit).toEqual(
           userPermissionUpdate.canEdit,
         );
-        expect((await savedNote.groupPermissions)[0].group.name).toEqual(
-          groupPermissionUpdate.groupName,
-        );
+        expect(
+          (await (await savedNote.groupPermissions)[0].group).name,
+        ).toEqual(groupPermissionUpdate.groupName);
         expect((await savedNote.groupPermissions)[0].canEdit).toEqual(
           groupPermissionUpdate.canEdit,
         );
@@ -937,6 +949,8 @@ describe('PermissionsService', () => {
       it('with user not added before and editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -951,6 +965,8 @@ describe('PermissionsService', () => {
       it('with user not added before and not editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -965,6 +981,8 @@ describe('PermissionsService', () => {
       it('with user added before and editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -983,6 +1001,8 @@ describe('PermissionsService', () => {
       it('with user added before and not editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -1005,6 +1025,8 @@ describe('PermissionsService', () => {
       it('with user added before and editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -1020,6 +1042,8 @@ describe('PermissionsService', () => {
       it('with user not added before and not editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -1039,6 +1063,8 @@ describe('PermissionsService', () => {
       it('with group not added before and editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -1057,6 +1083,8 @@ describe('PermissionsService', () => {
       it('with group not added before and not editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -1075,6 +1103,8 @@ describe('PermissionsService', () => {
       it('with group added before and editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -1097,6 +1127,8 @@ describe('PermissionsService', () => {
       it('with group added before and not editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -1123,6 +1155,8 @@ describe('PermissionsService', () => {
       it('with user added before and editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -1138,6 +1172,8 @@ describe('PermissionsService', () => {
       it('with user not added before and not editable', async () => {
         jest
           .spyOn(noteRepo, 'save')
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           .mockImplementationOnce(async (entry: Note) => {
             return entry;
           });
@@ -1158,6 +1194,8 @@ describe('PermissionsService', () => {
       const user = User.create('test', 'Testy') as User;
       jest
         .spyOn(noteRepo, 'save')
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         .mockImplementationOnce(async (entry: Note) => {
           return entry;
         });

--- a/test/private-api/history.e2e-spec.ts
+++ b/test/private-api/history.e2e-spec.ts
@@ -101,16 +101,16 @@ describe('History', () => {
         .expect(201);
       const userEntries = await testSetup.historyService.getEntriesByUser(user);
       expect(userEntries.length).toEqual(1);
-      expect((await userEntries[0].note.aliases)[0].name).toEqual(
+      expect((await (await userEntries[0].note).aliases)[0].name).toEqual(
         (await note2.aliases)[0].name,
       );
-      expect((await userEntries[0].note.aliases)[0].primary).toEqual(
+      expect((await (await userEntries[0].note).aliases)[0].primary).toEqual(
         (await note2.aliases)[0].primary,
       );
-      expect((await userEntries[0].note.aliases)[0].id).toEqual(
+      expect((await (await userEntries[0].note).aliases)[0].id).toEqual(
         (await note2.aliases)[0].id,
       );
-      expect(userEntries[0].user.username).toEqual(user.username);
+      expect((await userEntries[0].user).username).toEqual(user.username);
       expect(userEntries[0].pinStatus).toEqual(pinStatus);
       expect(userEntries[0].updatedAt).toEqual(lastVisited);
     });
@@ -161,11 +161,13 @@ describe('History', () => {
           user,
         );
         expect(historyEntries).toHaveLength(1);
-        expect(await historyEntries[0].note.aliases).toEqual(
-          await prevEntry.note.aliases,
+        expect(await (await historyEntries[0].note).aliases).toEqual(
+          await (
+            await prevEntry.note
+          ).aliases,
         );
-        expect(historyEntries[0].user.username).toEqual(
-          prevEntry.user.username,
+        expect((await historyEntries[0].user).username).toEqual(
+          (await prevEntry.user).username,
         );
         expect(historyEntries[0].pinStatus).toEqual(prevEntry.pinStatus);
         expect(historyEntries[0].updatedAt).toEqual(prevEntry.updatedAt);
@@ -189,8 +191,9 @@ describe('History', () => {
       user,
     );
     expect(entry.pinStatus).toBeFalsy();
-    const alias = (await entry.note.aliases).filter((alias) => alias.primary)[0]
-      .name;
+    const alias = (await (await entry.note).aliases).filter(
+      (alias) => alias.primary,
+    )[0].name;
     await agent
       .put(`/api/private/me/history/${alias || 'null'}`)
       .send({ pinStatus: true })
@@ -203,8 +206,9 @@ describe('History', () => {
 
   it('DELETE /me/history/:note', async () => {
     const entry = await historyService.updateHistoryEntryTimestamp(note2, user);
-    const alias = (await entry.note.aliases).filter((alias) => alias.primary)[0]
-      .name;
+    const alias = (await (await entry.note).aliases).filter(
+      (alias) => alias.primary,
+    )[0].name;
     const entry2 = await historyService.updateHistoryEntryTimestamp(note, user);
     const entryDto = await historyService.toHistoryEntryDto(entry2);
     await agent

--- a/test/public-api/me.e2e-spec.ts
+++ b/test/public-api/me.e2e-spec.ts
@@ -118,7 +118,7 @@ describe('Me', () => {
       let theEntry: HistoryEntryDto;
       for (const entry of history) {
         if (
-          (await entry.note.aliases).find(
+          (await (await entry.note).aliases).find(
             (element) => element.name === noteName,
           )
         ) {
@@ -147,7 +147,7 @@ describe('Me', () => {
       const history = await testSetup.historyService.getEntriesByUser(user);
       for (const entry of history) {
         if (
-          (await entry.note.aliases).find(
+          (await (await entry.note).aliases).find(
             (element) => element.name === noteName,
           )
         ) {

--- a/test/public-api/notes.e2e-spec.ts
+++ b/test/public-api/notes.e2e-spec.ts
@@ -211,9 +211,9 @@ describe('Notes', () => {
       expect((await updatedNote.userPermissions)[0].canEdit).toEqual(
         updateNotePermission.sharedToUsers[0].canEdit,
       );
-      expect((await updatedNote.userPermissions)[0].user.username).toEqual(
-        user.username,
-      );
+      expect(
+        (await (await updatedNote.userPermissions)[0].user).username,
+      ).toEqual(user.username);
       expect(await updatedNote.groupPermissions).toHaveLength(0);
       await request(testSetup.app.getHttpServer())
         .delete('/api/v2/notes/test3')


### PR DESCRIPTION
### Component/Part
Entities and callers

### Description
TypeORM promises to support composite primary keys,
but that does not work in reality.
This replaces the composite key used in the permission entities with
a single generated primary key and
a unique index on the relation columns.

See typeorm/typeorm#8513

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
