### PR TITLE
Fix frontend and backend crashes

### DIFF
--- a/commons/src/y-doc-message-transporter.ts
+++ b/commons/src/y-doc-message-transporter.ts
@@ -82,9 +82,10 @@ export abstract class YDocMessageTransporter extends EventEmitter2 {
         break
       case MessageType.COMPLETE_AWARENESS_STATE_REQUEST:
         this.send(
-          encodeAwarenessUpdateMessage(this.awareness, [
-            ...this.awareness.getStates().keys()
-          ])
+          encodeAwarenessUpdateMessage(
+            this.awareness,
+            Array.from(this.awareness.getStates().keys())
+          )
         )
         break
       case MessageType.AWARENESS_UPDATE:

--- a/frontend/src/components/editor-page/renderer-pane/hooks/use-send-scroll-state.ts
+++ b/frontend/src/components/editor-page/renderer-pane/hooks/use-send-scroll-state.ts
@@ -21,7 +21,12 @@ export const useSendScrollState = (scrollState: ScrollState | undefined): void =
   const rendererReady = useApplicationState((state) => state.rendererStatus.rendererReady)
 
   useEffect(() => {
-    if (rendererReady && scrollState && !equal(scrollState, oldScrollState.current)) {
+    if (
+      iframeCommunicator.isCommunicationEnabled() &&
+      rendererReady &&
+      scrollState &&
+      !equal(scrollState, oldScrollState.current)
+    ) {
       oldScrollState.current = scrollState
       iframeCommunicator.sendMessageToOtherSide({ type: CommunicationMessageType.SET_SCROLL_STATE, scrollState })
     }

--- a/frontend/src/components/render-page/window-post-message-communicator/window-post-message-communicator.ts
+++ b/frontend/src/components/render-page/window-post-message-communicator/window-post-message-communicator.ts
@@ -93,6 +93,10 @@ export abstract class WindowPostMessageCommunicator<
     this.communicationEnabled = true
   }
 
+  public isCommunicationEnabled(): boolean {
+    return this.communicationEnabled
+  }
+
   /**
    * Sends a message to the message target.
    *


### PR DESCRIPTION
### Component/Part
Frontend & Backend

### Description
This PR fixes two crashes. 
- One in the frontend when changing pages which can result in sending the scroll state if the iframe has already been unloaded
- One in the backend that is caused by weird nodejs errors that have worked before :shrug: .

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #3091