### PR TITLE
Throw error if noteId is empty

### DIFF
--- a/src/realtime/websocket/utils/extract-note-id-from-request-url.spec.ts
+++ b/src/realtime/websocket/utils/extract-note-id-from-request-url.spec.ts
@@ -30,6 +30,13 @@ describe('extract note id from path', () => {
     expect(() => extractNoteIdFromRequestUrl(mockedRequest)).toThrow();
   });
 
+  it('fails if note id is empty', () => {
+    const mockedRequest = Mock.of<IncomingMessage>({
+      url: '/realtime?noteId=',
+    });
+    expect(() => extractNoteIdFromRequestUrl(mockedRequest)).toThrow();
+  });
+
   it('fails if path is empty', () => {
     const mockedRequest = Mock.of<IncomingMessage>({
       url: '',

--- a/src/realtime/websocket/utils/extract-note-id-from-request-url.ts
+++ b/src/realtime/websocket/utils/extract-note-id-from-request-url.ts
@@ -21,7 +21,7 @@ export function extractNoteIdFromRequestUrl(request: IncomingMessage): string {
   const url = new URL(request.url, 'https://example.org');
   const noteId = url.searchParams.get('noteId');
   if (noteId === null || noteId === '') {
-    throw new Error(`Path doesn't contain parameter noteId: ${request.url}`);
+    throw new Error("Path doesn't contain parameter noteId");
   } else {
     return noteId;
   }

--- a/src/realtime/websocket/utils/extract-note-id-from-request-url.ts
+++ b/src/realtime/websocket/utils/extract-note-id-from-request-url.ts
@@ -20,8 +20,8 @@ export function extractNoteIdFromRequestUrl(request: IncomingMessage): string {
   // The example.org domain should be safe to use according to RFC 6761 §6.5.
   const url = new URL(request.url, 'https://example.org');
   const noteId = url.searchParams.get('noteId');
-  if (noteId === null) {
-    throw new Error("Path doesn't contain parameter noteId");
+  if (noteId === null || noteId === '') {
+    throw new Error(`Path doesn't contain parameter noteId: ${request.url}`);
   } else {
     return noteId;
   }


### PR DESCRIPTION
### Component/Part
realtime/websocket

### Description
This PR fixes the error handling when the url is "/realtime?noteId=".

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
