### PR TITLE
feat(opengraph): add opengraph support

### DIFF
--- a/frontend/cypress/e2e/opengraph.spec.ts
+++ b/frontend/cypress/e2e/opengraph.spec.ts
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+describe('Opengraph metadata', () => {
+  beforeEach(() => {
+    cy.visitTestNote()
+  })
+
+  it('includes the note title if not overridden', () => {
+    cy.setCodemirrorContent('---\ntitle: Test title\n---')
+    cy.get('meta[property="og:title"]').should('have.attr', 'content', 'Test title')
+  })
+
+  it('includes the note title if overridden', () => {
+    cy.setCodemirrorContent('---\ntitle: Test title\nopengraph:\n  title: Overridden title\n---')
+    cy.get('meta[property="og:title"]').should('have.attr', 'content', 'Overridden title')
+  })
+
+  it('includes custom opengraph tags', () => {
+    cy.setCodemirrorContent('---\nopengraph:\n  image: https://dummyimage.com/48\n---')
+    cy.get('meta[property="og:image"]').should('have.attr', 'content', 'https://dummyimage.com/48')
+  })
+})

--- a/frontend/src/components/editor-page/editor-page-content.tsx
+++ b/frontend/src/components/editor-page/editor-page-content.tsx
@@ -17,6 +17,7 @@ import { EditorDocumentRenderer } from './editor-document-renderer/editor-docume
 import { EditorPane } from './editor-pane/editor-pane'
 import { useComponentsFromAppExtensions } from './editor-pane/hooks/use-components-from-app-extensions'
 import { useUpdateLocalHistoryEntry } from './hooks/use-update-local-history-entry'
+import { OpengraphHead } from './opengraph-head/opengraph-head'
 import { Sidebar } from './sidebar/sidebar'
 import { Splitter } from './splitter/splitter'
 import type { DualScrollState, ScrollState } from './synced-scroll/scroll-props'
@@ -128,6 +129,7 @@ export const EditorPageContent: React.FC = () => {
         {editorExtensionComponents}
         <CommunicatorImageLightbox />
         <NoteAndAppTitleHead />
+        <OpengraphHead />
         <MotdModal />
         <div className={'d-flex flex-column vh-100'}>
           <AppBar mode={AppBarMode.EDITOR} />

--- a/frontend/src/components/editor-page/opengraph-head/opengraph-head.tsx
+++ b/frontend/src/components/editor-page/opengraph-head/opengraph-head.tsx
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useApplicationState } from '../../../hooks/common/use-application-state'
+import { useNoteTitle } from '../../../hooks/common/use-note-title'
+import Head from 'next/head'
+import React, { useMemo } from 'react'
+
+/**
+ * Returns the meta tags for the opengraph protocol as defined in the note frontmatter.
+ */
+export const OpengraphHead: React.FC = () => {
+  const noteTitle = useNoteTitle()
+  const openGraphData = useApplicationState((state) => state.noteDetails.frontmatter.opengraph)
+  const openGraphMetaElements = useMemo(() => {
+    const elements = Object.entries(openGraphData)
+      .filter(([, value]) => value && String(value).trim() !== '')
+      .map(([key, value]) => <meta property={`og:${key}`} content={value} key={key} />)
+    if (!Object.prototype.hasOwnProperty.call(openGraphData, 'title')) {
+      elements.push(<meta property={'og:title'} content={noteTitle} />)
+    }
+    return elements
+  }, [noteTitle, openGraphData])
+
+  return <Head>{openGraphMetaElements}</Head>
+}

--- a/frontend/src/components/editor-page/opengraph-head/opengraph-head.tsx
+++ b/frontend/src/components/editor-page/opengraph-head/opengraph-head.tsx
@@ -18,7 +18,7 @@ export const OpengraphHead: React.FC = () => {
     const elements = Object.entries(openGraphData)
       .filter(([, value]) => value && String(value).trim() !== '')
       .map(([key, value]) => <meta property={`og:${key}`} content={value} key={key} />)
-    if (!Object.prototype.hasOwnProperty.call(openGraphData, 'title')) {
+    if (!('title' in openGraphData)) {
       elements.push(<meta property={'og:title'} content={noteTitle} />)
     }
     return elements


### PR DESCRIPTION
### Component/Part
Editor page

### Description
This PR adds support for the opengraph protocol. Opengraph tags defined in the frontmatter will be inserted into the HTML head.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Closes #2906 
