### PR TITLE
docs(setup): add freebsd ports to Community -> Distribution Packages

### DIFF
--- a/docs/content/setup/community.md
+++ b/docs/content/setup/community.md
@@ -72,3 +72,9 @@ using the button below. This will run the official Docker image from [quay.io](h
 HedgeDoc is available in the Arch Linux _community_ repository.
 
 [Link to the package](https://archlinux.org/packages/community/any/hedgedoc/)
+
+### FreeBSD
+
+HedgeDoc is available in the FreeBSD _ports_ repository. After installation, customise your `config.json` file, referring to the official HedgeDoc documentation.
+
+[Ports Repository](https://freshports.org/www/hedgedoc)


### PR DESCRIPTION
### Component/Part
docs

### Description
This PR adds the install method freebsd ports.

Thanks to Dave Cottlehuber.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->


- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

