### PR TITLE
docs: Fix keycloak guide

### DIFF
--- a/docs/content/guides/auth/keycloak.md
+++ b/docs/content/guides/auth/keycloak.md
@@ -40,6 +40,7 @@ CMD_OAUTH2_AUTHORIZATION_URL=https://keycloak.example.com/auth/realms/your-realm
 CMD_OAUTH2_CLIENT_ID=<your client ID>
 CMD_OAUTH2_CLIENT_SECRET=<your client secret, which you can find under the Credentials tab for your client>
 CMD_OAUTH2_PROVIDERNAME=Keycloak
+CMD_OAUTH2_SCOPE="openid email profile"
 CMD_DOMAIN=<hedgedoc.example.com>
 CMD_PROTOCOL_USESSL=true 
 CMD_URL_ADDPORT=false


### PR DESCRIPTION
### Component/Part
Docs

### Description
Since Keycloak version 20.0.0 it's needed to explicitly request the openid scope. Since we define it anyway, why not request all the scopes hedgedoc needs to function.

This patch should help to fix people's HedgeDoc deployments.

References:
https://github.com/keycloak/keycloak/pull/14237
https://shivering-isles.com/fixing-hedgedoc-profile-info-keycloak-20


### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

