### PR TITLE
fix(tests): syntax for loop in console-logger service

### DIFF
--- a/backend/src/logger/console-logger.service.spec.ts
+++ b/backend/src/logger/console-logger.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -7,9 +7,11 @@ import { ConsoleLoggerService } from './console-logger.service';
 
 describe('sanitize', () => {
   it('removes non-printable ASCII character', () => {
-    for (let i = 0; i++; i < 32) {
-      const hexString = i.toString(16);
-      expect(ConsoleLoggerService.sanitize(`a${hexString}b`)).toEqual('ab');
+    for (let i = 0; i < 32; i++) {
+      const nonPrintableString = String.fromCharCode(i);
+      expect(ConsoleLoggerService.sanitize(`a${nonPrintableString}b`)).toEqual(
+        'ab',
+      );
     }
   });
   it('replaces non-zero-width space with space', () => {


### PR DESCRIPTION
### Component/Part
Tests

### Description
This PR fixes a wrongly defined loop in the tests for the sanitize method of the console logger.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
https://github.com/hedgedoc/hedgedoc/security/code-scanning/20
