### PR TITLE
fix: create-non-existing-note-hint.test.tsx

### DIFF
--- a/frontend/src/components/common/note-loading-boundary/create-non-existing-note-hint.test.tsx
+++ b/frontend/src/components/common/note-loading-boundary/create-non-existing-note-hint.test.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -68,6 +68,7 @@ describe('create non existing note hint', () => {
     const onNoteCreatedCallback = jest.fn()
     const view = render(<CreateNonExistingNoteHint onNoteCreated={onNoteCreatedCallback}></CreateNonExistingNoteHint>)
     await screen.findByTestId('createNoteMessage')
+    await waitForOtherPromisesToFinish()
     expect(onNoteCreatedCallback).not.toBeCalled()
     expect(view.container).toMatchSnapshot()
   })
@@ -83,6 +84,7 @@ describe('create non existing note hint', () => {
     await waitFor(async () => {
       expect(await screen.findByTestId('loadingMessage')).toBeInTheDocument()
     })
+    await waitForOtherPromisesToFinish()
     expect(onNoteCreatedCallback).not.toBeCalled()
     expect(view.container).toMatchSnapshot()
   })
@@ -98,6 +100,7 @@ describe('create non existing note hint', () => {
     await waitFor(async () => {
       expect(await screen.findByTestId('noteCreated')).toBeInTheDocument()
     })
+    await waitForOtherPromisesToFinish()
     expect(onNoteCreatedCallback).toBeCalled()
     expect(view.container).toMatchSnapshot()
   })
@@ -113,6 +116,7 @@ describe('create non existing note hint', () => {
     await waitFor(async () => {
       expect(await screen.findByTestId('failedMessage')).toBeInTheDocument()
     })
+    await waitForOtherPromisesToFinish()
     expect(onNoteCreatedCallback).not.toBeCalled()
     expect(view.container).toMatchSnapshot()
   })

--- a/frontend/src/components/common/note-loading-boundary/create-non-existing-note-hint.tsx
+++ b/frontend/src/components/common/note-loading-boundary/create-non-existing-note-hint.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -20,6 +20,8 @@ export interface CreateNonExistingNoteHintProps {
 /**
  * Shows a button that creates an empty note with the alias from the current window URL.
  * When the button was clicked it also shows the progress.
+ *
+ * @param onNoteCreated A function that will be called after the note was created.
  */
 export const CreateNonExistingNoteHint: React.FC<CreateNonExistingNoteHintProps> = ({ onNoteCreated }) => {
   useTranslation()


### PR DESCRIPTION
### Component/Part
frontend test

### Description
This PR fixes the create-non-existing-note-hint.test.tsx.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
