### PR TITLE
ci: add paths command to skip unnecessary GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,9 +18,15 @@ name: "CodeQL"
 on:
   push:
     branches: [ develop ]
+    paths:
+      - 'src/'
+      - 'test/'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ develop ]
+    paths:
+      - 'src/'
+      - 'test/'
   schedule:
     - cron: '15 4 * * 3'
 


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR skips unnecessary GitHub actions via paths command.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

