### PR TITLE
fix(ci): fix concurrency of ci runs if triggered by pull_request_target

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -18,13 +18,14 @@ permissions:
 env:
   NODE_VERSION: 18
   HEAD_COMMIT_HASH: "${{ !!github.event.pull_request && github.event.pull_request.head.sha || github.sha }}"
+  HEAD_REF: "${{ !!github.event.pull_request && github.event.pull_request.head.label || github.ref }}"
 
 defaults:
   run:
     working-directory: frontend
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ env.HEAD_REF }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend-netlify-deploy-pr.yml
+++ b/.github/workflows/frontend-netlify-deploy-pr.yml
@@ -35,7 +35,7 @@ defaults:
     working-directory: frontend
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.label }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Component/Part
CI

### Description
If a CI run is triggered by `pull_request_target` then `github.ref` is set to the target branch instead of the pull request branch. This causes that CI runs of parallel pull requests are cancelling each other because they have the same concurrency group.
This PR fixes this behaviour by using the pull request meta data for the concurrency group.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
