### PR TITLE
fix(ci): Add write permissions for push of frontend image to ghcr

### DIFF
--- a/.github/workflows/frontend-docker.yml
+++ b/.github/workflows/frontend-docker.yml
@@ -18,6 +18,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   changes:


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR adds the necessary permissions for the CI to push the frontend docker image to GHCR.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
