### PR TITLE
Set the session cookie after registering

### DIFF
--- a/backend/src/api/private/auth/auth.controller.ts
+++ b/backend/src/api/private/auth/auth.controller.ts
@@ -54,13 +54,18 @@ export class AuthController {
   @UseGuards(RegistrationEnabledGuard)
   @Post('local')
   @OpenApi(201, 400, 409)
-  async registerUser(@Body() registerDto: RegisterDto): Promise<void> {
+  async registerUser(
+    @Req() request: RequestWithSession,
+    @Body() registerDto: RegisterDto,
+  ): Promise<void> {
     const user = await this.usersService.createUser(
       registerDto.username,
       registerDto.displayName,
     );
     // ToDo: Figure out how to rollback user if anything with this calls goes wrong
     await this.identityService.createLocalIdentity(user, registerDto.password);
+    request.session.user = registerDto.username;
+    request.session.authProvider = 'local';
   }
 
   @UseGuards(LoginEnabledGuard, SessionGuard)


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->
api/private/auth/local

### Description
This PR fixes https://github.com/hedgedoc/react-client/issues/2524
though I have no idea how the auth things work

### Steps
1. Clear your cookies
2. Visit /register and fill in the form
3. Click "Register"
4. No redirection, just an error message ← problem
5. Visit /login and see you can sign in

With this patch,
4. You will be redirected to /intro and you will see you have signed in

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [ ] Added / updated tests
- [ ] Added / updated documentation
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
https://github.com/hedgedoc/react-client/issues/2524