### PR TITLE
Fix translation login button

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -8,7 +8,7 @@
     "Collaborate with URL": "Collaboration en temps-réel",
     "Support charts and MathJax": "Gère les graphiques et MathJax",
     "Support slide mode": "Gère le mode présentation",
-    "Sign In": "S'inscrire",
+    "Sign In": "S'inscrire | Se connecter",
     "Below is the history from browser": "Ci-dessous, l'historique du navigateur",
     "Welcome!": "Bienvenue !",
     "New note": "Nouvelle note",


### PR DESCRIPTION
Signed-off-by: ImaCrea <maximeguedj@pm.me>

### Component/Part
UI button

### Description
The translation for the login button in French was not easy as it was translating only "Register". So people wanting to sign in were lost and looking for a button to login. Best solution found is to insert a translation for "Register | Log in" in French : "S'inscrire | Se connecter".

Here's a screenshot done for testing if it looks well:
![Capture d’écran 2022-11-29 à 19 43 58](https://user-images.githubusercontent.com/764332/204619179-10130fa6-1b8f-4604-8155-369f57002b85.png)

Tested with "average" user and it does the job. :)

### Steps
Simply updates a translation.

