### PR TITLE
fix: Remove all `Equal` in where Clause in `find`

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -27,6 +27,17 @@ describe('AuthService', () => {
   let userRepo: Repository<User>;
   let authTokenRepo: Repository<AuthToken>;
 
+  class CreateQueryBuilderClass {
+    leftJoinAndSelect: () => CreateQueryBuilderClass;
+    where: () => CreateQueryBuilderClass;
+    orWhere: () => CreateQueryBuilderClass;
+    setParameter: () => CreateQueryBuilderClass;
+    getOne: () => AuthToken;
+    getMany: () => AuthToken[];
+  }
+
+  let createQueryBuilderFunc: CreateQueryBuilderClass;
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -68,6 +79,21 @@ describe('AuthService', () => {
       'abc',
       new Date(new Date().getTime() + 60000), // make this AuthToken valid for 1min
     ) as AuthToken;
+
+    const createQueryBuilder = {
+      leftJoinAndSelect: () => createQueryBuilder,
+      where: () => createQueryBuilder,
+      orWhere: () => createQueryBuilder,
+      setParameter: () => createQueryBuilder,
+      getOne: () => authToken,
+      getMany: () => [authToken],
+    };
+    createQueryBuilderFunc = createQueryBuilder;
+    jest
+      .spyOn(authTokenRepo, 'createQueryBuilder')
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      .mockImplementation(() => createQueryBuilder);
   });
 
   it('should be defined', () => {
@@ -76,7 +102,7 @@ describe('AuthService', () => {
 
   describe('getTokensByUser', () => {
     it('works', async () => {
-      jest.spyOn(authTokenRepo, 'find').mockResolvedValueOnce([authToken]);
+      createQueryBuilderFunc.getMany = () => [authToken];
       const tokens = await service.getTokensByUser(user);
       expect(tokens).toHaveLength(1);
       expect(tokens).toEqual([authToken]);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -7,7 +7,7 @@ import { Injectable } from '@nestjs/common';
 import { Cron, Timeout } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import crypto, { randomBytes } from 'crypto';
-import { Equal, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import {
   NotInDBError,
@@ -160,9 +160,10 @@ export class AuthService {
   }
 
   async getTokensByUser(user: User): Promise<AuthToken[]> {
-    const tokens = await this.authTokenRepository.find({
-      where: { user: Equal(user) },
-    });
+    const tokens = await this.authTokenRepository
+      .createQueryBuilder('token')
+      .where('token.userId = :userId', { userId: user.id })
+      .getMany();
     if (tokens === null) {
       return [];
     }

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -8,7 +8,7 @@ import { ModuleRef } from '@nestjs/core';
 import { InjectRepository } from '@nestjs/typeorm';
 import crypto from 'crypto';
 import * as FileType from 'file-type';
-import { Equal, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import mediaConfiguration, { MediaConfig } from '../config/media.config';
 import { ClientError, NotInDBError } from '../errors/errors';
@@ -147,10 +147,10 @@ export class MediaService {
    * @return {MediaUpload[]} arary of media uploads owned by the user
    */
   async listUploadsByUser(user: User): Promise<MediaUpload[]> {
-    const mediaUploads = await this.mediaUploadRepository.find({
-      where: { user: Equal(user) },
-      relations: ['user', 'note'],
-    });
+    const mediaUploads = await this.mediaUploadRepository
+      .createQueryBuilder('media')
+      .where('media.userId = :userId', { userId: user.id })
+      .getMany();
     if (mediaUploads === null) {
       return [];
     }

--- a/src/utils/test-utils/mockSelectQueryBuilder.ts
+++ b/src/utils/test-utils/mockSelectQueryBuilder.ts
@@ -24,6 +24,7 @@ export function mockSelectQueryBuilder<T>(
     getOne: () => Promise.resolve(returnValue),
     orWhere: () => mockedQueryBuilder,
     setParameter: () => mockedQueryBuilder,
+    getMany: () => Promise.resolve(returnValue ? [returnValue] : []),
   });
   return mockedQueryBuilder;
 }


### PR DESCRIPTION
### Component/Part
Services

### Description
Remove all `Equal` in where Clause in `find` to fix #2467.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#2467 
