### PR TITLE
fix(frontend): use "action" prop in revisions list

### DIFF
--- a/frontend/global-styles/variables.dark.scss
+++ b/frontend/global-styles/variables.dark.scss
@@ -114,6 +114,7 @@ $progress-bg: $gray-700;
 $list-group-bg: $gray-800;
 $list-group-border-color: $gray-700;
 $list-group-hover-bg: $gray-700;
+$list-group-action-hover-color: $white;
 
 // Breadcrumbs
 $breadcrumb-bg: $gray-700;

--- a/frontend/src/components/editor-page/document-bar/revisions/revision-list-entry.module.scss
+++ b/frontend/src/components/editor-page/document-bar/revisions/revision-list-entry.module.scss
@@ -5,8 +5,6 @@
  */
 
 .revision-item {
-  cursor: pointer;
-
   span > img {
     height: 1.25rem;
   }

--- a/frontend/src/components/editor-page/document-bar/revisions/revision-list-entry.tsx
+++ b/frontend/src/components/editor-page/document-bar/revisions/revision-list-entry.tsx
@@ -54,7 +54,8 @@ export const RevisionListEntry: React.FC<RevisionListEntryProps> = ({ active, on
     <ListGroup.Item
       active={active}
       onClick={onSelect}
-      className={`user-select-none ${styles['revision-item']} d-flex flex-column`}>
+      action
+      className={`${styles['revision-item']} d-flex flex-column`}>
       <span>
         <ForkAwesomeIcon icon={'clock-o'} className='mx-2' />
         {revisionCreationTime}


### PR DESCRIPTION
### Component/Part
Frontend - Revision list

### Description
This PR sets the "action" prop for the revision entry list in the revisions modal. This indicates that the entries should be clickable. This causes that react-bootstrap styles them correctly and uses buttons.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
