### PR TITLE
Fix image uploads

### DIFF
--- a/backend/src/api/private/media/media.controller.ts
+++ b/backend/src/api/private/media/media.controller.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import {
+  BadRequestException,
   Controller,
   Delete,
   Param,
@@ -73,12 +74,15 @@ export class MediaController {
     500,
   )
   async uploadMedia(
-    @UploadedFile() file: MulterFile,
+    @UploadedFile() file: MulterFile | undefined,
     @RequestNote() note: Note,
     @RequestUser() user: User,
   ): Promise<MediaUploadDto> {
+    if (file === undefined) {
+      throw new BadRequestException('Request does not contain a file');
+    }
     this.logger.debug(
-      `Recieved filename '${file.originalname}' for note '${note.id}' from user '${user.username}'`,
+      `Received filename '${file.originalname}' for note '${note.id}' from user '${user.username}'`,
       'uploadMedia',
     );
     const upload = await this.mediaService.saveFile(file.buffer, user, note);

--- a/backend/test/private-api/media.e2e-spec.ts
+++ b/backend/test/private-api/media.e2e-spec.ts
@@ -106,6 +106,13 @@ describe('Media', () => {
           .expect('Content-Type', /json/)
           .expect(500);
       });
+      it('no media uploaded', async () => {
+        await agent
+          .post('/api/private/media')
+          .set('HedgeDoc-Note', 'test_upload_media')
+          .expect(400);
+        await expect(fs.access(uploadPath)).rejects.toBeDefined();
+      });
       afterEach(async () => {
         await ensureDeleted(uploadPath);
       });

--- a/dev-reverse-proxy/Caddyfile
+++ b/dev-reverse-proxy/Caddyfile
@@ -13,4 +13,5 @@ log {
 reverse_proxy /realtime http://127.0.0.1:3000
 reverse_proxy /api/* http://127.0.0.1:3000
 reverse_proxy /public/* http://127.0.0.1:3000
+reverse_proxy /uploads/* http://127.0.0.1:3000
 reverse_proxy /* http://127.0.0.1:3001

--- a/frontend/src/api/media/index.ts
+++ b/frontend/src/api/media/index.ts
@@ -35,7 +35,6 @@ export const uploadFile = async (noteIdOrAlias: string, media: Blob): Promise<Me
   const postData = new FormData()
   postData.append('file', media)
   const response = await new PostApiRequestBuilder<MediaUpload, void>('media')
-    .withHeader('Content-Type', 'multipart/form-data')
     .withHeader('HedgeDoc-Note', noteIdOrAlias)
     .withBody(postData)
     .sendRequest()


### PR DESCRIPTION
### Component/Part
The upload stack™

### Description
This PR fixes image uploads by
- improving error handling on empty uploads slightly
- not sending the `Content-Type` header, which confuses multer
- configuring Caddy to proxy the uploads route to the backend
### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
