### PR TITLE
fix(commons): extract name of markdown content yjs channel into the commons package

### DIFF
--- a/backend/src/realtime/realtime-note/websocket-doc.ts
+++ b/backend/src/realtime/realtime-note/websocket-doc.ts
@@ -3,7 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { encodeDocumentUpdateMessage } from '@hedgedoc/commons';
+import {
+  encodeDocumentUpdateMessage,
+  MARKDOWN_CONTENT_CHANNEL_NAME,
+} from '@hedgedoc/commons';
 import { Doc } from 'yjs';
 
 import { RealtimeNote } from './realtime-note';
@@ -13,8 +16,6 @@ import { WebsocketConnection } from './websocket-connection';
  * This is the implementation of {@link Doc YDoc} which includes additional handlers for message sending and receiving.
  */
 export class WebsocketDoc extends Doc {
-  private static readonly channelName = 'markdownContent';
-
   /**
    * Creates a new WebsocketDoc instance.
    *
@@ -55,7 +56,7 @@ export class WebsocketDoc extends Doc {
    * @private
    */
   private initializeContent(initialContent: string): void {
-    this.getText(WebsocketDoc.channelName).insert(0, initialContent);
+    this.getText(MARKDOWN_CONTENT_CHANNEL_NAME).insert(0, initialContent);
   }
 
   /**
@@ -66,6 +67,6 @@ export class WebsocketDoc extends Doc {
    * @return The current note content.
    */
   public getCurrentContent(): string {
-    return this.getText(WebsocketDoc.channelName).toString();
+    return this.getText(MARKDOWN_CONTENT_CHANNEL_NAME).toString();
   }
 }

--- a/commons/src/constants/markdown-content-channel-name.ts
+++ b/commons/src/constants/markdown-content-channel-name.ts
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export const MARKDOWN_CONTENT_CHANNEL_NAME = 'markdownContent'

--- a/commons/src/index.ts
+++ b/commons/src/index.ts
@@ -33,3 +33,5 @@ export {
 export type { MessageTransporterEvents } from './y-doc-message-transporter.js'
 
 export { waitForOtherPromisesToFinish } from './utils/wait-for-other-promises-to-finish.js'
+
+export { MARKDOWN_CONTENT_CHANNEL_NAME } from './constants/markdown-content-channel-name.js'

--- a/commons/src/y-doc-message-transporter.test.ts
+++ b/commons/src/y-doc-message-transporter.test.ts
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { MARKDOWN_CONTENT_CHANNEL_NAME } from './constants/markdown-content-channel-name.js'
 import { encodeDocumentUpdateMessage } from './messages/document-update-message.js'
 import { MessageType } from './messages/message-type.enum.js'
 import { YDocMessageTransporter } from './y-doc-message-transporter.js'
@@ -55,9 +56,9 @@ describe('message transporter', () =>
     const docClient2: Doc = new Doc()
     const dummyAwareness: Awareness = new Awareness(docServer)
 
-    const textServer = docServer.getText('markdownContent')
-    const textClient1 = docClient1.getText('markdownContent')
-    const textClient2 = docClient2.getText('markdownContent')
+    const textServer = docServer.getText(MARKDOWN_CONTENT_CHANNEL_NAME)
+    const textClient1 = docClient1.getText(MARKDOWN_CONTENT_CHANNEL_NAME)
+    const textClient2 = docClient2.getText(MARKDOWN_CONTENT_CHANNEL_NAME)
     textServer.insert(0, 'This is a test note')
 
     textServer.observe(() =>

--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/mock-connection.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/mock-connection.ts
@@ -3,8 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { MARKDOWN_CONTENT_CHANNEL_NAME } from './use-markdown-content-y-text'
-import { YDocMessageTransporter } from '@hedgedoc/commons'
+import { MARKDOWN_CONTENT_CHANNEL_NAME, YDocMessageTransporter } from '@hedgedoc/commons'
 import type { Awareness } from 'y-protocols/awareness'
 import type { Doc } from 'yjs'
 

--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-markdown-content-y-text.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-markdown-content-y-text.ts
@@ -3,11 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { MARKDOWN_CONTENT_CHANNEL_NAME } from '@hedgedoc/commons'
 import { useMemo } from 'react'
 import type { Doc } from 'yjs'
-import type { YText } from 'yjs/dist/src/types/YText'
-
-export const MARKDOWN_CONTENT_CHANNEL_NAME = 'markdownContent'
+import type { Text as YText } from 'yjs'
 
 /**
  * Extracts the y-text channel that saves the markdown content from the given yDoc.


### PR DESCRIPTION
### Component/Part
Commons, Backend, Frontend

### Description
This PR extracts the name of the markdown content yjs channel into the commons package.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
