### PR TITLE
fix(ci): deploy pull request only if label is present

### DIFF
--- a/.github/workflows/frontend-netlify-deploy-pr.yml
+++ b/.github/workflows/frontend-netlify-deploy-pr.yml
@@ -39,29 +39,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    name: Check for frontend changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      changed: ${{ github.event_name == 'push' || steps.changed.outputs.files }}
-    steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        if: github.event_name != 'push'
-
-      - name: Check for frontend file changes
-        if: github.event_name != 'push'
-        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
-        id: changed
-        with:
-          filters: |
-            files:
-              - 'commons/**'
-              - 'frontend/**'
-              - '.github/**'
-              - '.yarn/**'
-
   deploy:
     needs: changes
     if: "contains(github.event.pull_request.labels.*.name, 'ci: force deployment') && ((github.event_name == 'pull_request_target') == github.event.pull_request.head.repo.fork)"
@@ -71,43 +48,34 @@ jobs:
       DEPLOY_URL: "https://${{ github.event.number }}--hedgedoc-ui-test.netlify.app/"
     steps:
       - name: Checkout repository
-        if: needs.changes.outputs.changed == 'true'
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup node
-        if: needs.changes.outputs.changed == 'true'
         uses: ./.github/actions/setup-node
         with:
           NODE_VERSION: ${{ env.NODE_VERSION }}
 
       - name: Patch intro.md to include netlify banner.
-        if: needs.changes.outputs.changed == 'true'
         run: cp netlify/intro.md public/public/intro.md
 
       - name: Patch motd.md to include privacy policy.
-        if: needs.changes.outputs.changed == 'true'
         run: cp netlify/motd.md public/public/motd.md
 
       - name: Patch version.json to include git hash
-        if: needs.changes.outputs.changed == 'true'
         run: jq ".version = \"0.0.0+${GITHUB_SHA:0:8}\"" src/version.json > src/_version.json && mv src/_version.json src/version.json
 
       - name: Patch base URL
-        if: needs.changes.outputs.changed == 'true'
         run: echo "HD_BASE_URL=\"${{ env.DEPLOY_URL }}\"" >> .env.production
 
       - name: Build app
-        if: needs.changes.outputs.changed == 'true'
         run: yarn build:mock
 
       - name: Remove Next.js cache to avoid it being deployed
-        if: needs.changes.outputs.changed == 'true'
         run: rm -r .next/cache
 
       - name: Mark GitHub deployment as started
-        if: needs.changes.outputs.changed == 'true'
         uses: bobheadxi/deployments@88ce5600046c82542f8246ac287d0a53c461bca3 # v1.4.0
         id: github-deployment
         with:
@@ -118,17 +86,14 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Install netlify CLI
-        if: needs.changes.outputs.changed == 'true'
         run: "npm install -g netlify-cli@${{ env.NETLIFY_VERSION }}"
 
       - name: Run netlify CLI
-        if: needs.changes.outputs.changed == 'true'
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: "netlify deploy --build --context deploy-preview --alias \"${{ github.event.number }}\" --json --message \"PR #${{ github.event.number }}\""
 
       - name: Mark GitHub deployment as finished
-        if: needs.changes.outputs.changed == 'true'
         uses: bobheadxi/deployments@88ce5600046c82542f8246ac287d0a53c461bca3 # v1.4.0
         with:
           step: finish

--- a/.github/workflows/frontend-netlify-deploy-pr.yml
+++ b/.github/workflows/frontend-netlify-deploy-pr.yml
@@ -64,7 +64,7 @@ jobs:
 
   deploy:
     needs: changes
-    if: "(github.event.pull_request.draft == false || contains( github.event.pull_request.labels.*.name, 'ci: force deployment')) && ((github.event_name == 'pull_request_target') == github.event.pull_request.head.repo.fork)"
+    if: "contains(github.event.pull_request.labels.*.name, 'ci: force deployment') && ((github.event_name == 'pull_request_target') == github.event.pull_request.head.repo.fork)"
     runs-on: ubuntu-latest
     name: Deploys to netlify
     env:


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR removes the pull request condition from the deploy workflow so it only deploys if the label `ci: force deployment` is present.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
