### PR TITLE
Fix flakiness for async loaded components

### DIFF
--- a/frontend/src/components/common/async-loading-boundary/__snapshots__/async-loading-boundary.test.tsx.snap
+++ b/frontend/src/components/common/async-loading-boundary/__snapshots__/async-loading-boundary.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Async loading boundary shows a waiting spinner if loading 1`] = `
+<div>
+  <div
+    class="m-3 d-flex align-items-center justify-content-center"
+  >
+    <i
+      class="fa  fa-spinner fa-spin "
+    />
+  </div>
+</div>
+`;
+
+exports[`Async loading boundary shows an error if error is given with loading 1`] = `
+<div>
+  <div
+    class="fade alert alert-danger show"
+    role="alert"
+  >
+    common.errorWhileLoading
+  </div>
+</div>
+`;
+
+exports[`Async loading boundary shows an error if error is given without loading 1`] = `
+<div>
+  <div
+    class="fade alert alert-danger show"
+    role="alert"
+  >
+    common.errorWhileLoading
+  </div>
+</div>
+`;
+
+exports[`Async loading boundary shows the children if not loading and no error 1`] = `
+<div>
+  children
+</div>
+`;

--- a/frontend/src/components/common/async-loading-boundary/__snapshots__/custom-async-loading-boundary.test.tsx.snap
+++ b/frontend/src/components/common/async-loading-boundary/__snapshots__/custom-async-loading-boundary.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Custom error async loading boundary shows a waiting spinner if loading 1`] = `
+<div>
+  wait
+</div>
+`;
+
+exports[`Custom error async loading boundary shows an error if error is given with loading 1`] = `
+<div>
+  error
+</div>
+`;
+
+exports[`Custom error async loading boundary shows an error if error is given without loading 1`] = `
+<div>
+  error
+</div>
+`;
+
+exports[`Custom error async loading boundary shows the children if not loading and no error 1`] = `
+<div>
+  children
+</div>
+`;

--- a/frontend/src/components/common/async-loading-boundary/async-loading-boundary.test.tsx
+++ b/frontend/src/components/common/async-loading-boundary/async-loading-boundary.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { mockI18n } from '../../markdown-renderer/test-utils/mock-i18n'
+import { AsyncLoadingBoundary } from './async-loading-boundary'
+import { render } from '@testing-library/react'
+
+describe('Async loading boundary', () => {
+  beforeAll(() => mockI18n())
+
+  it('shows the children if not loading and no error', () => {
+    const view = render(
+      <AsyncLoadingBoundary loading={false} componentName={'test'}>
+        children
+      </AsyncLoadingBoundary>
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+
+  it('shows a waiting spinner if loading', () => {
+    const view = render(
+      <AsyncLoadingBoundary loading={true} componentName={'test'}>
+        children
+      </AsyncLoadingBoundary>
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+
+  it('shows an error if error is given without loading', () => {
+    const view = render(
+      <AsyncLoadingBoundary loading={false} error={new Error('error')} componentName={'test'}>
+        children
+      </AsyncLoadingBoundary>
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+
+  it('shows an error if error is given with loading', () => {
+    const view = render(
+      <AsyncLoadingBoundary loading={true} error={new Error('error')} componentName={'test'}>
+        children
+      </AsyncLoadingBoundary>
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+})

--- a/frontend/src/components/common/async-loading-boundary/async-loading-boundary.tsx
+++ b/frontend/src/components/common/async-loading-boundary/async-loading-boundary.tsx
@@ -3,9 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { WaitSpinner } from './wait-spinner/wait-spinner'
-import type { PropsWithChildren, ReactNode } from 'react'
-import React, { Fragment } from 'react'
+import { WaitSpinner } from '../wait-spinner/wait-spinner'
+import { CustomAsyncLoadingBoundary } from './custom-async-loading-boundary'
+import type { PropsWithChildren } from 'react'
+import React, { Fragment, useMemo } from 'react'
 import { Alert } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -13,7 +14,6 @@ export interface AsyncLoadingBoundaryProps {
   loading: boolean
   error?: Error | boolean
   componentName: string
-  errorComponent?: ReactNode
 }
 
 /**
@@ -30,22 +30,27 @@ export const AsyncLoadingBoundary: React.FC<PropsWithChildren<AsyncLoadingBounda
   loading,
   error,
   componentName,
-  errorComponent,
   children
 }) => {
   useTranslation()
-  if (error !== undefined && error !== false) {
-    if (errorComponent) {
-      return <Fragment>{errorComponent}</Fragment>
-    }
-    return (
+
+  const errorComponent = useMemo(() => {
+    return error ? (
       <Alert variant={'danger'}>
         <Trans i18nKey={'common.errorWhileLoading'} values={{ name: componentName }} />
       </Alert>
+    ) : (
+      <Fragment></Fragment>
     )
-  } else if (loading) {
-    return <WaitSpinner />
-  } else {
-    return <Fragment>{children}</Fragment>
-  }
+  }, [componentName, error])
+
+  return (
+    <CustomAsyncLoadingBoundary
+      loading={loading}
+      error={error}
+      errorComponent={errorComponent}
+      loadingComponent={<WaitSpinner />}>
+      {children}
+    </CustomAsyncLoadingBoundary>
+  )
 }

--- a/frontend/src/components/common/async-loading-boundary/custom-async-loading-boundary.test.tsx
+++ b/frontend/src/components/common/async-loading-boundary/custom-async-loading-boundary.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { mockI18n } from '../../markdown-renderer/test-utils/mock-i18n'
+import { CustomAsyncLoadingBoundary } from './custom-async-loading-boundary'
+import { render } from '@testing-library/react'
+
+describe('Custom error async loading boundary', () => {
+  beforeAll(() => mockI18n())
+
+  it('shows the children if not loading and no error', () => {
+    const view = render(
+      <CustomAsyncLoadingBoundary loading={false} errorComponent={'error'} loadingComponent={'wait'}>
+        children
+      </CustomAsyncLoadingBoundary>
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+
+  it('shows a waiting spinner if loading', () => {
+    const view = render(
+      <CustomAsyncLoadingBoundary loading={true} errorComponent={'error'} loadingComponent={'wait'}>
+        children
+      </CustomAsyncLoadingBoundary>
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+
+  it('shows an error if error is given without loading', () => {
+    const view = render(
+      <CustomAsyncLoadingBoundary
+        loading={false}
+        error={new Error('error')}
+        errorComponent={'error'}
+        loadingComponent={'wait'}>
+        children
+      </CustomAsyncLoadingBoundary>
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+
+  it('shows an error if error is given with loading', () => {
+    const view = render(
+      <CustomAsyncLoadingBoundary
+        loading={true}
+        error={new Error('error')}
+        errorComponent={'error'}
+        loadingComponent={'wait'}>
+        children
+      </CustomAsyncLoadingBoundary>
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+})

--- a/frontend/src/components/common/async-loading-boundary/custom-async-loading-boundary.tsx
+++ b/frontend/src/components/common/async-loading-boundary/custom-async-loading-boundary.tsx
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import type { PropsWithChildren, ReactNode } from 'react'
+import React, { Fragment } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export interface CustomErrorAsyncLoadingBoundaryProps {
+  loading: boolean
+  error?: Error | boolean
+  errorComponent: ReactNode
+  loadingComponent: ReactNode
+}
+
+/**
+ * Indicates that a component currently loading or an error occurred.
+ * It's meant to be used in combination with useAsync from react-use.
+ *
+ * @param loading Indicates that the component is currently loading. Setting this will show a spinner instead of the children.
+ * @param error Indicates that an error occurred during the loading process. Setting this to any non-null value will show an error message instead of the children.
+ * @param componentName The name of the component that is currently loading. It will be shown in the error message.
+ * @param errorComponent Optional component that will be used in case of an error instead of the default alert message.
+ * @param children The child {@link ReactElement elements} that are only shown if the component isn't in loading or error state
+ */
+export const CustomAsyncLoadingBoundary: React.FC<PropsWithChildren<CustomErrorAsyncLoadingBoundaryProps>> = ({
+  loading,
+  error,
+  errorComponent,
+  loadingComponent,
+  children
+}) => {
+  useTranslation()
+  if (error) {
+    return <Fragment>{errorComponent}</Fragment>
+  } else if (loading) {
+    return <Fragment>{loadingComponent}</Fragment>
+  } else {
+    return <Fragment>{children}</Fragment>
+  }
+}

--- a/frontend/src/components/common/note-loading-boundary/hooks/use-load-note-from-server.ts
+++ b/frontend/src/components/common/note-loading-boundary/hooks/use-load-note-from-server.ts
@@ -14,7 +14,7 @@ import type { AsyncState } from 'react-use/lib/useAsyncFn'
  *
  * @return An {@link AsyncState async state} that represents the current state of the loading process.
  */
-export const useLoadNoteFromServer = (): [AsyncState<void>, () => void] => {
+export const useLoadNoteFromServer = (): [AsyncState<boolean>, () => void] => {
   const id = useSingleStringUrlParameter('noteId', undefined)
 
   return useAsyncFn(async () => {
@@ -23,5 +23,6 @@ export const useLoadNoteFromServer = (): [AsyncState<void>, () => void] => {
     }
     const noteFromServer = await getNote(id)
     setNoteDataFromServer(noteFromServer)
+    return true
   }, [id])
 }

--- a/frontend/src/components/common/user-avatar/user-avatar-for-username.tsx
+++ b/frontend/src/components/common/user-avatar/user-avatar-for-username.tsx
@@ -5,7 +5,7 @@
  */
 import { getUser } from '../../../api/users'
 import type { UserInfo } from '../../../api/users/types'
-import { AsyncLoadingBoundary } from '../async-loading-boundary'
+import { AsyncLoadingBoundary } from '../async-loading-boundary/async-loading-boundary'
 import type { UserAvatarProps } from './user-avatar'
 import { UserAvatar } from './user-avatar'
 import React from 'react'

--- a/frontend/src/components/common/user-avatar/user-avatar-for-username.tsx
+++ b/frontend/src/components/common/user-avatar/user-avatar-for-username.tsx
@@ -38,13 +38,9 @@ export const UserAvatarForUsername: React.FC<UserAvatarForUsernameProps> = ({ us
     }
   }, [username, t])
 
-  if (!value) {
-    return null
-  }
-
   return (
-    <AsyncLoadingBoundary loading={loading} error={error} componentName={'UserAvatarForUsername'}>
-      <UserAvatar user={value} {...props} />
+    <AsyncLoadingBoundary loading={loading || !value} error={error} componentName={'UserAvatarForUsername'}>
+      <UserAvatar user={value as UserInfo} {...props} />
     </AsyncLoadingBoundary>
   )
 }

--- a/frontend/src/components/editor-page/document-bar/revisions/revision-list.tsx
+++ b/frontend/src/components/editor-page/document-bar/revisions/revision-list.tsx
@@ -5,7 +5,7 @@
  */
 import { getAllRevisions } from '../../../../api/revisions'
 import { useApplicationState } from '../../../../hooks/common/use-application-state'
-import { AsyncLoadingBoundary } from '../../../common/async-loading-boundary'
+import { AsyncLoadingBoundary } from '../../../common/async-loading-boundary/async-loading-boundary'
 import { RevisionListEntry } from './revision-list-entry'
 import { DateTime } from 'luxon'
 import React, { useMemo } from 'react'

--- a/frontend/src/components/editor-page/document-bar/revisions/revision-list.tsx
+++ b/frontend/src/components/editor-page/document-bar/revisions/revision-list.tsx
@@ -55,7 +55,7 @@ export const RevisionList: React.FC<RevisionListProps> = ({ selectedRevisionId, 
   }, [loading, onRevisionSelect, revisions, selectedRevisionId])
 
   return (
-    <AsyncLoadingBoundary loading={loading} error={error} componentName={'revision list'}>
+    <AsyncLoadingBoundary loading={loading || !revisions} error={error} componentName={'revision list'}>
       <ListGroup>{revisionList}</ListGroup>
     </AsyncLoadingBoundary>
   )

--- a/frontend/src/components/editor-page/document-bar/revisions/revision-viewer.tsx
+++ b/frontend/src/components/editor-page/document-bar/revisions/revision-viewer.tsx
@@ -51,7 +51,7 @@ export const RevisionViewer: React.FC<RevisionViewerProps> = ({ selectedRevision
   }
 
   return (
-    <AsyncLoadingBoundary loading={loading} componentName={'RevisionViewer'} error={error}>
+    <AsyncLoadingBoundary loading={loading || !value} componentName={'RevisionViewer'} error={error}>
       <ReactDiffViewer
         oldValue={previousRevisionContent ?? ''}
         newValue={value?.content ?? ''}

--- a/frontend/src/components/editor-page/document-bar/revisions/revision-viewer.tsx
+++ b/frontend/src/components/editor-page/document-bar/revisions/revision-viewer.tsx
@@ -6,7 +6,7 @@
 import { getRevision } from '../../../../api/revisions'
 import { useApplicationState } from '../../../../hooks/common/use-application-state'
 import { useDarkModeState } from '../../../../hooks/common/use-dark-mode-state'
-import { AsyncLoadingBoundary } from '../../../common/async-loading-boundary'
+import { AsyncLoadingBoundary } from '../../../common/async-loading-boundary/async-loading-boundary'
 import { invertUnifiedPatch } from './invert-unified-patch'
 import { Optional } from '@mrdrogdrog/optional'
 import { applyPatch, parsePatch } from 'diff'

--- a/frontend/src/components/intro-page/intro-custom-content.tsx
+++ b/frontend/src/components/intro-page/intro-custom-content.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { Logger } from '../../utils/logger'
-import { AsyncLoadingBoundary } from '../common/async-loading-boundary'
+import { AsyncLoadingBoundary } from '../common/async-loading-boundary/async-loading-boundary'
 import { RenderIframe } from '../editor-page/renderer-pane/render-iframe'
 import { RendererType } from '../render-page/window-post-message-communicator/rendering-message'
 import { fetchFrontPageContent } from './requests'

--- a/frontend/src/components/intro-page/intro-custom-content.tsx
+++ b/frontend/src/components/intro-page/intro-custom-content.tsx
@@ -26,7 +26,7 @@ export const IntroCustomContent: React.FC = () => {
   }, [error])
 
   return (
-    <AsyncLoadingBoundary loading={loading} error={error} componentName={'custom intro content'}>
+    <AsyncLoadingBoundary loading={loading || !value} error={error} componentName={'custom intro content'}>
       <RenderIframe
         frameClasses={'w-100 overflow-y-hidden'}
         markdownContentLines={value as string[]}

--- a/frontend/src/extensions/extra-integrations/abcjs/abc-frame.tsx
+++ b/frontend/src/extensions/extra-integrations/abcjs/abc-frame.tsx
@@ -49,7 +49,7 @@ export const AbcFrame: React.FC<CodeProps> = ({ code }) => {
   }, [code, abcLib])
 
   return (
-    <AsyncLoadingBoundary loading={loading} error={!!loadingError} componentName={'abc.js'}>
+    <AsyncLoadingBoundary loading={loading || !abcLib} error={!!loadingError} componentName={'abc.js'}>
       <ShowIf condition={!!renderError}>
         <Alert variant={'danger'}>
           <Trans i18nKey={'editor.embeddings.abcJs.errorWhileRendering'} />

--- a/frontend/src/extensions/extra-integrations/abcjs/abc-frame.tsx
+++ b/frontend/src/extensions/extra-integrations/abcjs/abc-frame.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { AsyncLoadingBoundary } from '../../../components/common/async-loading-boundary'
+import { AsyncLoadingBoundary } from '../../../components/common/async-loading-boundary/async-loading-boundary'
 import { ShowIf } from '../../../components/common/show-if/show-if'
 import { WaitSpinner } from '../../../components/common/wait-spinner/wait-spinner'
 import type { CodeProps } from '../../../components/markdown-renderer/replace-components/code-block-component-replacer'

--- a/frontend/src/extensions/extra-integrations/flowchart/flowchart.tsx
+++ b/frontend/src/extensions/extra-integrations/flowchart/flowchart.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import fontStyles from '../../../../global-styles/variables.module.scss'
-import { AsyncLoadingBoundary } from '../../../components/common/async-loading-boundary'
+import { AsyncLoadingBoundary } from '../../../components/common/async-loading-boundary/async-loading-boundary'
 import { ShowIf } from '../../../components/common/show-if/show-if'
 import type { CodeProps } from '../../../components/markdown-renderer/replace-components/code-block-component-replacer'
 import { useDarkModeState } from '../../../hooks/common/use-dark-mode-state'

--- a/frontend/src/extensions/extra-integrations/flowchart/flowchart.tsx
+++ b/frontend/src/extensions/extra-integrations/flowchart/flowchart.tsx
@@ -70,7 +70,7 @@ export const FlowChart: React.FC<CodeProps> = ({ code }) => {
   }, [code, darkModeActivated, flowchartLib])
 
   return (
-    <AsyncLoadingBoundary loading={loading} componentName={'flowchart.js'} error={!!libLoadingError}>
+    <AsyncLoadingBoundary loading={loading || !flowchartLib} componentName={'flowchart.js'} error={!!libLoadingError}>
       <ShowIf condition={syntaxError}>
         <Alert variant={'danger'}>
           <Trans i18nKey={'renderer.flowchart.invalidSyntax'} />

--- a/frontend/src/extensions/extra-integrations/graphviz/graphviz-frame.tsx
+++ b/frontend/src/extensions/extra-integrations/graphviz/graphviz-frame.tsx
@@ -61,7 +61,7 @@ export const GraphvizFrame: React.FC<CodeProps> = ({ code }) => {
   }, [code, basePath, showError, graphvizImport])
 
   return (
-    <AsyncLoadingBoundary loading={isLibLoading} componentName={'graphviz'} error={libLoadingError}>
+    <AsyncLoadingBoundary loading={isLibLoading || !graphvizImport} componentName={'graphviz'} error={libLoadingError}>
       <ShowIf condition={!!error}>
         <Alert variant={'warning'}>{error}</Alert>
       </ShowIf>

--- a/frontend/src/extensions/extra-integrations/graphviz/graphviz-frame.tsx
+++ b/frontend/src/extensions/extra-integrations/graphviz/graphviz-frame.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { AsyncLoadingBoundary } from '../../../components/common/async-loading-boundary'
+import { AsyncLoadingBoundary } from '../../../components/common/async-loading-boundary/async-loading-boundary'
 import { ShowIf } from '../../../components/common/show-if/show-if'
 import type { CodeProps } from '../../../components/markdown-renderer/replace-components/code-block-component-replacer'
 import { cypressId } from '../../../utils/cypress-attribute'

--- a/frontend/src/extensions/extra-integrations/highlighted-code-fence/highlighted-code.tsx
+++ b/frontend/src/extensions/extra-integrations/highlighted-code-fence/highlighted-code.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { AsyncLoadingBoundary } from '../../../components/common/async-loading-boundary'
+import { AsyncLoadingBoundary } from '../../../components/common/async-loading-boundary/async-loading-boundary'
 import { CopyToClipboardButton } from '../../../components/common/copyable/copy-to-clipboard-button/copy-to-clipboard-button'
 import { cypressAttribute, cypressId } from '../../../utils/cypress-attribute'
 import { testId } from '../../../utils/test-id'

--- a/frontend/src/extensions/extra-integrations/highlighted-code-fence/highlighted-code.tsx
+++ b/frontend/src/extensions/extra-integrations/highlighted-code-fence/highlighted-code.tsx
@@ -36,7 +36,7 @@ export const HighlightedCode: React.FC<HighlightedCodeProps> = ({ code, language
   const wrappedDomLines = useAttachLineNumbers(codeDom, startLineNumber)
 
   return (
-    <AsyncLoadingBoundary loading={loading} error={!!error} componentName={'highlight.js'}>
+    <AsyncLoadingBoundary loading={loading || !hljsApi} error={!!error} componentName={'highlight.js'}>
       <div className={styles['code-highlighter']} {...cypressId('highlighted-code-block')}>
         <code
           {...testId('code-highlighter')}

--- a/frontend/src/extensions/extra-integrations/vega-lite/vega-lite-chart.tsx
+++ b/frontend/src/extensions/extra-integrations/vega-lite/vega-lite-chart.tsx
@@ -58,7 +58,7 @@ export const VegaLiteChart: React.FC<CodeProps> = ({ code }) => {
   }, [renderingError])
 
   return (
-    <AsyncLoadingBoundary loading={libLoading} error={libLoadingError} componentName={'Vega Lite'}>
+    <AsyncLoadingBoundary loading={libLoading || !vegaEmbed} error={libLoadingError} componentName={'Vega Lite'}>
       <ShowIf condition={!!renderingError}>
         <Alert variant={'danger'}>
           <Trans i18nKey={'renderer.vega-lite.errorJson'} />

--- a/frontend/src/extensions/extra-integrations/vega-lite/vega-lite-chart.tsx
+++ b/frontend/src/extensions/extra-integrations/vega-lite/vega-lite-chart.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { AsyncLoadingBoundary } from '../../../components/common/async-loading-boundary'
+import { AsyncLoadingBoundary } from '../../../components/common/async-loading-boundary/async-loading-boundary'
 import { ShowIf } from '../../../components/common/show-if/show-if'
 import type { CodeProps } from '../../../components/markdown-renderer/replace-components/code-block-component-replacer'
 import { Logger } from '../../../utils/logger'

--- a/frontend/src/pages/new.tsx
+++ b/frontend/src/pages/new.tsx
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { createNote } from '../api/notes'
-import { AsyncLoadingBoundary } from '../components/common/async-loading-boundary'
+import { LoadingScreen } from '../components/application-loader/loading-screen/loading-screen'
+import { CustomAsyncLoadingBoundary } from '../components/common/async-loading-boundary/custom-async-loading-boundary'
 import { Redirect } from '../components/common/redirect'
 import { CommonErrorPage } from '../components/error-pages/common-error-page'
 import { useSingleStringUrlParameter } from '../hooks/common/use-single-string-url-parameter'
@@ -22,10 +23,10 @@ export const NewNotePage: NextPage = () => {
   }, [newContent])
 
   return (
-    <AsyncLoadingBoundary
+    <CustomAsyncLoadingBoundary
       loading={loading}
-      componentName={'NewNotePage'}
       error={error}
+      loadingComponent={<LoadingScreen />}
       errorComponent={
         <CommonErrorPage
           titleI18nKey={'errors.noteCreationFailed.title'}
@@ -33,7 +34,7 @@ export const NewNotePage: NextPage = () => {
         />
       }>
       {value ? <Redirect to={`/n/${value.metadata.primaryAddress}`} /> : null}
-    </AsyncLoadingBoundary>
+    </CustomAsyncLoadingBoundary>
   )
 }
 

--- a/frontend/src/pages/new.tsx
+++ b/frontend/src/pages/new.tsx
@@ -24,7 +24,7 @@ export const NewNotePage: NextPage = () => {
 
   return (
     <CustomAsyncLoadingBoundary
-      loading={loading}
+      loading={loading || !value}
       error={error}
       loadingComponent={<LoadingScreen />}
       errorComponent={


### PR DESCRIPTION
### Component/Part
Async Loading Boundary

### Description
This PR splits the async loading boundary into one that shows an alert on error and one that shows a custom error.
It also tightens the conditions for components where the async loading boundary is used to prevent race conditions and flakiness of rendering.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

