### PR TITLE
Frontend does not handle PasswordTooWeakError

### DIFF
--- a/backend/src/api/private/auth/auth.controller.ts
+++ b/backend/src/api/private/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -53,7 +53,7 @@ export class AuthController {
 
   @UseGuards(RegistrationEnabledGuard)
   @Post('local')
-  @OpenApi(201, 400, 409)
+  @OpenApi(201, 400, 403, 409)
   async registerUser(
     @Req() request: RequestWithSession,
     @Body() registerDto: RegisterDto,

--- a/backend/src/api/utils/registration-enabled.guard.ts
+++ b/backend/src/api/utils/registration-enabled.guard.ts
@@ -1,16 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import {
-  BadRequestException,
-  CanActivate,
-  Inject,
-  Injectable,
-} from '@nestjs/common';
+import { CanActivate, Inject, Injectable } from '@nestjs/common';
 
 import authConfiguration, { AuthConfig } from '../../config/auth.config';
+import { RegistrationDisabledError } from '../../errors/errors';
 import { ConsoleLoggerService } from '../../logger/console-logger.service';
 
 @Injectable()
@@ -26,7 +22,7 @@ export class RegistrationEnabledGuard implements CanActivate {
   canActivate(): boolean {
     if (!this.authConfig.local.enableRegister) {
       this.logger.debug('User registration is disabled.', 'canActivate');
-      throw new BadRequestException('User registration is disabled.');
+      throw new RegistrationDisabledError();
     }
     return true;
   }

--- a/backend/src/errors/error-mapping.ts
+++ b/backend/src/errors/error-mapping.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -8,6 +8,7 @@ import {
   BadRequestException,
   Catch,
   ConflictException,
+  ForbiddenException,
   InternalServerErrorException,
   NotFoundException,
   PayloadTooLargeException,
@@ -74,6 +75,10 @@ const mapOfHedgeDocErrorsToHttpErrors: Map<string, HttpExceptionConstructor> =
     [
       'MaximumDocumentLengthExceededError',
       (object): HttpException => new PayloadTooLargeException(object),
+    ],
+    [
+      'RegistrationDisabledError',
+      (object): HttpException => new ForbiddenException(object),
     ],
   ]);
 

--- a/backend/src/errors/errors.ts
+++ b/backend/src/errors/errors.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -58,4 +58,8 @@ export class PasswordTooWeakError extends Error {
 
 export class MaximumDocumentLengthExceededError extends Error {
   name = 'MaximumDocumentLengthExceededError';
+}
+
+export class RegistrationDisabledError extends Error {
+  name = 'RegistrationDisabledError';
 }

--- a/backend/test/private-api/auth.e2e-spec.ts
+++ b/backend/test/private-api/auth.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -92,7 +92,7 @@ describe('Auth', () => {
           .post('/api/private/auth/local')
           .set('Content-Type', 'application/json')
           .send(JSON.stringify(registrationDto))
-          .expect(400);
+          .expect(403);
         testSetup.configService.get('authConfig').local.enableRegister = true;
       });
     });

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -561,7 +561,8 @@
         "message": "Your account has been registered successfully. You can now log in with your username and password."
       },
       "error": {
-        "registrationDisabled": "The registration is disabled",
+        "passwordTooWeak": "The password is too weak.",
+        "registrationDisabled": "The registration is disabled.",
         "usernameExisting": "There is already an account with this username.",
         "other": "There was an error while registering your account. Just try it again."
       }

--- a/frontend/src/api/auth/local.ts
+++ b/frontend/src/api/auth/local.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -36,6 +36,7 @@ export const doLocalLogin = async (username: string, password: string): Promise<
  * @param username The username of the new user.
  * @param displayName The display name of the new user.
  * @param password The password of the new user.
+ * @throws {RegisterError.PASSWORD_TOO_WEAK} when the backend deems the password too weak.
  * @throws {RegisterError.USERNAME_EXISTING} when there is already an existing user with the same username.
  * @throws {RegisterError.REGISTRATION_DISABLED} when the registration of local users has been disabled on the backend.
  * @throws {Error} when the api request wasn't successful.
@@ -48,7 +49,8 @@ export const doLocalRegister = async (username: string, displayName: string, pas
       password
     })
     .withStatusCodeErrorMapping({
-      400: RegisterError.REGISTRATION_DISABLED,
+      400: RegisterError.PASSWORD_TOO_WEAK,
+      403: RegisterError.REGISTRATION_DISABLED,
       409: RegisterError.USERNAME_EXISTING
     })
     .sendRequest()

--- a/frontend/src/api/auth/types.ts
+++ b/frontend/src/api/auth/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -12,6 +12,7 @@ export enum AuthError {
 
 export enum RegisterError {
   USERNAME_EXISTING = 'usernameExisting',
+  PASSWORD_TOO_WEAK = 'passwordTooWeak',
   REGISTRATION_DISABLED = 'registrationDisabled',
   OTHER = 'other'
 }

--- a/frontend/src/components/register-page/register-error/register-error.tsx
+++ b/frontend/src/components/register-page/register-error/register-error.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -22,6 +22,8 @@ export const RegisterError: React.FC<RegisterErrorProps> = ({ error }) => {
 
   const errorMessageI18nKey = useMemo(() => {
     switch (error) {
+      case RegisterErrorType.PASSWORD_TOO_WEAK:
+        return 'login.register.error.passwordTooWeak'
       case RegisterErrorType.REGISTRATION_DISABLED:
         return 'login.register.error.registrationDisabled'
       case RegisterErrorType.USERNAME_EXISTING:


### PR DESCRIPTION
### Component/Part
backend: error mapping of RegistrationDisabledError
frontend: handling of RegistrationDiabledError and PasswordtToWeakError

### Description
This PR fixes/adds/improves/...

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #3134 