### PR TITLE
feat(frontend): add fork awesome linter

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
     - `{%pdf https://example.org/example-pdf.pdf %}` -> Embedding removed
 - The use of `sequence` as code block language ([Why?](https://github.com/hedgedoc/react-client/issues/488#issuecomment-683262875))
 - Comma-separated definition of tags in the yaml-frontmatter
+- Fork Awesome Icons will be removed in a future release
 
 ### Removed
 

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -223,7 +223,7 @@
       "shortcode": "The {{shortcode}} short-code is deprecated and will be removed in a future release. Use a single line URL instead.",
       "frontmatter": "The yaml-metadata is invalid.",
       "frontmatter-tags": "The comma-separated definition of tags in the yaml-metadata is deprecated. Use a yaml-array instead.",
-      "fork-awesome": "Fork Awesome is deprecated and will be removed in future release. Please use the new bootstrap icons instead. See {{link}} for more information."
+      "fork-awesome": "Fork Awesome is deprecated and will be removed in a future release. Please use bootstrap icons instead. See {{link}} for more information."
     },
     "upload": {
       "uploadFile": {

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -222,7 +222,8 @@
       "sequence": "The use of 'sequence' as code block language is deprecated and will be removed in a future release.",
       "shortcode": "The {{shortcode}} short-code is deprecated and will be removed in a future release. Use a single line URL instead.",
       "frontmatter": "The yaml-metadata is invalid.",
-      "frontmatter-tags": "The comma-separated definition of tags in the yaml-metadata is deprecated. Use a yaml-array instead."
+      "frontmatter-tags": "The comma-separated definition of tags in the yaml-metadata is deprecated. Use a yaml-array instead.",
+      "fork-awesome": "Fork Awesome is deprecated and will be removed in future release. Please use the new bootstrap icons instead. See {{link}} for more information."
     },
     "upload": {
       "uploadFile": {

--- a/frontend/src/components/editor-page/editor-pane/linter/single-line-regex-linter.ts
+++ b/frontend/src/components/editor-page/editor-pane/linter/single-line-regex-linter.ts
@@ -51,25 +51,28 @@ export class SingleLineRegexLinter implements Linter {
       .map(({ lineStartIndex, regexResult }) => this.createDiagnostic(lineStartIndex, regexResult as RegExpExecArray))
   }
 
-  private createDiagnostic(from: number, found: RegExpExecArray): Diagnostic {
-    let actions: Action[] = []
-    if (this.replace !== undefined) {
-      const replacedText = this.replace(found[1])
-      actions = [
-        {
-          name: t(this.actionLabel ?? 'editor.linter.defaultAction'),
-          apply: (view: EditorView, from: number, to: number) => {
-            view.dispatch({
-              changes: { from, to, insert: replacedText }
-            })
-          }
-        }
-      ]
+  private buildActions(found: RegExpExecArray): Action[] {
+    if (this.replace === undefined) {
+      return []
     }
+    const replacedText = this.replace(found[1])
+    return [
+      {
+        name: t(this.actionLabel ?? 'editor.linter.defaultAction'),
+        apply: (view: EditorView, from: number, to: number) => {
+          view.dispatch({
+            changes: { from, to, insert: replacedText }
+          })
+        }
+      }
+    ]
+  }
+
+  private createDiagnostic(from: number, found: RegExpExecArray): Diagnostic {
     return {
       from: from,
       to: from + found[0].length,
-      actions: actions,
+      actions: this.buildActions(found),
       message: this.message,
       severity: 'warning'
     }

--- a/frontend/src/extensions/extra-integrations/fork-awesome/fork-awesome-app-extension.ts
+++ b/frontend/src/extensions/extra-integrations/fork-awesome/fork-awesome-app-extension.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import type { Linter } from '../../../components/editor-page/editor-pane/linter/linter'
+import { SingleLineRegexLinter } from '../../../components/editor-page/editor-pane/linter/single-line-regex-linter'
+import { AppExtension } from '../../base/app-extension'
+import { t } from 'i18next'
+
+export const forkAwesomeRegex = /<i class=["']fa fa-[\w-]+["'](?: aria-hidden=["']true["'])?\/?>(?:<\/i>)?/
+
+/**
+ * Adds support for flow charts to the markdown rendering.
+ */
+export class ForkAwesomeAppExtension extends AppExtension {
+  buildCodeMirrorLinter(): Linter[] {
+    return [
+      new SingleLineRegexLinter(
+        forkAwesomeRegex,
+        t('editor.linter.fork-awesome', { link: 'https://docs.hedgedoc.org' }) // ToDo: Add correct link here
+      )
+    ]
+  }
+}

--- a/frontend/src/extensions/extra-integrations/fork-awesome/fork-awesome-app-extension.ts
+++ b/frontend/src/extensions/extra-integrations/fork-awesome/fork-awesome-app-extension.ts
@@ -8,7 +8,7 @@ import { SingleLineRegexLinter } from '../../../components/editor-page/editor-pa
 import { AppExtension } from '../../base/app-extension'
 import { t } from 'i18next'
 
-export const forkAwesomeRegex = /<i class=["']fa fa-[\w-]+["'](?: aria-hidden=["']true["'])?\/?>(?:<\/i>)?/
+const forkAwesomeRegex = /<i class=["'][\w\s]*fa-[\w-]+[\w\s-]*["'][^>]*\/?>(?:<\/i>)?/
 
 /**
  * Adds support for flow charts to the markdown rendering.

--- a/frontend/src/extensions/extra-integrations/optional-app-extensions.ts
+++ b/frontend/src/extensions/extra-integrations/optional-app-extensions.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -9,6 +9,7 @@ import { AlertAppExtension } from './alert/alert-app-extension'
 import { BlockquoteAppExtension } from './blockquote/blockquote-app-extension'
 import { CsvTableAppExtension } from './csv/csv-table-app-extension'
 import { FlowchartAppExtension } from './flowchart/flowchart-app-extension'
+import { ForkAwesomeAppExtension } from './fork-awesome/fork-awesome-app-extension'
 import { GistAppExtension } from './gist/gist-app-extension'
 import { GraphvizAppExtension } from './graphviz/graphviz-app-extension'
 import { HighlightedCodeFenceAppExtension } from './highlighted-code-fence/highlighted-code-fence-app-extension'
@@ -44,5 +45,6 @@ export const optionalAppExtensions: AppExtension[] = [
   new VimeoAppExtension(),
   new YoutubeAppExtension(),
   new TaskListCheckboxAppExtension(),
-  new HighlightedCodeFenceAppExtension()
+  new HighlightedCodeFenceAppExtension(),
+  new ForkAwesomeAppExtension()
 ]


### PR DESCRIPTION
### Component/Part
Linter

### Description
This PR adds a new linter that will tell users that their fork awesome icon is deprecated and will stop working in the future and that they should replace it with a new bootstrap icon.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#2929 