### PR TITLE
fix(note): permissions of purgeNoteRevisions

### DIFF
--- a/src/api/private/notes/notes.controller.ts
+++ b/src/api/private/notes/notes.controller.ts
@@ -165,7 +165,7 @@ export class NotesController {
 
   @Delete(':noteIdOrAlias/revisions')
   @OpenApi(204, 404)
-  @Permissions(Permission.READ)
+  @Permissions(Permission.OWNER)
   @UseInterceptors(GetNoteInterceptor)
   async purgeNoteRevisions(
     @RequestUser() user: User,


### PR DESCRIPTION
### Component/Part
note service

### Description
This PR fixes the permissions needed to purge all revisions in a note in the public api.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x