### PR TITLE
misc(ci): pin dependencies of GitHub actions

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
 
     - name: Cache yarn cache
-      uses: actions/cache@v3
+      uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d # v3.2.2
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -28,7 +28,7 @@ runs:
           ${{ runner.os }}-yarn-${{ inputs.NODE_VERSION }}
 
     - name: Set up NodeJS
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
         node-version: ${{ inputs.NODE_VERSION }}
 

--- a/.github/workflows/backend-docker-cleanup.yml
+++ b/.github/workflows/backend-docker-cleanup.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cleanup CI containers
-        uses: snok/container-retention-policy@v1
+        uses: snok/container-retention-policy@6601a342b42bf08909bbd5b48736d4176100365b # v1.5.1
         with:
           image-names: hedgedoc-ci
           cut-off: A day ago UTC

--- a/.github/workflows/backend-docker.yml
+++ b/.github/workflows/backend-docker.yml
@@ -29,12 +29,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for backend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -49,16 +49,16 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: needs.changes.outputs.changed == 'true'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
         if: needs.changes.outputs.changed == 'true'
 
       - name: Login to GHCR
         if: needs.changes.outputs.changed == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build dev image
         if: needs.changes.outputs.changed == 'true'
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
         with:
           push: true
           file: backend/docker/Dockerfile
@@ -99,13 +99,13 @@ jobs:
     if: (github.event_name == 'pull_request_target') == github.event.pull_request.head.repo.fork
     needs: [ sqlite-test, sqlite-e2e, changes ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: needs.changes.outputs.changed == 'true'
 
       - name: Generate Docker metadata
         if: needs.changes.outputs.changed == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # v4.1.1
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           tags: |
@@ -115,16 +115,16 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
         if: needs.changes.outputs.changed == 'true'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
         if: needs.changes.outputs.changed == 'true'
 
       - name: Login to GHCR
         if: github.event_name == 'push' && needs.changes.outputs.changed == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build and push
         if: needs.changes.outputs.changed == 'true'
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
         with:
           push: ${{ github.event_name == 'push' }}
           file: backend/docker/Dockerfile

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -30,12 +30,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for backend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -49,7 +49,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: needs.changes.outputs.changed == 'true'
         with:
           fetch-depth: 0
@@ -84,7 +84,7 @@ jobs:
         ports:
           - 3306:3306
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: needs.changes.outputs.changed == 'true'
         with:
           fetch-depth: 0
@@ -113,7 +113,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: needs.changes.outputs.changed == 'true'
         with:
           fetch-depth: 0

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -31,12 +31,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for backend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -50,7 +50,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: needs.changes.outputs.changed == 'true'
 
       - name: Setup node
@@ -69,7 +69,7 @@ jobs:
       matrix:
         node-version: [ 14.x, 16.x, 18.x ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: needs.changes.outputs.changed == 'true'
 
       - name: Setup node
@@ -85,7 +85,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: needs.changes.outputs.changed == 'true'
         with:
           fetch-depth: 0
@@ -99,7 +99,7 @@ jobs:
       - run: yarn run test:cov
         if: needs.changes.outputs.changed == 'true'
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         if: needs.changes.outputs.changed == 'true'
         with:
           directory: backend/coverage

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,6 +34,10 @@ on:
   schedule:
     - cron: '15 4 * * 3'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze
@@ -53,11 +57,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@959cbb7472c4d4ad70cdfe6f4976053fe48ab394 # v2.1.37
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -69,7 +73,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@959cbb7472c4d4ad70cdfe6f4976053fe48ab394 # v2.1.37
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -83,6 +87,6 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@959cbb7472c4d4ad70cdfe6f4976053fe48ab394 # v2.1.37
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/commons-lint.yml
+++ b/.github/workflows/commons-lint.yml
@@ -26,12 +26,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for frontend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Setup node
         if: needs.changes.outputs.changed == 'true'

--- a/.github/workflows/commons-tests.yml
+++ b/.github/workflows/commons-tests.yml
@@ -27,12 +27,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for frontend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Setup node
         if: needs.changes.outputs.changed == 'true'

--- a/.github/workflows/frontend-docker.yml
+++ b/.github/workflows/frontend-docker.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.job }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: Check for frontend changes
@@ -25,12 +28,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for frontend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -44,13 +47,13 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: needs.changes.outputs.changed == 'true'
 
       - name: Generate Docker metadata
         if: needs.changes.outputs.changed == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # v4.1.1
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           tags: |
@@ -61,15 +64,15 @@ jobs:
 
       - name: Set up QEMU
         if: needs.changes.outputs.changed == 'true'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
 
       - name: Set up Docker Buildx
         if: needs.changes.outputs.changed == 'true'
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request' && needs.changes.outputs.changed == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -77,7 +80,7 @@ jobs:
 
       - name: Build and push
         if: needs.changes.outputs.changed == 'true'
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
         with:
           push: true
           file: frontend/docker/Dockerfile

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -36,12 +36,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for frontend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -59,13 +59,13 @@ jobs:
     steps:
       - name: Check out repo
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: ${{ env.HEAD_COMMIT_HASH }}
 
       - name: Cache build
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/cache@v3.2.2
+        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d # v3.2.2
         id: build-cache
         with:
           path: frontend/.next
@@ -81,7 +81,7 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true' && needs.changes.outputs.changed == 'true'
         run: yarn build:test
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
         if: needs.changes.outputs.changed == 'true'
         with:
           retention-days: 1
@@ -108,11 +108,11 @@ jobs:
     steps:
       - name: Check out repo
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Cache build
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/cache@v3.2.2
+        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d # v3.2.2
         id: build-cache
         with:
           path: frontend/.next
@@ -125,7 +125,7 @@ jobs:
 
       - name: Cache yarn cache
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d # v3.2.2
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Set up NodeJS
         if: steps.build-cache.outputs.cache-hit != 'true' && needs.changes.outputs.changed == 'true'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -145,7 +145,7 @@ jobs:
 
       - name: Download built frontend
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
         with:
           name: e2e-build
           path: frontend/.next
@@ -167,7 +167,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
         if: needs.changes.outputs.changed == 'true'
         with:
           name: screenshots

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -26,12 +26,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for frontend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Setup node
         if: needs.changes.outputs.changed == 'true'

--- a/.github/workflows/frontend-netlify-deploy-main.yml
+++ b/.github/workflows/frontend-netlify-deploy-main.yml
@@ -29,12 +29,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for frontend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Setup node
         if: needs.changes.outputs.changed == 'true'

--- a/.github/workflows/frontend-netlify-deploy-pr.yml
+++ b/.github/workflows/frontend-netlify-deploy-pr.yml
@@ -47,12 +47,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for frontend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -108,7 +108,7 @@ jobs:
 
       - name: Mark GitHub deployment as started
         if: needs.changes.outputs.changed == 'true'
-        uses: bobheadxi/deployments@v1.3.0
+        uses: bobheadxi/deployments@9d4477fdaa4120020cd10ab7e97f68c801422e73 # v1.3.0
         id: github-deployment
         with:
           step: start
@@ -129,7 +129,7 @@ jobs:
 
       - name: Mark GitHub deployment as finished
         if: needs.changes.outputs.changed == 'true'
-        uses: bobheadxi/deployments@v1.3.0
+        uses: bobheadxi/deployments@9d4477fdaa4120020cd10ab7e97f68c801422e73 # v1.3.0
         with:
           step: finish
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/frontend-test-and-build.yml
+++ b/.github/workflows/frontend-test-and-build.yml
@@ -27,12 +27,12 @@ jobs:
     outputs:
       changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         if: github.event_name != 'push'
 
       - name: Check for frontend file changes
         if: github.event_name != 'push'
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changed
         with:
           filters: |
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: needs.changes.outputs.changed == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Setup node
         if: needs.changes.outputs.changed == 'true'

--- a/.github/workflows/njsscan-analysis.yml
+++ b/.github/workflows/njsscan-analysis.yml
@@ -19,13 +19,13 @@ jobs:
     name: Njsscan code scanning
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - name: Scan with njsscan
       id: njsscan
-      uses: ajinabraham/njsscan-action@master
+      uses: ajinabraham/njsscan-action@d58d8b2f26322cd35a9efb8003baac517f226d81 # master
       with:
         args: '--sarif --output results.sarif src || true'
     - name: Upload njsscan report
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@959cbb7472c4d4ad70cdfe6f4976053fe48ab394 # v2.1.37
       with:
         sarif_file: results.sarif

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -14,6 +14,6 @@ jobs:
   reuse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v1
+        uses: fsfe/reuse-action@e7a435374d26d54b324fa6699d8eafb076340dfd # v1.2.0


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR pins the dependencies of the GitHub actions we use. This is recommended by the OpenSSF and mentioned in numerous alerts of the scorecard tool.
Changes were generated using [StepSecurity SecureWorkflow](https://app.stepsecurity.io/secureworkflow/).

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
numerous "Code scanning" alerts by scorecard
