### PR TITLE
fix(i18n): clarify where to find /features for new users

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -96,6 +96,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - Note tags can be set as yaml-array in frontmatter.
 - If only one external login provider is configured, the sign-in button will directly link to it.
 - Links in Gist-Frames work only if explicitly opened in new tabs.
+- Changed default editor-placeholder to include the full url to the /features-page as new users might not find it otherwise.
 
 ---
 

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -233,7 +233,7 @@
       "failed": "Error while uploading {{fileName}}"
     },
     "untitledNote": "Untitled",
-    "placeholder": "← Start by entering a title here\n===\nVisit the features page if you don't know what to do.\nHappy hacking :)",
+    "placeholder": "← Start by entering a title here\n===\nVisit {{host}}features if you don't know what to do.\nHappy hacking :)",
     "infoToc": "Structure your note with headings to see a table-of-contents here.",
     "help": {
       "shortcuts": {

--- a/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
+++ b/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { useApplicationState } from '../../../hooks/common/use-application-state'
+import { useBaseUrl, ORIGIN } from '../../../hooks/common/use-base-url'
 import { useDarkModeState } from '../../../hooks/common/use-dark-mode-state'
 import { cypressAttribute, cypressId } from '../../../utils/cypress-attribute'
 import { findLanguageByCodeBlockName } from '../../markdown-renderer/extensions/base/code-block-markdown-extension/find-language-by-code-block-name'
@@ -129,6 +130,8 @@ export const EditorPane: React.FC<ScrollProps> = ({ scrollState, onScroll, onMak
 
   const darkModeActivated = useDarkModeState()
 
+  const editorOrigin = useBaseUrl(ORIGIN.EDITOR)
+
   return (
     <div
       className={`d-flex flex-column h-100 position-relative`}
@@ -140,7 +143,7 @@ export const EditorPane: React.FC<ScrollProps> = ({ scrollState, onScroll, onMak
       <ToolBar />
       <ReactCodeMirror
         editable={firstUpdateHappened && connectionSynced}
-        placeholder={t('editor.placeholder') ?? ''}
+        placeholder={t('editor.placeholder', { host: editorOrigin }) ?? ''}
         extensions={extensions}
         width={'100%'}
         height={'100%'}


### PR DESCRIPTION
Signed-off-by: Lukas Mertens <git@lukas-mertens.de>

### Component/Part
Editor

### Description
This PR changes the default placeholder to be more user-friendly. As a new user 

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [ ] Added / updated tests
- [ ] Added / updated documentation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

<img width="855" alt="image" src="https://user-images.githubusercontent.com/10901304/209788909-e9146fa4-239a-4f8d-8d35-024bdfeb3b9e.png">
