### PR TITLE
fix(frontend): add error prop to password input

### DIFF
--- a/frontend/src/components/common/fields/fields.ts
+++ b/frontend/src/components/common/fields/fields.ts
@@ -8,4 +8,5 @@ import type { ChangeEvent } from 'react'
 export interface CommonFieldProps {
   onChange: (event: ChangeEvent<HTMLInputElement>) => void
   value: string
+  hasError?: boolean
 }

--- a/frontend/src/components/common/fields/new-password-field.tsx
+++ b/frontend/src/components/common/fields/new-password-field.tsx
@@ -14,7 +14,7 @@ import { Trans, useTranslation } from 'react-i18next'
  * @param onChange Hook that is called when the entered password changes.
  * @param value The currently entered password.
  */
-export const NewPasswordField: React.FC<CommonFieldProps> = ({ onChange, value }) => {
+export const NewPasswordField: React.FC<CommonFieldProps> = ({ onChange, value, hasError = false }) => {
   const { t } = useTranslation()
 
   const isValid = useMemo(() => {
@@ -30,6 +30,7 @@ export const NewPasswordField: React.FC<CommonFieldProps> = ({ onChange, value }
         type='password'
         size='sm'
         isValid={isValid}
+        isInvalid={hasError}
         onChange={onChange}
         placeholder={t('login.auth.password') ?? undefined}
         className='bg-dark text-light'

--- a/frontend/src/components/common/fields/password-again-field.tsx
+++ b/frontend/src/components/common/fields/password-again-field.tsx
@@ -19,16 +19,21 @@ interface PasswordAgainFieldProps extends CommonFieldProps {
  * @param value The currently entered retype of the password.
  * @param password The password entered into the password input field.
  */
-export const PasswordAgainField: React.FC<PasswordAgainFieldProps> = ({ onChange, value, password }) => {
+export const PasswordAgainField: React.FC<PasswordAgainFieldProps> = ({
+  onChange,
+  value,
+  password,
+  hasError = false
+}) => {
   const { t } = useTranslation()
 
   const isInvalid = useMemo(() => {
-    return value !== '' && password !== value
-  }, [password, value])
+    return value !== '' && password !== value && hasError
+  }, [password, value, hasError])
 
   const isValid = useMemo(() => {
-    return password !== '' && password === value
-  }, [password, value])
+    return password !== '' && password === value && !hasError
+  }, [password, value, hasError])
 
   return (
     <Form.Group>

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -69,6 +69,10 @@ export const RegisterPage: NextPage = () => {
     )
   }, [username, password, displayName, passwordAgain])
 
+  const isWeakPassword = useMemo(() => {
+    return error === RegisterErrorType.PASSWORD_TOO_WEAK
+  }, [error])
+
   const onUsernameChange = useOnInputChange(setUsername)
   const onDisplayNameChange = useOnInputChange(setDisplayName)
   const onPasswordChange = useOnInputChange(setPassword)
@@ -95,8 +99,13 @@ export const RegisterPage: NextPage = () => {
                 <Form onSubmit={doRegisterSubmit}>
                   <UsernameField onChange={onUsernameChange} value={username} />
                   <DisplayNameField onChange={onDisplayNameChange} value={displayName} />
-                  <NewPasswordField onChange={onPasswordChange} value={password} />
-                  <PasswordAgainField password={password} onChange={onPasswordAgainChange} value={passwordAgain} />
+                  <NewPasswordField onChange={onPasswordChange} value={password} hasError={isWeakPassword} />
+                  <PasswordAgainField
+                    password={password}
+                    onChange={onPasswordAgainChange}
+                    value={passwordAgain}
+                    hasError={isWeakPassword}
+                  />
 
                   <RegisterInfos />
 


### PR DESCRIPTION
Signed-off-by: Avinash <avinash.kumar.cs92@gmail.com>

### Component/Part
<!-- e.g database -->

### Description
This PR fixes style for password input error when there is an weak password error

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
[Fixes issue 3163](https://github.com/hedgedoc/hedgedoc/issues/3163)
