### PR TITLE
fix(frontend): import type from the correct file

### DIFF
--- a/frontend/src/components/editor-page/editor-pane/tool-bar/formatters/replace-selection.test.ts
+++ b/frontend/src/components/editor-page/editor-pane/tool-bar/formatters/replace-selection.test.ts
@@ -1,10 +1,10 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import type { ContentEdits } from './changes'
 import { replaceSelection } from './replace-selection'
+import type { ContentEdits } from './types/changes'
 
 describe('replace selection', () => {
   it('inserts a text after the from-cursor if no to-cursor is present', () => {


### PR DESCRIPTION
### Component/Part
frontend test imports

### Description
This PR fixes the type import in the `replace-selection.test.ts`.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
