### PR TITLE
API documentation (Swagger): Version number + paths

### DIFF
--- a/backend/src/app-init.ts
+++ b/backend/src/app-init.ts
@@ -29,16 +29,16 @@ export async function setupApp(
   mediaConfig: MediaConfig,
   logger: ConsoleLoggerService,
 ): Promise<void> {
-  setupPublicApiDocs(app);
+  await setupPublicApiDocs(app);
   logger.log(
-    `Serving OpenAPI docs for public api under '/apidoc'`,
+    `Serving OpenAPI docs for public API under '/apidoc/v2'`,
     'AppBootstrap',
   );
 
   if (process.env.NODE_ENV === 'development') {
-    setupPrivateApiDocs(app);
+    await setupPrivateApiDocs(app);
     logger.log(
-      `Serving OpenAPI docs for private api under '/private/apidoc'`,
+      `Serving OpenAPI docs for private API under '/apidoc/private'`,
       'AppBootstrap',
     );
   }

--- a/backend/src/monitoring/server-status.dto.ts
+++ b/backend/src/monitoring/server-status.dto.ts
@@ -18,6 +18,8 @@ export class ServerVersion {
   preRelease?: string;
   @ApiProperty()
   commit?: string;
+  @ApiProperty()
+  fullString: string;
 }
 
 export class ServerStatusDto extends BaseDto {

--- a/backend/src/utils/serverVersion.ts
+++ b/backend/src/utils/serverVersion.ts
@@ -22,11 +22,15 @@ export async function getServerVersionFromPackageJson(): Promise<ServerVersion> 
     const versionParts: number[] = packageInfo.version
       .split('.')
       .map((x) => parseInt(x, 10));
+    const preRelease = 'dev'; // TODO: Replace this?
     versionCache = {
       major: versionParts[0],
       minor: versionParts[1],
       patch: versionParts[2],
-      preRelease: 'dev', // TODO: Replace this?
+      preRelease: preRelease,
+      fullString: `${versionParts[0]}.${versionParts[1]}.${versionParts[2]}${
+        preRelease ? '-' + preRelease : ''
+      }`,
     };
   }
 

--- a/backend/src/utils/swagger.ts
+++ b/backend/src/utils/swagger.ts
@@ -8,12 +8,13 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 import { PrivateApiModule } from '../api/private/private-api.module';
 import { PublicApiModule } from '../api/public/public-api.module';
+import { getServerVersionFromPackageJson } from './serverVersion';
 
-export function setupPublicApiDocs(app: INestApplication): void {
+export async function setupPublicApiDocs(app: INestApplication): Promise<void> {
+  const version = await getServerVersionFromPackageJson();
   const publicApiOptions = new DocumentBuilder()
     .setTitle('HedgeDoc Public API')
-    // TODO: Use real version
-    .setVersion('2.0-dev')
+    .setVersion(version.fullString)
     .addSecurity('token', {
       type: 'http',
       scheme: 'bearer',
@@ -25,11 +26,13 @@ export function setupPublicApiDocs(app: INestApplication): void {
   SwaggerModule.setup('apidoc', app, publicApi);
 }
 
-export function setupPrivateApiDocs(app: INestApplication): void {
+export async function setupPrivateApiDocs(
+  app: INestApplication,
+): Promise<void> {
+  const version = await getServerVersionFromPackageJson();
   const privateApiOptions = new DocumentBuilder()
     .setTitle('HedgeDoc Private API')
-    // TODO: Use real version
-    .setVersion('2.0-dev')
+    .setVersion(version.fullString)
     .build();
 
   const privateApi = SwaggerModule.createDocument(app, privateApiOptions, {

--- a/backend/src/utils/swagger.ts
+++ b/backend/src/utils/swagger.ts
@@ -23,7 +23,7 @@ export async function setupPublicApiDocs(app: INestApplication): Promise<void> {
   const publicApi = SwaggerModule.createDocument(app, publicApiOptions, {
     include: [PublicApiModule],
   });
-  SwaggerModule.setup('apidoc', app, publicApi);
+  SwaggerModule.setup('apidoc/v2', app, publicApi);
 }
 
 export async function setupPrivateApiDocs(
@@ -38,5 +38,5 @@ export async function setupPrivateApiDocs(
   const privateApi = SwaggerModule.createDocument(app, privateApiOptions, {
     include: [PrivateApiModule],
   });
-  SwaggerModule.setup('private/apidoc', app, privateApi);
+  SwaggerModule.setup('apidoc/private', app, privateApi);
 }

--- a/dev-reverse-proxy/Caddyfile
+++ b/dev-reverse-proxy/Caddyfile
@@ -14,4 +14,5 @@ reverse_proxy /realtime http://127.0.0.1:3000
 reverse_proxy /api/* http://127.0.0.1:3000
 reverse_proxy /public/* http://127.0.0.1:3000
 reverse_proxy /uploads/* http://127.0.0.1:3000
+reverse_proxy /apidoc/* http://127.0.0.1:3000
 reverse_proxy /* http://127.0.0.1:3001


### PR DESCRIPTION
### Component/Part
API documentation (Swagger UI)

### Description
This PR adds the real version number from the backend to the API docs. To accomplish this easily, the `ServerVersion` class is extended by a new field `fullString` that contains a pre-calculated string representation of the version parts.

Next, the paths of the API docs were slightly changed to be more similar to the actual API base URLs. The new routes are `/apidoc/v2` (for `/api/v2`) and `/apidoc/private` (for `/api/private`).

Finally, the Caddyfile has been extended to proxy the API docs from the backend server.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
