### PR TITLE
ci: disable renovate auto-rebase

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,6 @@
     "default:automergeDigest",
     ":gitSignOff",
     ":prHourlyLimitNone",
-    ":rebaseStalePrs",
     ":maintainLockFilesWeekly",
     ":automergePatch",
     ":separateMajorReleases"


### PR DESCRIPTION
### Component/Part
Renovate config

### Description
Save CI resources by not rebasing unnecessarily

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
