### PR TITLE
fix(config-mocks): adapt all mock config to use create and register functions

### DIFF
--- a/src/config/mock/app.config.mock.ts
+++ b/src/config/mock/app.config.mock.ts
@@ -3,18 +3,26 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { registerAs } from '@nestjs/config';
+import { ConfigFactoryKeyHost, registerAs } from '@nestjs/config';
+import { ConfigFactory } from '@nestjs/config/dist/interfaces';
 
 import { AppConfig } from '../app.config';
 import { Loglevel } from '../loglevel.enum';
 
-export default registerAs(
-  'appConfig',
-  (): AppConfig => ({
+export function createDefaultMockAppConfig(): AppConfig {
+  return {
     domain: 'md.example.com',
     rendererBaseUrl: 'md-renderer.example.com',
     port: 3000,
     loglevel: Loglevel.ERROR,
     persistInterval: 10,
-  }),
-);
+  };
+}
+
+export function registerAppConfig(
+  appConfig: AppConfig,
+): ConfigFactory<AppConfig> & ConfigFactoryKeyHost<AppConfig> {
+  return registerAs('appConfig', (): AppConfig => appConfig);
+}
+
+export default registerAppConfig(createDefaultMockAppConfig());

--- a/src/config/mock/auth.config.mock.ts
+++ b/src/config/mock/auth.config.mock.ts
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { registerAs } from '@nestjs/config';
+import { ConfigFactoryKeyHost, registerAs } from '@nestjs/config';
+import { ConfigFactory } from '@nestjs/config/dist/interfaces';
 
 import { AuthConfig } from '../auth.config';
 
-export default registerAs(
-  'authConfig',
-  (): AuthConfig => ({
+export function createDefaultMockAuthConfig(): AuthConfig {
+  return {
     session: {
       secret: 'my_secret',
       lifetime: 1209600000,
@@ -45,5 +45,13 @@ export default registerAs(
     ldap: [],
     saml: [],
     oauth2: [],
-  }),
-);
+  };
+}
+
+export function registerAuthConfig(
+  authConfig: AuthConfig,
+): ConfigFactory<AuthConfig> & ConfigFactoryKeyHost<AuthConfig> {
+  return registerAs('authConfig', (): AuthConfig => authConfig);
+}
+
+export default registerAuthConfig(createDefaultMockAuthConfig());

--- a/src/config/mock/customization.config.mock.ts
+++ b/src/config/mock/customization.config.mock.ts
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { registerAs } from '@nestjs/config';
+import { ConfigFactoryKeyHost, registerAs } from '@nestjs/config';
+import { ConfigFactory } from '@nestjs/config/dist/interfaces';
 
 import { CustomizationConfig } from '../customization.config';
 
-export default registerAs(
-  'customizationConfig',
-  (): CustomizationConfig => ({
+export function createDefaultMockCustomizationConfig(): CustomizationConfig {
+  return {
     branding: {
       customName: 'ACME Corp',
       customLogo: '',
@@ -19,5 +19,19 @@ export default registerAs(
       termsOfUse: '/test/termsOfUse',
       imprint: '/test/imprint',
     },
-  }),
+  };
+}
+
+export function registerCustomizationConfig(
+  customizationConfig: CustomizationConfig,
+): ConfigFactory<CustomizationConfig> &
+  ConfigFactoryKeyHost<CustomizationConfig> {
+  return registerAs(
+    'customizationConfig',
+    (): CustomizationConfig => customizationConfig,
+  );
+}
+
+export default registerCustomizationConfig(
+  createDefaultMockCustomizationConfig(),
 );

--- a/src/config/mock/database.config.mock.ts
+++ b/src/config/mock/database.config.mock.ts
@@ -3,14 +3,14 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { registerAs } from '@nestjs/config';
+import { ConfigFactoryKeyHost, registerAs } from '@nestjs/config';
+import { ConfigFactory } from '@nestjs/config/dist/interfaces';
 
 import { DatabaseType } from '../database-type.enum';
 import { DatabaseConfig } from '../database.config';
 
-export default registerAs(
-  'databaseConfig',
-  (): DatabaseConfig => ({
+export function createDefaultMockDatabaseConfig(): DatabaseConfig {
+  return {
     type: (process.env.HEDGEDOC_TEST_DB_TYPE ||
       DatabaseType.SQLITE) as DatabaseType,
     database: 'hedgedoc',
@@ -18,5 +18,13 @@ export default registerAs(
     host: 'localhost',
     port: 0,
     username: 'hedgedoc',
-  }),
-);
+  };
+}
+
+export function registerDatabaseConfig(
+  databaseConfig: DatabaseConfig,
+): ConfigFactory<DatabaseConfig> & ConfigFactoryKeyHost<DatabaseConfig> {
+  return registerAs('databaseConfig', (): DatabaseConfig => databaseConfig);
+}
+
+export default registerDatabaseConfig(createDefaultMockDatabaseConfig());

--- a/src/config/mock/external-services.config.mock.ts
+++ b/src/config/mock/external-services.config.mock.ts
@@ -3,14 +3,28 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { registerAs } from '@nestjs/config';
+import { ConfigFactoryKeyHost, registerAs } from '@nestjs/config';
+import { ConfigFactory } from '@nestjs/config/dist/interfaces';
 
 import { ExternalServicesConfig } from '../external-services.config';
 
-export default registerAs(
-  'externalServicesConfig',
-  (): ExternalServicesConfig => ({
+export function createDefaultMockExternalServicesConfig(): ExternalServicesConfig {
+  return {
     plantUmlServer: 'plantuml.example.com',
     imageProxy: 'imageProxy.example.com',
-  }),
+  };
+}
+
+export function registerExternalServiceConfig(
+  externalServicesConfig: ExternalServicesConfig,
+): ConfigFactory<ExternalServicesConfig> &
+  ConfigFactoryKeyHost<ExternalServicesConfig> {
+  return registerAs(
+    'externalServicesConfig',
+    (): ExternalServicesConfig => externalServicesConfig,
+  );
+}
+
+export default registerExternalServiceConfig(
+  createDefaultMockExternalServicesConfig(),
 );

--- a/src/config/mock/media.config.mock.ts
+++ b/src/config/mock/media.config.mock.ts
@@ -3,22 +3,46 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { registerAs } from '@nestjs/config';
+import { ConfigFactoryKeyHost, registerAs } from '@nestjs/config';
+import { ConfigFactory } from '@nestjs/config/dist/interfaces';
 
 import { BackendType } from '../../media/backends/backend-type.enum';
-import { MediaBackendConfig, MediaConfig } from '../media.config';
+import { MediaConfig } from '../media.config';
 
-export default registerAs(
-  'mediaConfig',
-  (): Omit<MediaConfig, 'backend'> & {
-    backend: Pick<MediaBackendConfig, 'use' | 'filesystem'>;
-  } => ({
+export function createDefaultMockMediaConfig(): MediaConfig {
+  return {
     backend: {
       use: BackendType.FILESYSTEM,
       filesystem: {
         uploadPath:
           'test_uploads' + Math.floor(Math.random() * 100000).toString(),
       },
+      s3: {
+        accessKeyId: '',
+        secretAccessKey: '',
+        bucket: '',
+        endPoint: '',
+      },
+      azure: {
+        connectionString: '',
+        container: '',
+      },
+      imgur: {
+        clientID: '',
+      },
+      webdav: {
+        connectionString: '',
+        uploadDir: '',
+        publicUrl: '',
+      },
     },
-  }),
-);
+  };
+}
+
+export function registerMediaConfig(
+  appConfig: MediaConfig,
+): ConfigFactory<MediaConfig> & ConfigFactoryKeyHost<MediaConfig> {
+  return registerAs('mediaConfig', (): MediaConfig => appConfig);
+}
+
+export default registerMediaConfig(createDefaultMockMediaConfig());


### PR DESCRIPTION
### Component/Part
mock configs

### Description
This PR changes the mock configs to use a create and register function. This makes it easier to change the config in tests. 

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
