### PR TITLE
fix(bundle): force esbuild-loader to use cjs instead of iife

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -17,6 +17,7 @@ module.exports = [
       minimizer: [
         new EsbuildPlugin({
           target: 'es2015',
+          format: "cjs",
           exclude: ['MathJax/extensions/a11y/mathmaps']
         })
       ],
@@ -31,7 +32,8 @@ module.exports = [
     optimization: {
       minimizer: [
         new EsbuildPlugin({
-          target: 'es2015'
+          target: 'es2015',
+          format: "cjs"
         }),
         new OptimizeCSSAssetsPlugin({})
       ]


### PR DESCRIPTION
### Component/Part
webpack config

### Description
Beginning with esbuild-loader 3 it uses iife for web bundles to avoid pollution of the "window" object.
However, this broke our prod (and only the prod!) bundle because some variables should go into the global namespace.

See https://github.com/esbuild-kit/esbuild-loader/releases/tag/v3.0.0

It is important to delete the `public/build` directory before compiling again to see an effect.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
