### PR TITLE
fix(ci): prevent job run instead of step run

### DIFF
--- a/.github/workflows/backend-docker.yml
+++ b/.github/workflows/backend-docker.yml
@@ -63,21 +63,21 @@ jobs:
 
   sqlite-test:
     runs-on: ubuntu-latest
+    if: needs.changes.outputs.changed == 'true'
     needs: [ build-dev, changes ]
     container:
       image: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-ci:${{ github.sha }}
     steps:
       - run: cd /usr/src/app && yarn run test
-        if: needs.changes.outputs.changed == 'true'
 
   sqlite-e2e:
     runs-on: ubuntu-latest
+    if: needs.changes.outputs.changed == 'true'
     needs: [ build-dev, changes ]
     container:
       image: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-ci:${{ github.sha }}
     steps:
       - run: cd /usr/src/app && yarn run test:e2e
-        if: needs.changes.outputs.changed == 'true'
 
   build-prod:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Component/Part
CI

### Description
The CI runner can't pull an image that doesn't exist because it hasn't been built if no changes have been made to the backend.
This PR changes the workflow to skip the test jobs if no changes have been made. This should be okay because the jobs aren't marked as necessary.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
