### PR TITLE
chore: Add resolution for codemirror/autocompletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "resolutions": {
     "domhandler": "5.0.3",
     "@codemirror/state": "6.1.4",
+    "@codemirror/autocomplete": "6.4.0",
     "@codemirror/view": "6.7.1",
     "@codemirror/language": "6.3.2",
     "@types/react": "18.0.26",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,23 +1758,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/autocomplete@npm:^6.0.0, @codemirror/autocomplete@npm:^6.3.2":
-  version: 6.3.4
-  resolution: "@codemirror/autocomplete@npm:6.3.4"
-  dependencies:
-    "@codemirror/language": ^6.0.0
-    "@codemirror/state": ^6.0.0
-    "@codemirror/view": ^6.6.0
-    "@lezer/common": ^1.0.0
-  peerDependencies:
-    "@codemirror/language": ^6.0.0
-    "@codemirror/state": ^6.0.0
-    "@codemirror/view": ^6.0.0
-    "@lezer/common": ^1.0.0
-  checksum: dafb6b3dee11551ed7a2ec1d20fa05641abefe2e0b5da045d4a3383146bb04f0b9650448a378a5921cc183944d626482a608b71f3da5a036a881a873006b8dbf
-  languageName: node
-  linkType: hard
-
 "@codemirror/commands@npm:6.1.2, @codemirror/commands@npm:^6.0.0, @codemirror/commands@npm:^6.1.0":
   version: 6.1.2
   resolution: "@codemirror/commands@npm:6.1.2"


### PR DESCRIPTION
### Component/Part
package.json

### Description
This PR adds a package resolution for `@codemirror/autocompletion`

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
