### PR TITLE
Update OCI labels in 2.0 docker images

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -53,10 +53,10 @@ RUN --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/tmp/.yarn \
 ## Stage 3: Final image, only production dependencies
 FROM base as prod
 
-LABEL org.opencontainers.image.title='HedgeDoc production image'
+LABEL org.opencontainers.image.title='HedgeDoc production backend image'
 LABEL org.opencontainers.image.url='https://hedgedoc.org'
 LABEL org.opencontainers.image.source='https://github.com/hedgedoc/hedgedoc'
-LABEL org.opencontainers.image.documentation='https://github.com/hedgedoc/hedgedoc/blob/develop/docs/docker/README.md'
+LABEL org.opencontainers.image.documentation='https://github.com/hedgedoc/hedgedoc/blob/develop/docs/content/dev/docker.md'
 LABEL org.opencontainers.image.licenses='AGPL-3.0'
 
 USER node

--- a/frontend/docker/Dockerfile
+++ b/frontend/docker/Dockerfile
@@ -37,6 +37,12 @@ FROM base
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+LABEL org.opencontainers.image.title='HedgeDoc production frontend image'
+LABEL org.opencontainers.image.url='https://hedgedoc.org'
+LABEL org.opencontainers.image.source='https://github.com/hedgedoc/hedgedoc'
+LABEL org.opencontainers.image.documentation='https://github.com/hedgedoc/hedgedoc/blob/develop/docs/content/dev/docker.md'
+LABEL org.opencontainers.image.licenses='AGPL-3.0'
+
 WORKDIR /usr/src/app
 
 COPY --from=builder --chown=node:node /usr/src/app/frontend/.next/standalone ./


### PR DESCRIPTION
### Component/Part
Dockerfiles

### Description
This PR adds and updates the OCI labels for the 2.0 docker images.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Brought to attention by hedgedoc/container#402
