### PR TITLE
docs: fixed link to history writeup on index page

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -8,7 +8,7 @@ it by visiting our [HedgeDoc demo server][hedgedoc-demo].
 
 It is inspired by Hackpad, Etherpad and similar collaborative editors. This
 project originated with the team at [HackMD](https://hackmd.io) and now forked
-into its own organization. [A longer write-up can be read in the history doc](hedgedoc-history-details) or [you can have a look at an explanatory graph over at our website][hedgedoc-history].
+into its own organization. [A longer write-up can be read in the history doc][hedgedoc-history-details] or [you can have a look at an explanatory graph over at our website][hedgedoc-history].
 
 If you have any questions that aren't answered here, feel free to ask us on [Matrix][matrix.org-url], stop by our [community forums][hedgedoc-community] or have a look at our [FAQ][hedgedoc-faq].
 


### PR DESCRIPTION
### Component/Part
Documentation

### Description
This PR fixes the link

### Steps

- [ ] Added implementation
- [ ] Added / updated tests
- [x] Added / updated documentation
- [ ] Added changelog snippet
- [ ] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x#690 