### PR TITLE
feat: add note specific filename for unidiff format in revision patch

### DIFF
--- a/backend/src/revisions/revisions.service.spec.ts
+++ b/backend/src/revisions/revisions.service.spec.ts
@@ -199,7 +199,7 @@ describe('RevisionsService', () => {
 
   describe('createRevision', () => {
     it('creates a new revision', async () => {
-      const note = Mock.of<Note>({});
+      const note = Mock.of<Note>({ publicId: 'test-note' });
       const oldContent = 'old content\n';
       const newContent = 'new content\n';
 
@@ -216,10 +216,10 @@ describe('RevisionsService', () => {
       expect(createdRevision?.content).toBe(newContent);
       await expect(createdRevision?.note).resolves.toBe(note);
       expect(createdRevision?.patch).toMatchInlineSnapshot(`
-        "Index: markdownContent
+        "Index: test-note
         ===================================================================
-        --- markdownContent
-        +++ markdownContent
+        --- test-note
+        +++ test-note
         @@ -1,1 +1,1 @@
         -old content
         +new content

--- a/backend/src/revisions/revisions.service.ts
+++ b/backend/src/revisions/revisions.service.ts
@@ -153,7 +153,7 @@ export class RevisionsService {
       return undefined;
     }
     const patch = createPatch(
-      'markdownContent',
+      note.publicId,
       latestRevision.content,
       newContent,
     );


### PR DESCRIPTION
Signed-off-by: Philip Molares <philip.molares@udo.edu>

### Component/Part
revsision

### Description
This PR fixes the creation of the patch field in the revision.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
closes #2857 