### PR TITLE
fix(ci): add checkout action into check-changes job

### DIFF
--- a/.github/workflows/backend-docker.yml
+++ b/.github/workflows/backend-docker.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       changed: ${{ steps.changed.outputs.files }}
     steps:
+      - uses: actions/checkout@v3
       - name: Check for backend file changes
         uses: dorny/paths-filter@v2
         id: changed

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       changed: ${{ steps.changed.outputs.files }}
     steps:
+      - uses: actions/checkout@v3
       - name: Check for backend file changes
         uses: dorny/paths-filter@v2
         id: changed

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       changed: ${{ steps.changed.outputs.files }}
     steps:
+      - uses: actions/checkout@v3
       - name: Check for backend file changes
         uses: dorny/paths-filter@v2
         id: changed

--- a/.github/workflows/frontend-docker.yml
+++ b/.github/workflows/frontend-docker.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       changed: ${{ steps.changed.outputs.files }}
     steps:
+      - uses: actions/checkout@v3
       - name: Check for frontend file changes
         uses: dorny/paths-filter@v2
         id: changed

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -36,6 +36,7 @@ jobs:
     outputs:
       changed: ${{ steps.changed.outputs.files }}
     steps:
+      - uses: actions/checkout@v3
       - name: Check for frontend file changes
         uses: dorny/paths-filter@v2
         id: changed

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -24,7 +24,7 @@ defaults:
     working-directory: frontend
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       changed: ${{ steps.changed.outputs.files }}
     steps:
+      - uses: actions/checkout@v3
       - name: Check for frontend file changes
         uses: dorny/paths-filter@v2
         id: changed

--- a/.github/workflows/frontend-netlify-deploy-main.yml
+++ b/.github/workflows/frontend-netlify-deploy-main.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       changed: ${{ steps.changed.outputs.files }}
     steps:
+      - uses: actions/checkout@v3
       - name: Check for frontend file changes
         uses: dorny/paths-filter@v2
         id: changed

--- a/.github/workflows/frontend-netlify-deploy-pr.yml
+++ b/.github/workflows/frontend-netlify-deploy-pr.yml
@@ -35,7 +35,7 @@ defaults:
     working-directory: frontend
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend-netlify-deploy-pr.yml
+++ b/.github/workflows/frontend-netlify-deploy-pr.yml
@@ -47,6 +47,7 @@ jobs:
     outputs:
       changed: ${{ steps.changed.outputs.files }}
     steps:
+      - uses: actions/checkout@v3
       - name: Check for frontend file changes
         uses: dorny/paths-filter@v2
         id: changed

--- a/.github/workflows/frontend-test-and-build.yml
+++ b/.github/workflows/frontend-test-and-build.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       changed: ${{ steps.changed.outputs.files }}
     steps:
+      - uses: actions/checkout@v3
       - name: Check for frontend file changes
         uses: dorny/paths-filter@v2
         id: changed


### PR DESCRIPTION
### Component/Part
Github Action

### Description
This PR adds a checkout action to the check-changes jobs because otherwise the filter action fails.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
