### PR TITLE
fix(ci): fix docker build args

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,10 +67,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: .
-          build-args:
-            TURBO_TOKEN: "${{ secrets.TURBO_TOKEN }}"
-            TURBO_API: "${{ vars.TURBO_API }}"
-            TURBO_TEAM: "${{ vars.TURBO_TEAM }}"
+          build-args: |
+            TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
+            TURBO_API=${{ vars.TURBO_API }}
+            TURBO_TEAM=${{ vars.TURBO_TEAM }}
 
       - name: Build and push frontend
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
@@ -82,8 +82,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: .
-          build-args:
-            BUILD_VERSION: "${{ github.event.head_commit.id }}"
-            TURBO_TOKEN: "${{ secrets.TURBO_TOKEN }}"
-            TURBO_API: "${{ vars.TURBO_API }}"
-            TURBO_TEAM: "${{ vars.TURBO_TEAM }}"
+          build-args: |
+            BUILD_VERSION=${{ github.event.head_commit.id }}
+            TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
+            TURBO_API=${{ vars.TURBO_API }}
+            TURBO_TEAM=${{ vars.TURBO_TEAM }}


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR fixes the docker build-args in the CI workflow.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
