### PR TITLE
fix(frontend): Fix i18n types

### DIFF
--- a/frontend/src/components/common/links/translated-external-link.tsx
+++ b/frontend/src/components/common/links/translated-external-link.tsx
@@ -5,7 +5,7 @@
  */
 import { ExternalLink } from './external-link'
 import type { TranslatedLinkProps } from './types'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 /**
@@ -17,5 +17,6 @@ import { useTranslation } from 'react-i18next'
  */
 export const TranslatedExternalLink: React.FC<TranslatedLinkProps> = ({ i18nKey, i18nOption, ...props }) => {
   const { t } = useTranslation()
-  return <ExternalLink text={t(i18nKey, i18nOption)} {...props} />
+  const text = useMemo(() => (i18nOption ? t(i18nKey, i18nOption) : t(i18nKey)), [i18nKey, i18nOption, t])
+  return <ExternalLink text={text} {...props} />
 }

--- a/frontend/src/components/common/links/translated-internal-link.tsx
+++ b/frontend/src/components/common/links/translated-internal-link.tsx
@@ -5,7 +5,7 @@
  */
 import { InternalLink } from './internal-link'
 import type { TranslatedLinkProps } from './types'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 /**
@@ -17,5 +17,6 @@ import { useTranslation } from 'react-i18next'
  */
 export const TranslatedInternalLink: React.FC<TranslatedLinkProps> = ({ i18nKey, i18nOption, ...props }) => {
   const { t } = useTranslation()
-  return <InternalLink text={t(i18nKey, i18nOption)} {...props} />
+  const text = useMemo(() => (i18nOption ? t(i18nKey, i18nOption) : t(i18nKey)), [i18nKey, i18nOption, t])
+  return <InternalLink text={text} {...props} />
 }

--- a/frontend/src/components/common/links/types.d.ts
+++ b/frontend/src/components/common/links/types.d.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import type { IconName } from '../fork-awesome/fork-awesome-icon'
-import type { TOptions } from 'i18next'
+import type { TOptionsBase } from 'i18next'
 
 interface GeneralLinkProp {
   href: string
@@ -20,5 +20,5 @@ export interface LinkWithTextProps extends GeneralLinkProp {
 
 export interface TranslatedLinkProps extends GeneralLinkProp {
   i18nKey: string
-  i18nOption?: TOptions
+  i18nOption?: TOptionsBase & Record<string, unknown>
 }

--- a/frontend/src/components/notifications/ui-notification-boundary.tsx
+++ b/frontend/src/components/notifications/ui-notification-boundary.tsx
@@ -75,7 +75,7 @@ export const UiNotificationBoundary: React.FC<PropsWithChildren> = ({ children }
   )
 
   const showErrorNotification = useCallback(
-    (messageI18nKey: string, messageI18nOptions?: TOptions) =>
+    (messageI18nKey: string, messageI18nOptions: Record<string, unknown> = {}) =>
       (error: Error): void => {
         log.error(t(messageI18nKey, messageI18nOptions), error)
         void dispatchUiNotification('common.errorOccurred', messageI18nKey, {


### PR DESCRIPTION
### Component/Part
Frontend

### Description
This PR fixes type errors in some components that use i18n

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
