### PR TITLE
fix(redux): avoid state mutation in history redux

### DIFF
--- a/frontend/src/components/editor-page/hooks/use-update-local-history-entry.ts
+++ b/frontend/src/components/editor-page/hooks/use-update-local-history-entry.ts
@@ -43,10 +43,11 @@ export const useUpdateLocalHistoryEntry = (): void => {
     if (entry.origin === HistoryEntryOrigin.REMOTE) {
       return
     }
-    entry.title = currentNoteTitle
-    entry.tags = currentNoteTags
-    entry.lastVisitedAt = new Date().toISOString()
-    updateLocalHistoryEntry(id, entry)
+    const updatedEntry = { ...entry }
+    updatedEntry.title = currentNoteTitle
+    updatedEntry.tags = currentNoteTags
+    updatedEntry.lastVisitedAt = new Date().toISOString()
+    updateLocalHistoryEntry(id, updatedEntry)
     lastNoteTitle.current = currentNoteTitle
     lastNoteTags.current = currentNoteTags
   }, [id, userExists, currentNoteTitle, currentNoteTags])


### PR DESCRIPTION
### Component/Part
Redux -> History update

### Description
When updating the data of a note in the redux, the old state element gets manipulated and will be dispatched again into the state. Redux is not optimized for external state-mutations and has some weird side-effects in that case and sometimes throws an error.
This commit fixes the problem by using a clone of the entry.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
