### PR TITLE
fix(image-router): correct usage of rimraf

### DIFF
--- a/lib/web/imageRouter/index.js
+++ b/lib/web/imageRouter/index.js
@@ -83,7 +83,7 @@ imageRouter.post('/uploadimage', function (req, res) {
   form.parse(req, async function (err, fields, files) {
     if (err) {
       logger.error(`Image upload error: formidable error: ${err}`)
-      rimraf(tmpDir)
+      rimraf.sync(tmpDir)
       return errors.errorForbidden(res)
     } else if (!files.image || !files.image.filepath) {
       logger.error('Image upload error: Upload didn\'t contain file)')


### PR DESCRIPTION
### Component/Part
Image Router

### Description
This PR fixes the usage of rimraf

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
