### PR TITLE
fix(night-mode): migrate cookie solution to store only and simplify code

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -4,6 +4,7 @@
 
 ### Bugfixes
 - Fix note titles with special characters producing invalid file names in user export zip file
+- Fix night-mode toggle not working when page is loaded with night-mode enabled
 
 ## <i class="fa fa-tag"></i> 1.9.6 <i class="fa fa-calendar-o"></i> 2022-11-06
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -658,8 +658,13 @@ $(document).ready(function () {
       })
   }
 
+  if (Cookies.get('nightMode') !== undefined) {
+    store.set('nightMode', Cookies.get('nightMode') === 'true')
+    Cookies.remove('nightMode')
+  }
+
   // Re-enable nightmode
-  if (store.get('nightMode') || Cookies.get('nightMode')) {
+  if (store.get('nightMode') === true) {
     $body.addClass('night')
     ui.toolbar.night.addClass('active')
   }
@@ -2084,24 +2089,12 @@ $('.ui-delete-modal-confirm').click(function () {
 
 function toggleNightMode () {
   const $body = $('body')
-  const isActive = ui.toolbar.night.hasClass('active')
-  if (isActive) {
-    $body.removeClass('night')
-    appState.nightMode = false
-  } else {
-    $body.addClass('night')
-    appState.nightMode = true
-  }
-  if (store.enabled) {
-    store.set('nightMode', !isActive)
-  } else {
-    Cookies.set('nightMode', !isActive, {
-      expires: 365,
-      sameSite: window.cookiePolicy,
-      secure: window.location.protocol === 'https:'
-    })
-  }
+  const isActive = store.get('nightMode') === true
+  $body.toggleClass('night', !isActive)
+  ui.toolbar.night.toggleClass('active', !isActive)
+  store.set('nightMode', !isActive)
 }
+
 function emitPermission (_permission) {
   if (_permission !== permission) {
     socket.emit('permission', _permission)

--- a/public/js/lib/appState.js
+++ b/public/js/lib/appState.js
@@ -2,8 +2,7 @@ import modeType from './modeType'
 
 const state = {
   syncscroll: true,
-  currentMode: modeType.view,
-  nightMode: false
+  currentMode: modeType.view
 }
 
 export default state


### PR DESCRIPTION
### Component/Part
Night mode toggle

### Description
This PR fixes the night-mode toggle by cleaning-up the messy old code a bit.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #3334 
