### PR TITLE
Refactor DefaultAccessLevel & NotesService

### DIFF
--- a/backend/src/config/default-access-level.enum.ts
+++ b/backend/src/config/default-access-level.enum.ts
@@ -4,21 +4,21 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-export enum DefaultAccessPermission {
+export enum DefaultAccessLevel {
   NONE = 'none',
   READ = 'read',
   WRITE = 'write',
 }
 
-export function getDefaultAccessPermissionOrdinal(
-  permission: DefaultAccessPermission,
+export function getDefaultAccessLevelOrdinal(
+  permission: DefaultAccessLevel,
 ): number {
   switch (permission) {
-    case DefaultAccessPermission.NONE:
+    case DefaultAccessLevel.NONE:
       return 0;
-    case DefaultAccessPermission.READ:
+    case DefaultAccessLevel.READ:
       return 1;
-    case DefaultAccessPermission.WRITE:
+    case DefaultAccessLevel.WRITE:
       return 2;
     default:
       throw Error('Unknown permission');

--- a/backend/src/config/mock/note.config.mock.ts
+++ b/backend/src/config/mock/note.config.mock.ts
@@ -6,7 +6,7 @@
 import { ConfigFactoryKeyHost, registerAs } from '@nestjs/config';
 import { ConfigFactory } from '@nestjs/config/dist/interfaces';
 
-import { DefaultAccessPermission } from '../default-access-permission.enum';
+import { DefaultAccessLevel } from '../default-access-level.enum';
 import { GuestAccess } from '../guest_access.enum';
 import { NoteConfig } from '../note.config';
 
@@ -16,8 +16,8 @@ export function createDefaultMockNoteConfig(): NoteConfig {
     forbiddenNoteIds: ['forbiddenNoteId'],
     permissions: {
       default: {
-        everyone: DefaultAccessPermission.READ,
-        loggedIn: DefaultAccessPermission.WRITE,
+        everyone: DefaultAccessLevel.READ,
+        loggedIn: DefaultAccessLevel.WRITE,
       },
     },
     guestAccess: GuestAccess.CREATE,

--- a/backend/src/config/note.config.spec.ts
+++ b/backend/src/config/note.config.spec.ts
@@ -5,7 +5,7 @@
  */
 import mockedEnv from 'mocked-env';
 
-import { DefaultAccessPermission } from './default-access-permission.enum';
+import { DefaultAccessLevel } from './default-access-level.enum';
 import { GuestAccess } from './guest_access.enum';
 import noteConfig from './note.config';
 
@@ -27,8 +27,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -41,10 +41,10 @@ describe('noteConfig', () => {
       expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
       expect(config.maxDocumentLength).toEqual(maxDocumentLength);
       expect(config.permissions.default.everyone).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
       expect(config.permissions.default.loggedIn).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
       expect(config.guestAccess).toEqual(guestAccess);
       restore();
@@ -55,8 +55,8 @@ describe('noteConfig', () => {
         {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -68,10 +68,10 @@ describe('noteConfig', () => {
       expect(config.forbiddenNoteIds).toHaveLength(0);
       expect(config.maxDocumentLength).toEqual(maxDocumentLength);
       expect(config.permissions.default.everyone).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
       expect(config.permissions.default.loggedIn).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
       expect(config.guestAccess).toEqual(guestAccess);
       restore();
@@ -83,8 +83,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteId,
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -97,10 +97,10 @@ describe('noteConfig', () => {
       expect(config.forbiddenNoteIds[0]).toEqual(forbiddenNoteId);
       expect(config.maxDocumentLength).toEqual(maxDocumentLength);
       expect(config.permissions.default.everyone).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
       expect(config.permissions.default.loggedIn).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
 
       expect(config.guestAccess).toEqual(guestAccess);
@@ -112,8 +112,8 @@ describe('noteConfig', () => {
         {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -126,10 +126,10 @@ describe('noteConfig', () => {
       expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
       expect(config.maxDocumentLength).toEqual(100000);
       expect(config.permissions.default.everyone).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
       expect(config.permissions.default.loggedIn).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
 
       expect(config.guestAccess).toEqual(guestAccess);
@@ -142,7 +142,7 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -155,10 +155,10 @@ describe('noteConfig', () => {
       expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
       expect(config.maxDocumentLength).toEqual(maxDocumentLength);
       expect(config.permissions.default.everyone).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
       expect(config.permissions.default.loggedIn).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
 
       expect(config.guestAccess).toEqual(guestAccess);
@@ -171,7 +171,7 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -184,10 +184,10 @@ describe('noteConfig', () => {
       expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
       expect(config.maxDocumentLength).toEqual(maxDocumentLength);
       expect(config.permissions.default.everyone).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
       expect(config.permissions.default.loggedIn).toEqual(
-        DefaultAccessPermission.WRITE,
+        DefaultAccessLevel.WRITE,
       );
 
       expect(config.guestAccess).toEqual(guestAccess);
@@ -200,7 +200,7 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
         {
@@ -212,10 +212,10 @@ describe('noteConfig', () => {
       expect(config.forbiddenNoteIds).toEqual(forbiddenNoteIds);
       expect(config.maxDocumentLength).toEqual(maxDocumentLength);
       expect(config.permissions.default.everyone).toEqual(
-        DefaultAccessPermission.READ,
+        DefaultAccessLevel.READ,
       );
       expect(config.permissions.default.loggedIn).toEqual(
-        DefaultAccessPermission.WRITE,
+        DefaultAccessLevel.WRITE,
       );
 
       expect(config.guestAccess).toEqual(GuestAccess.WRITE);
@@ -230,8 +230,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: invalidforbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -251,8 +251,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: negativeMaxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -272,8 +272,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: floatMaxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -293,8 +293,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: invalidMaxDocumentLength,
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -315,7 +315,7 @@ describe('noteConfig', () => {
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
           HD_PERMISSION_DEFAULT_EVERYONE: wrongDefaultPermission,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -335,7 +335,7 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
           HD_PERMISSION_DEFAULT_LOGGED_IN: wrongDefaultPermission,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
@@ -356,8 +356,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: wrongDefaultPermission,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -377,8 +377,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: 'deny',
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -398,8 +398,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.WRITE,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.READ,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.WRITE,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.READ,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -408,7 +408,7 @@ describe('noteConfig', () => {
         },
       );
       expect(() => noteConfig()).toThrow(
-        `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${DefaultAccessPermission.WRITE}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${DefaultAccessPermission.READ}'. This gives everyone greater permissions than logged-in users which is not allowed.`,
+        `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${DefaultAccessLevel.WRITE}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${DefaultAccessLevel.READ}'. This gives everyone greater permissions than logged-in users which is not allowed.`,
       );
       restore();
     });
@@ -419,8 +419,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.WRITE,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.NONE,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.WRITE,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.NONE,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -429,7 +429,7 @@ describe('noteConfig', () => {
         },
       );
       expect(() => noteConfig()).toThrow(
-        `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${DefaultAccessPermission.WRITE}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${DefaultAccessPermission.NONE}'. This gives everyone greater permissions than logged-in users which is not allowed.`,
+        `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${DefaultAccessLevel.WRITE}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${DefaultAccessLevel.NONE}'. This gives everyone greater permissions than logged-in users which is not allowed.`,
       );
       restore();
     });
@@ -440,8 +440,8 @@ describe('noteConfig', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           HD_FORBIDDEN_NOTE_IDS: forbiddenNoteIds.join(' , '),
           HD_MAX_DOCUMENT_LENGTH: maxDocumentLength.toString(),
-          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessPermission.READ,
-          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessPermission.NONE,
+          HD_PERMISSION_DEFAULT_EVERYONE: DefaultAccessLevel.READ,
+          HD_PERMISSION_DEFAULT_LOGGED_IN: DefaultAccessLevel.NONE,
           HD_GUEST_ACCESS: guestAccess,
           /* eslint-enable @typescript-eslint/naming-convention */
         },
@@ -450,7 +450,7 @@ describe('noteConfig', () => {
         },
       );
       expect(() => noteConfig()).toThrow(
-        `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${DefaultAccessPermission.READ}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${DefaultAccessPermission.NONE}'. This gives everyone greater permissions than logged-in users which is not allowed.`,
+        `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${DefaultAccessLevel.READ}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${DefaultAccessLevel.NONE}'. This gives everyone greater permissions than logged-in users which is not allowed.`,
       );
       restore();
     });

--- a/backend/src/config/note.config.ts
+++ b/backend/src/config/note.config.ts
@@ -7,9 +7,9 @@ import { registerAs } from '@nestjs/config';
 import * as Joi from 'joi';
 
 import {
-  DefaultAccessPermission,
-  getDefaultAccessPermissionOrdinal,
-} from './default-access-permission.enum';
+  DefaultAccessLevel,
+  getDefaultAccessLevelOrdinal,
+} from './default-access-level.enum';
 import { GuestAccess } from './guest_access.enum';
 import { buildErrorMessage, parseOptionalNumber, toArrayConfig } from './utils';
 
@@ -19,8 +19,8 @@ export interface NoteConfig {
   guestAccess: GuestAccess;
   permissions: {
     default: {
-      everyone: DefaultAccessPermission;
-      loggedIn: DefaultAccessPermission;
+      everyone: DefaultAccessLevel;
+      loggedIn: DefaultAccessLevel;
     };
   };
 }
@@ -45,14 +45,14 @@ const schema = Joi.object<NoteConfig>({
   permissions: {
     default: {
       everyone: Joi.string()
-        .valid(...Object.values(DefaultAccessPermission))
+        .valid(...Object.values(DefaultAccessLevel))
         .optional()
-        .default(DefaultAccessPermission.READ)
+        .default(DefaultAccessLevel.READ)
         .label('HD_PERMISSION_DEFAULT_EVERYONE'),
       loggedIn: Joi.string()
-        .valid(...Object.values(DefaultAccessPermission))
+        .valid(...Object.values(DefaultAccessLevel))
         .optional()
-        .default(DefaultAccessPermission.WRITE)
+        .default(DefaultAccessLevel.WRITE)
         .label('HD_PERMISSION_DEFAULT_LOGGED_IN'),
     },
   },
@@ -74,8 +74,8 @@ function checkLoggedInUsersHaveHigherDefaultPermissionsThanGuests(
   const everyone = config.permissions.default.everyone;
   const loggedIn = config.permissions.default.loggedIn;
   if (
-    getDefaultAccessPermissionOrdinal(everyone) >
-    getDefaultAccessPermissionOrdinal(loggedIn)
+    getDefaultAccessLevelOrdinal(everyone) >
+    getDefaultAccessLevelOrdinal(loggedIn)
   ) {
     throw new Error(
       `'HD_PERMISSION_DEFAULT_EVERYONE' is set to '${everyone}', but 'HD_PERMISSION_DEFAULT_LOGGED_IN' is set to '${loggedIn}'. This gives everyone greater permissions than logged-in users which is not allowed.`,

--- a/backend/src/frontend-config/frontend-config.service.spec.ts
+++ b/backend/src/frontend-config/frontend-config.service.spec.ts
@@ -10,7 +10,7 @@ import { URL } from 'url';
 import { AppConfig } from '../config/app.config';
 import { AuthConfig } from '../config/auth.config';
 import { CustomizationConfig } from '../config/customization.config';
-import { DefaultAccessPermission } from '../config/default-access-permission.enum';
+import { DefaultAccessLevel } from '../config/default-access-level.enum';
 import { ExternalServicesConfig } from '../config/external-services.config';
 import { GitlabScope, GitlabVersion } from '../config/gitlab.enum';
 import { GuestAccess } from '../config/guest_access.enum';
@@ -197,8 +197,8 @@ describe('FrontendConfigService', () => {
                     guestAccess: GuestAccess.CREATE,
                     permissions: {
                       default: {
-                        everyone: DefaultAccessPermission.READ,
-                        loggedIn: DefaultAccessPermission.WRITE,
+                        everyone: DefaultAccessLevel.READ,
+                        loggedIn: DefaultAccessLevel.WRITE,
                       },
                     },
                   } as NoteConfig;
@@ -360,8 +360,8 @@ describe('FrontendConfigService', () => {
                 guestAccess: GuestAccess.CREATE,
                 permissions: {
                   default: {
-                    everyone: DefaultAccessPermission.READ,
-                    loggedIn: DefaultAccessPermission.WRITE,
+                    everyone: DefaultAccessLevel.READ,
+                    loggedIn: DefaultAccessLevel.WRITE,
                   },
                 },
               };

--- a/backend/src/notes/notes.service.spec.ts
+++ b/backend/src/notes/notes.service.spec.ts
@@ -16,7 +16,7 @@ import {
 
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
-import { DefaultAccessPermission } from '../config/default-access-permission.enum';
+import { DefaultAccessLevel } from '../config/default-access-level.enum';
 import appConfigMock from '../config/mock/app.config.mock';
 import authConfigMock from '../config/mock/auth.config.mock';
 import databaseConfigMock from '../config/mock/database.config.mock';
@@ -372,13 +372,13 @@ describe('NotesService', () => {
         const groupPermissions = await newNote.groupPermissions;
         expect(groupPermissions).toHaveLength(2);
         expect(groupPermissions[0].canEdit).toEqual(
-          everyoneDefaultAccessPermission !== DefaultAccessPermission.WRITE,
+          everyoneDefaultAccessPermission !== DefaultAccessLevel.WRITE,
         );
         expect((await groupPermissions[0].group).name).toEqual(
           SpecialGroup.EVERYONE,
         );
         expect(groupPermissions[1].canEdit).toEqual(
-          loggedinDefaultAccessPermission === DefaultAccessPermission.WRITE,
+          loggedinDefaultAccessPermission === DefaultAccessLevel.WRITE,
         );
         expect((await groupPermissions[1].group).name).toEqual(
           SpecialGroup.LOGGED_IN,
@@ -398,13 +398,13 @@ describe('NotesService', () => {
         const groupPermissions = await newNote.groupPermissions;
         expect(groupPermissions).toHaveLength(2);
         expect(groupPermissions[0].canEdit).toEqual(
-          everyoneDefaultAccessPermission === DefaultAccessPermission.WRITE,
+          everyoneDefaultAccessPermission === DefaultAccessLevel.WRITE,
         );
         expect((await groupPermissions[0].group).name).toEqual(
           SpecialGroup.EVERYONE,
         );
         expect(groupPermissions[1].canEdit).toEqual(
-          loggedinDefaultAccessPermission === DefaultAccessPermission.WRITE,
+          loggedinDefaultAccessPermission === DefaultAccessLevel.WRITE,
         );
         expect((await groupPermissions[1].group).name).toEqual(
           SpecialGroup.LOGGED_IN,
@@ -423,13 +423,13 @@ describe('NotesService', () => {
         const groupPermissions = await newNote.groupPermissions;
         expect(groupPermissions).toHaveLength(2);
         expect(groupPermissions[0].canEdit).toEqual(
-          everyoneDefaultAccessPermission !== DefaultAccessPermission.WRITE,
+          everyoneDefaultAccessPermission !== DefaultAccessLevel.WRITE,
         );
         expect((await groupPermissions[0].group).name).toEqual(
           SpecialGroup.EVERYONE,
         );
         expect(groupPermissions[1].canEdit).toEqual(
-          loggedinDefaultAccessPermission === DefaultAccessPermission.WRITE,
+          loggedinDefaultAccessPermission === DefaultAccessLevel.WRITE,
         );
         expect((await groupPermissions[1].group).name).toEqual(
           SpecialGroup.LOGGED_IN,
@@ -449,13 +449,13 @@ describe('NotesService', () => {
         const groupPermissions = await newNote.groupPermissions;
         expect(groupPermissions).toHaveLength(2);
         expect(groupPermissions[0].canEdit).toEqual(
-          everyoneDefaultAccessPermission === DefaultAccessPermission.WRITE,
+          everyoneDefaultAccessPermission === DefaultAccessLevel.WRITE,
         );
         expect((await groupPermissions[0].group).name).toEqual(
           SpecialGroup.EVERYONE,
         );
         expect(groupPermissions[1].canEdit).toEqual(
-          loggedinDefaultAccessPermission === DefaultAccessPermission.WRITE,
+          loggedinDefaultAccessPermission === DefaultAccessLevel.WRITE,
         );
         expect((await groupPermissions[1].group).name).toEqual(
           SpecialGroup.LOGGED_IN,
@@ -479,13 +479,13 @@ describe('NotesService', () => {
           const groupPermissions = await newNote.groupPermissions;
           expect(groupPermissions).toHaveLength(2);
           expect(groupPermissions[0].canEdit).toEqual(
-            everyoneDefaultAccessPermission === DefaultAccessPermission.WRITE,
+            everyoneDefaultAccessPermission === DefaultAccessLevel.WRITE,
           );
           expect((await groupPermissions[0].group).name).toEqual(
             SpecialGroup.EVERYONE,
           );
           expect(groupPermissions[1].canEdit).toEqual(
-            loggedinDefaultAccessPermission === DefaultAccessPermission.WRITE,
+            loggedinDefaultAccessPermission === DefaultAccessLevel.WRITE,
           );
           expect((await groupPermissions[1].group).name).toEqual(
             SpecialGroup.LOGGED_IN,
@@ -500,7 +500,7 @@ describe('NotesService', () => {
         beforeEach(
           () =>
             (noteMockConfig.permissions.default.everyone =
-              DefaultAccessPermission.NONE),
+              DefaultAccessLevel.NONE),
         );
         it('default permissions', async () => {
           mockGroupRepo();
@@ -514,7 +514,7 @@ describe('NotesService', () => {
           const groupPermissions = await newNote.groupPermissions;
           expect(groupPermissions).toHaveLength(1);
           expect(groupPermissions[0].canEdit).toEqual(
-            loggedinDefaultAccessPermission === DefaultAccessPermission.WRITE,
+            loggedinDefaultAccessPermission === DefaultAccessLevel.WRITE,
           );
           expect((await groupPermissions[0].group).name).toEqual(
             SpecialGroup.LOGGED_IN,

--- a/backend/src/permissions/permissions.service.spec.ts
+++ b/backend/src/permissions/permissions.service.spec.ts
@@ -11,7 +11,7 @@ import { DataSource, EntityManager, Repository } from 'typeorm';
 
 import { AuthToken } from '../auth/auth-token.entity';
 import { Author } from '../authors/author.entity';
-import { DefaultAccessPermission } from '../config/default-access-permission.enum';
+import { DefaultAccessLevel } from '../config/default-access-level.enum';
 import { GuestAccess } from '../config/guest_access.enum';
 import appConfigMock from '../config/mock/app.config.mock';
 import authConfigMock from '../config/mock/auth.config.mock';
@@ -271,10 +271,8 @@ describe('PermissionsService', () => {
 
     describe('guest permission', () => {
       beforeEach(() => {
-        noteMockConfig.permissions.default.loggedIn =
-          DefaultAccessPermission.WRITE;
-        noteMockConfig.permissions.default.everyone =
-          DefaultAccessPermission.WRITE;
+        noteMockConfig.permissions.default.loggedIn = DefaultAccessLevel.WRITE;
+        noteMockConfig.permissions.default.everyone = DefaultAccessLevel.WRITE;
       });
       describe('with guest access deny', () => {
         beforeEach(() => {
@@ -353,10 +351,8 @@ describe('PermissionsService', () => {
     });
     describe('guest permission', () => {
       beforeEach(() => {
-        noteMockConfig.permissions.default.loggedIn =
-          DefaultAccessPermission.WRITE;
-        noteMockConfig.permissions.default.everyone =
-          DefaultAccessPermission.WRITE;
+        noteMockConfig.permissions.default.loggedIn = DefaultAccessLevel.WRITE;
+        noteMockConfig.permissions.default.everyone = DefaultAccessLevel.WRITE;
       });
 
       describe('with guest access deny', () => {
@@ -558,7 +554,7 @@ describe('PermissionsService', () => {
    * creates the matrix multiplication of group0 to group4 of createAllNoteGroupPermissions
    */
   function createNoteGroupPermissionsCombinations(
-    everyoneDefaultPermission: DefaultAccessPermission,
+    everyoneDefaultPermission: DefaultAccessLevel,
   ): NoteGroupPermissionWithResultForUser[] {
     // for logged in users
     const noteGroupPermissions = createAllNoteGroupPermissions();
@@ -584,13 +580,11 @@ describe('PermissionsService', () => {
               }
 
               if (group2 !== null) {
-                if (
-                  everyoneDefaultPermission === DefaultAccessPermission.WRITE
-                ) {
+                if (everyoneDefaultPermission === DefaultAccessLevel.WRITE) {
                   writePermission = writePermission || group2.canEdit;
                   readPermission = true;
                 } else if (
-                  everyoneDefaultPermission === DefaultAccessPermission.READ
+                  everyoneDefaultPermission === DefaultAccessLevel.READ
                 ) {
                   readPermission = true;
                 }
@@ -666,7 +660,7 @@ describe('PermissionsService', () => {
 
   describe('check if groups work with', () => {
     const rawPermissions = createNoteGroupPermissionsCombinations(
-      DefaultAccessPermission.WRITE,
+      DefaultAccessLevel.WRITE,
     );
     const permissions = permuteNoteGroupPermissions(rawPermissions);
     let i = 0;
@@ -697,18 +691,14 @@ describe('PermissionsService', () => {
     });
     it('allows creation of notes for guests with permission', () => {
       noteMockConfig.guestAccess = GuestAccess.CREATE;
-      noteMockConfig.permissions.default.loggedIn =
-        DefaultAccessPermission.WRITE;
-      noteMockConfig.permissions.default.everyone =
-        DefaultAccessPermission.WRITE;
+      noteMockConfig.permissions.default.loggedIn = DefaultAccessLevel.WRITE;
+      noteMockConfig.permissions.default.everyone = DefaultAccessLevel.WRITE;
       expect(service.mayCreate(null)).toBeTruthy();
     });
     it('denies creation of notes for guests without permission', () => {
       noteMockConfig.guestAccess = GuestAccess.WRITE;
-      noteMockConfig.permissions.default.loggedIn =
-        DefaultAccessPermission.WRITE;
-      noteMockConfig.permissions.default.everyone =
-        DefaultAccessPermission.WRITE;
+      noteMockConfig.permissions.default.loggedIn = DefaultAccessLevel.WRITE;
+      noteMockConfig.permissions.default.everyone = DefaultAccessLevel.WRITE;
       expect(service.mayCreate(null)).toBeFalsy();
     });
   });


### PR DESCRIPTION
### Component/Part
DefaultAccessLevel & NotesService

### Description
This PR contains two refactorings extracted from my WIP E2E-tests branch:
- The `DefaultAccessPermission` enum is renamed to `DefaultAccessLevel`, to reduce confusion between the Permission class and the enum
- `NoteService.createNote` is rejiggled to make it easier to understand, comments are added

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
