### PR TITLE
fix(ci): remove env var in workflow

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -18,14 +18,13 @@ permissions:
 env:
   NODE_VERSION: 18
   HEAD_COMMIT_HASH: "${{ !!github.event.pull_request && github.event.pull_request.head.sha || github.sha }}"
-  HEAD_REF: "${{ !!github.event.pull_request && github.event.pull_request.head.label || github.ref }}"
 
 defaults:
   run:
     working-directory: frontend
 
 concurrency:
-  group: ${{ github.workflow }}-${{ env.HEAD_REF }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ !!github.event.pull_request && github.event.pull_request.head.label || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR removes a env var in the frontend e2e workflow because under some circunstances the variable can't be resolved.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
