### PR TITLE
fix(commons): remove redundant tsconfig for eslint

### DIFF
--- a/commons/.eslintrc.cjs
+++ b/commons/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "project": [
-            "./tsconfig-eslint.json"
+            "./tsconfig.json"
         ]
     },
     "plugins": [

--- a/commons/jest.config.json
+++ b/commons/jest.config.json
@@ -14,6 +14,7 @@
   "moduleNameMapper" : {
     "^(\\.{1,2}/.*)\\.js$" : "$1"
   },
+  "transformIgnorePatterns": ["<rootDir>/node_modules/"],
   "transform" : {
     "^.+\\.tsx?$" : [
       "ts-jest",

--- a/commons/tsconfig-eslint.json
+++ b/commons/tsconfig-eslint.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["./dist"]
-}

--- a/commons/tsconfig-eslint.json.license
+++ b/commons/tsconfig-eslint.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
-
-SPDX-License-Identifier: CC0-1.0

--- a/commons/tsconfig.json
+++ b/commons/tsconfig.json
@@ -20,5 +20,5 @@
     "sourceMap": true
   },
   "include": ["./src"],
-  "exclude": ["./dist", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["./dist"]
 }


### PR DESCRIPTION
### Component/Part
Commons

### Description
This PR removes the redundant tsconfig for linting

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

