### PR TITLE
fix(docs): Add a note that node 18 is not supported

### DIFF
--- a/docs/content/setup/manual-setup.md
+++ b/docs/content/setup/manual-setup.md
@@ -1,7 +1,7 @@
 # Manual Installation
 
 !!! info "Requirements on your server"
-    - Node.js `>= 14.13.1` or `>= 16`. We recommend you run HedgeDoc with the latest release of Node 16.
+    - Node.js `>= 14.13.1` or any version of Node 16. Node 18 is NOT supported. We recommend to run HedgeDoc with the latest release of Node 16.
     - Database (PostgreSQL, MySQL, MariaDB, SQLite)  
       The database must use charset `utf8`. This is typically the default in PostgreSQL and SQLite.  
       In MySQL and MariaDB UTF-8 might need to be set with `alter database <DBNAME> character set utf8 collate utf8_bin;`  


### PR DESCRIPTION
### Component/Part
Docs

### Description
Node 18 is not supported because of dependency problems. It's already covered by the package.json but not by the docs.
This PR fixes the docs.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #2695 
