### PR TITLE
feat: introduce event system

### DIFF
--- a/docs/content/dev/events.md
+++ b/docs/content/dev/events.md
@@ -1,0 +1,9 @@
+In HedgeDoc we use an event system based on [EventEmitter2][eventemitter2]. It's used to reduce circular dependencies between different services and inform these services about changes.
+
+HedgeDoc's system is basically [the system NestJS offers][nestjs/eventemitter].  
+The config for the `EventEmitterModule` is stored in `events.ts` and exported as `eventModuleConfig`.  
+In the same file enums for the event keys are defined. Each of these events is expected to be sent with an additional value. In the enum defintion a comment should tell you what exactly this value should be.
+
+[eventemitter2]: https://github.com/EventEmitter2/EventEmitter2
+[nestjs/eventemitter]: https://docs.nestjs.com/techniques/events
+

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nestjs/common": "9.1.2",
     "@nestjs/config": "2.2.0",
     "@nestjs/core": "9.1.2",
+    "@nestjs/event-emitter": "1.3.1",
     "@nestjs/passport": "9.0.0",
     "@nestjs/platform-express": "9.1.2",
     "@nestjs/platform-ws": "9.1.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@
  */
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { RouterModule, Routes } from 'nest-router';
@@ -22,6 +23,7 @@ import externalConfig from './config/external-services.config';
 import hstsConfig from './config/hsts.config';
 import mediaConfig from './config/media.config';
 import noteConfig from './config/note.config';
+import { eventModuleConfig } from './events';
 import { FrontendConfigModule } from './frontend-config/frontend-config.module';
 import { FrontendConfigService } from './frontend-config/frontend-config.service';
 import { GroupsModule } from './groups/groups.module';
@@ -87,6 +89,7 @@ const routes: Routes = [
       ],
       isGlobal: true,
     }),
+    EventEmitterModule.forRoot(eventModuleConfig),
     ScheduleModule.forRoot(),
     NotesModule,
     UsersModule,

--- a/src/events.ts
+++ b/src/events.ts
@@ -15,6 +15,6 @@ export const eventModuleConfig = {
 };
 
 export enum NoteEvent {
-  PERMISSION_CHANGE = 'note.permission_change',
-  DELETION = 'note.deletion',
+  PERMISSION_CHANGE = 'note.permission_change' /** noteId: The id of the [@link Note], which permissions are changed. **/,
+  DELETION = 'note.deletion' /** noteId: The id of the [@link Note], which is being deleted. **/,
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export enum NoteEvent {
+  PERMISSION_CHANGE = 'note.permission_change',
+  DELETION = 'note.deletion',
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,6 +4,16 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+export const eventModuleConfig = {
+  wildcard: false,
+  delimiter: '.',
+  newListener: false,
+  removeListener: false,
+  maxListeners: 10,
+  verboseMemoryLeak: true,
+  ignoreErrors: false,
+};
+
 export enum NoteEvent {
   PERMISSION_CHANGE = 'note.permission_change',
   DELETION = 'note.deletion',

--- a/src/history/history.service.spec.ts
+++ b/src/history/history.service.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ConfigModule } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
 import { Mock } from 'ts-mockery';
@@ -16,6 +17,7 @@ import authConfigMock from '../config/mock/auth.config.mock';
 import databaseConfigMock from '../config/mock/database.config.mock';
 import noteConfigMock from '../config/mock/note.config.mock';
 import { NotInDBError } from '../errors/errors';
+import { eventModuleConfig } from '../events';
 import { Group } from '../groups/group.entity';
 import { Identity } from '../identity/identity.entity';
 import { LoggerModule } from '../logger/logger.module';
@@ -89,6 +91,7 @@ describe('HistoryService', () => {
             noteConfigMock,
           ],
         }),
+        EventEmitterModule.forRoot(eventModuleConfig),
       ],
     })
       .overrideProvider(getRepositoryToken(User))

--- a/src/media/media.service.spec.ts
+++ b/src/media/media.service.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ConfigModule } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { promises as fs } from 'fs';
@@ -17,6 +18,7 @@ import databaseConfigMock from '../config/mock/database.config.mock';
 import mediaConfigMock from '../config/mock/media.config.mock';
 import noteConfigMock from '../config/mock/note.config.mock';
 import { ClientError, NotInDBError } from '../errors/errors';
+import { eventModuleConfig } from '../events';
 import { Group } from '../groups/group.entity';
 import { Identity } from '../identity/identity.entity';
 import { LoggerModule } from '../logger/logger.module';
@@ -65,6 +67,7 @@ describe('MediaService', () => {
         LoggerModule,
         NotesModule,
         UsersModule,
+        EventEmitterModule.forRoot(eventModuleConfig),
       ],
     })
       .overrideProvider(getRepositoryToken(Edit))

--- a/src/notes/alias.service.spec.ts
+++ b/src/notes/alias.service.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource, EntityManager, Repository } from 'typeorm';
@@ -20,6 +21,7 @@ import {
   NotInDBError,
   PrimaryAliasDeletionForbiddenError,
 } from '../errors/errors';
+import { eventModuleConfig } from '../events';
 import { Group } from '../groups/group.entity';
 import { GroupsModule } from '../groups/groups.module';
 import { Identity } from '../identity/identity.entity';
@@ -93,6 +95,7 @@ describe('AliasService', () => {
         RevisionsModule,
         NotesModule,
         RealtimeNoteModule,
+        EventEmitterModule.forRoot(eventModuleConfig),
       ],
     })
       .overrideProvider(getRepositoryToken(Note))

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -61,6 +61,7 @@ describe('NotesService', () => {
   let forbiddenNoteId: string;
   let everyoneDefaultAccessPermission: string;
   let loggedinDefaultAccessPermission: string;
+  let eventEmitter: EventEmitter2;
   const everyone = Group.create(
     SpecialGroup.EVERYONE,
     SpecialGroup.EVERYONE,
@@ -281,6 +282,7 @@ describe('NotesService', () => {
     revisionRepo = module.get<Repository<Revision>>(
       getRepositoryToken(Revision),
     );
+    eventEmitter = module.get<EventEmitter2>(EventEmitter2);
   });
 
   it('should be defined', () => {
@@ -584,7 +586,15 @@ describe('NotesService', () => {
           expect(entry).toEqual(note);
           return entry;
         });
+      const mockedEventEmitter = jest
+        .spyOn(eventEmitter, 'emit')
+        .mockImplementationOnce((event) => {
+          expect(event).toEqual(NoteEvent.DELETION);
+          return true;
+        });
+      expect(mockedEventEmitter).not.toHaveBeenCalled();
       await service.deleteNote(note);
+      expect(mockedEventEmitter).toHaveBeenCalled();
     });
   });
 

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import {
@@ -29,6 +30,7 @@ import {
   ForbiddenIdError,
   NotInDBError,
 } from '../errors/errors';
+import { eventModuleConfig, NoteEvent } from '../events';
 import { Group } from '../groups/group.entity';
 import { GroupsModule } from '../groups/groups.module';
 import { SpecialGroup } from '../groups/groups.special';
@@ -238,6 +240,7 @@ describe('NotesService', () => {
             registerNoteConfig(noteMockConfig),
           ],
         }),
+        EventEmitterModule.forRoot(eventModuleConfig),
       ],
     })
       .overrideProvider(getRepositoryToken(Note))

--- a/src/permissions/permissions.module.ts
+++ b/src/permissions/permissions.module.ts
@@ -3,13 +3,12 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { forwardRef, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { GroupsModule } from '../groups/groups.module';
 import { LoggerModule } from '../logger/logger.module';
 import { Note } from '../notes/note.entity';
-import { RealtimeNoteModule } from '../realtime/realtime-note/realtime-note.module';
 import { UsersModule } from '../users/users.module';
 import { PermissionsService } from './permissions.service';
 
@@ -19,7 +18,6 @@ import { PermissionsService } from './permissions.service';
     UsersModule,
     GroupsModule,
     LoggerModule,
-    forwardRef(() => RealtimeNoteModule),
   ],
   exports: [PermissionsService],
   providers: [PermissionsService],

--- a/src/permissions/permissions.service.spec.ts
+++ b/src/permissions/permissions.service.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ConfigModule } from '@nestjs/config';
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource, EntityManager, Repository } from 'typeorm';
@@ -21,6 +22,7 @@ import {
 } from '../config/mock/note.config.mock';
 import { NoteConfig } from '../config/note.config';
 import { PermissionsUpdateInconsistentError } from '../errors/errors';
+import { eventModuleConfig, NoteEvent } from '../events';
 import { Group } from '../groups/group.entity';
 import { GroupsModule } from '../groups/groups.module';
 import { SpecialGroup } from '../groups/groups.special';
@@ -34,7 +36,6 @@ import {
 import { Note } from '../notes/note.entity';
 import { NotesModule } from '../notes/notes.module';
 import { Tag } from '../notes/tag.entity';
-import { RealtimeNoteModule } from '../realtime/realtime-note/realtime-note.module';
 import { Edit } from '../revisions/edit.entity';
 import { Revision } from '../revisions/revision.entity';
 import { Session } from '../users/session.entity';
@@ -110,7 +111,7 @@ describe('PermissionsService', () => {
           ],
         }),
         GroupsModule,
-        RealtimeNoteModule,
+        EventEmitterModule.forRoot(eventModuleConfig),
       ],
     })
       .overrideProvider(getRepositoryToken(User))

--- a/src/permissions/permissions.service.spec.ts
+++ b/src/permissions/permissions.service.spec.ts
@@ -52,6 +52,7 @@ describe('PermissionsService', () => {
   let noteRepo: Repository<Note>;
   let userRepo: Repository<User>;
   let groupRepo: Repository<Group>;
+  let eventEmitter: EventEmitter2;
   const noteMockConfig: NoteConfig = createDefaultMockNoteConfig();
 
   beforeAll(async () => {
@@ -145,6 +146,11 @@ describe('PermissionsService', () => {
     notes = await createNoteUserPermissionNotes();
     groupRepo = module.get<Repository<Group>>(getRepositoryToken(Group));
     noteRepo = module.get<Repository<Note>>(getRepositoryToken(Note));
+    eventEmitter = module.get<EventEmitter2>(EventEmitter2);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   // The two users we test with:
@@ -730,6 +736,27 @@ describe('PermissionsService', () => {
       false,
     ) as Group;
     const note = Note.create(user) as Note;
+    it('emits PERMISSION_CHANGE event', async () => {
+      jest
+        .spyOn(noteRepo, 'save')
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        .mockImplementationOnce(async (entry: Note) => {
+          return entry;
+        });
+      const mockedEventEmitter = jest
+        .spyOn(eventEmitter, 'emit')
+        .mockImplementationOnce((event) => {
+          expect(event).toEqual(NoteEvent.PERMISSION_CHANGE);
+          return true;
+        });
+      expect(mockedEventEmitter).not.toHaveBeenCalled();
+      await service.updateNotePermissions(note, {
+        sharedToUsers: [],
+        sharedToGroups: [],
+      });
+      expect(mockedEventEmitter).toHaveBeenCalled();
+    });
     describe('works', () => {
       it('with empty GroupPermissions and with empty UserPermissions', async () => {
         jest
@@ -1037,6 +1064,26 @@ describe('PermissionsService', () => {
   });
 
   describe('setUserPermission', () => {
+    it('emits PERMISSION_CHANGE event', async () => {
+      jest
+        .spyOn(noteRepo, 'save')
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        .mockImplementationOnce(async (entry: Note) => {
+          return entry;
+        });
+      const note = Note.create(null) as Note;
+      const user = User.create('test', 'Testy') as User;
+      const mockedEventEmitter = jest
+        .spyOn(eventEmitter, 'emit')
+        .mockImplementationOnce((event) => {
+          expect(event).toEqual(NoteEvent.PERMISSION_CHANGE);
+          return true;
+        });
+      expect(mockedEventEmitter).not.toHaveBeenCalled();
+      await service.setUserPermission(note, user, true);
+      expect(mockedEventEmitter).toHaveBeenCalled();
+    });
     describe('works', () => {
       it('with user not added before and editable', async () => {
         jest
@@ -1113,6 +1160,29 @@ describe('PermissionsService', () => {
   });
 
   describe('removeUserPermission', () => {
+    it('emits PERMISSION_CHANGE event', async () => {
+      jest
+        .spyOn(noteRepo, 'save')
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        .mockImplementationOnce(async (entry: Note) => {
+          return entry;
+        });
+      const note = Note.create(null) as Note;
+      const user = User.create('test', 'Testy') as User;
+      note.userPermissions = Promise.resolve([
+        NoteUserPermission.create(user, note, true),
+      ]);
+      const mockedEventEmitter = jest
+        .spyOn(eventEmitter, 'emit')
+        .mockImplementationOnce((event) => {
+          expect(event).toEqual(NoteEvent.PERMISSION_CHANGE);
+          return true;
+        });
+      expect(mockedEventEmitter).not.toHaveBeenCalled();
+      await service.removeUserPermission(note, user);
+      expect(mockedEventEmitter).toHaveBeenCalled();
+    });
     describe('works', () => {
       it('with user added before and editable', async () => {
         jest
@@ -1151,6 +1221,26 @@ describe('PermissionsService', () => {
   });
 
   describe('setGroupPermission', () => {
+    it('emits PERMISSION_CHANGE event', async () => {
+      jest
+        .spyOn(noteRepo, 'save')
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        .mockImplementationOnce(async (entry: Note) => {
+          return entry;
+        });
+      const note = Note.create(null) as Note;
+      const group = Group.create('test', 'Testy', false) as Group;
+      const mockedEventEmitter = jest
+        .spyOn(eventEmitter, 'emit')
+        .mockImplementationOnce((event) => {
+          expect(event).toEqual(NoteEvent.PERMISSION_CHANGE);
+          return true;
+        });
+      expect(mockedEventEmitter).not.toHaveBeenCalled();
+      await service.setGroupPermission(note, group, true);
+      expect(mockedEventEmitter).toHaveBeenCalled();
+    });
     describe('works', () => {
       it('with group not added before and editable', async () => {
         jest
@@ -1243,6 +1333,29 @@ describe('PermissionsService', () => {
   });
 
   describe('removeGroupPermission', () => {
+    it('emits PERMISSION_CHANGE event', async () => {
+      jest
+        .spyOn(noteRepo, 'save')
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        .mockImplementationOnce(async (entry: Note) => {
+          return entry;
+        });
+      const note = Note.create(null) as Note;
+      const group = Group.create('test', 'Testy', false) as Group;
+      note.groupPermissions = Promise.resolve([
+        NoteGroupPermission.create(group, note, true),
+      ]);
+      const mockedEventEmitter = jest
+        .spyOn(eventEmitter, 'emit')
+        .mockImplementationOnce((event) => {
+          expect(event).toEqual(NoteEvent.PERMISSION_CHANGE);
+          return true;
+        });
+      expect(mockedEventEmitter).not.toHaveBeenCalled();
+      await service.removeGroupPermission(note, group);
+      expect(mockedEventEmitter).toHaveBeenCalled();
+    });
     describe('works', () => {
       it('with user added before and editable', async () => {
         jest

--- a/src/realtime/realtime-note/realtime-note.service.ts
+++ b/src/realtime/realtime-note/realtime-note.service.ts
@@ -5,9 +5,11 @@
  */
 import { Optional } from '@mrdrogdrog/optional';
 import { BeforeApplicationShutdown, Inject, Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
 import appConfiguration, { AppConfig } from '../../config/app.config';
+import { NoteEvent } from '../../events';
 import { ConsoleLoggerService } from '../../logger/console-logger.service';
 import { Note } from '../../notes/note.entity';
 import { RevisionsService } from '../../revisions/revisions.service';
@@ -100,5 +102,21 @@ export class RealtimeNoteService implements BeforeApplicationShutdown {
           );
         });
       });
+  }
+
+  @OnEvent(NoteEvent.PERMISSION_CHANGE)
+  public handleNotePermissionChanged(noteId: Note['id']): void {
+    const realtimeNote = this.realtimeNoteStore.find(noteId);
+    if (realtimeNote) {
+      realtimeNote.announcePermissionChange();
+    }
+  }
+
+  @OnEvent(NoteEvent.DELETION)
+  public handleNoteDeleted(noteId: Note['id']): void {
+    const realtimeNote = this.realtimeNoteStore.find(noteId);
+    if (realtimeNote) {
+      realtimeNote.announceNoteDeletion();
+    }
   }
 }

--- a/src/realtime/websocket/websocket.gateway.spec.ts
+++ b/src/realtime/websocket/websocket.gateway.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ConfigModule } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { IncomingMessage } from 'http';
@@ -17,6 +18,7 @@ import appConfigMock from '../../config/mock/app.config.mock';
 import authConfigMock from '../../config/mock/auth.config.mock';
 import databaseConfigMock from '../../config/mock/database.config.mock';
 import noteConfigMock from '../../config/mock/note.config.mock';
+import { eventModuleConfig } from '../../events';
 import { Group } from '../../groups/group.entity';
 import { Identity } from '../../identity/identity.entity';
 import { LoggerModule } from '../../logger/logger.module';
@@ -110,6 +112,7 @@ describe('Websocket gateway', () => {
             noteConfigMock,
           ],
         }),
+        EventEmitterModule.forRoot(eventModuleConfig),
       ],
     })
       .overrideProvider(getRepositoryToken(User))

--- a/src/revisions/revisions.service.spec.ts
+++ b/src/revisions/revisions.service.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ConfigModule } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Mock } from 'ts-mockery';
@@ -16,6 +17,7 @@ import authConfigMock from '../config/mock/auth.config.mock';
 import databaseConfigMock from '../config/mock/database.config.mock';
 import noteConfigMock from '../config/mock/note.config.mock';
 import { NotInDBError } from '../errors/errors';
+import { eventModuleConfig } from '../events';
 import { Group } from '../groups/group.entity';
 import { Identity } from '../identity/identity.entity';
 import { LoggerModule } from '../logger/logger.module';
@@ -58,6 +60,7 @@ describe('RevisionsService', () => {
             noteConfigMock,
           ],
         }),
+        EventEmitterModule.forRoot(eventModuleConfig),
       ],
     })
       .overrideProvider(getRepositoryToken(Edit))

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { Test, TestingModule, TestingModuleBuilder } from '@nestjs/testing';
 import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
@@ -30,6 +31,7 @@ import externalServicesConfigMock from '../src/config/mock/external-services.con
 import mediaConfigMock from '../src/config/mock/media.config.mock';
 import noteConfigMock from '../src/config/mock/note.config.mock';
 import { ErrorExceptionMapping } from '../src/errors/error-mapping';
+import { eventModuleConfig } from '../src/events';
 import { FrontendConfigModule } from '../src/frontend-config/frontend-config.module';
 import { GroupsModule } from '../src/groups/groups.module';
 import { GroupsService } from '../src/groups/groups.service';
@@ -233,6 +235,7 @@ export class TestSetupBuilder {
         FrontendConfigModule,
         IdentityModule,
         SessionModule,
+        EventEmitterModule.forRoot(eventModuleConfig),
       ],
       providers: [
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,6 +1238,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/event-emitter@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@nestjs/event-emitter@npm:1.3.1"
+  dependencies:
+    eventemitter2: 6.4.6
+  peerDependencies:
+    "@nestjs/common": ^7.0.0 || ^8.0.0 || ^9.0.0
+    "@nestjs/core": ^7.0.0 || ^8.0.0 || ^9.0.0
+    reflect-metadata: ^0.1.12
+  checksum: fd4b8f2ec6ff8f2aa5dce41d5bc4492ab22af908e42eff3b21978c929514ce816649ca1f077255171a8a586db731d0268b171a2e909f64dda7d6f2598b75a6fe
+  languageName: node
+  linkType: hard
+
 "@nestjs/mapped-types@npm:1.1.0":
   version: 1.1.0
   resolution: "@nestjs/mapped-types@npm:1.1.0"
@@ -4667,6 +4680,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter2@npm:6.4.6":
+  version: 6.4.6
+  resolution: "eventemitter2@npm:6.4.6"
+  checksum: 1ede7ce0c01298fa3bc1998b34857c2acd0e73a1d7406e37b9127a84712762cf303a46add62943ae6944cd806bdd29ff542344c727a012b2ea6fd3c90f059367
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^4.0.0":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
@@ -5469,6 +5489,7 @@ __metadata:
     "@nestjs/common": 9.1.2
     "@nestjs/config": 2.2.0
     "@nestjs/core": 9.1.2
+    "@nestjs/event-emitter": 1.3.1
     "@nestjs/passport": 9.0.0
     "@nestjs/platform-express": 9.1.2
     "@nestjs/platform-ws": 9.1.2


### PR DESCRIPTION
### Component/Part
event system

### Description
This PR adds an event system to HedgeDoc to send events, through the app without the need for tightly coupled services and modules. For now this is used to notify the realtime components of HedgeDoc about note permission changes or deletion.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x