### PR TITLE
deps: change codemirror git link to master

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "babel-runtime": "6.26.0",
     "bootstrap": "3.4.1",
     "bootstrap-validator": "0.11.9",
-    "codemirror": "git+https://github.com/hedgedoc/CodeMirror.git#hedgedoc/1.9.7",
+    "codemirror": "git+https://github.com/hedgedoc/CodeMirror.git",
     "copy-webpack-plugin": "6.4.1",
     "css-loader": "5.2.7",
     "emojify.js": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2618,10 +2618,10 @@ cls-bluebird@^2.1.0:
     is-bluebird "^1.0.2"
     shimmer "^1.1.0"
 
-"codemirror@git+https://github.com/hedgedoc/CodeMirror.git#hedgedoc/1.9.7":
-  version "5.65.11"
-  uid "3bf02f877d7f707557db12a4a0882ce20b79e491"
-  resolved "git+https://github.com/hedgedoc/CodeMirror.git#3bf02f877d7f707557db12a4a0882ce20b79e491"
+"codemirror@git+https://github.com/hedgedoc/CodeMirror.git":
+  version "5.65.12"
+  uid "64922b591f46d784169cae67ea8938b10254bc0e"
+  resolved "git+https://github.com/hedgedoc/CodeMirror.git#64922b591f46d784169cae67ea8938b10254bc0e"
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Component/Part
package.json

### Description
This PR changes the dependency of codemirror to the master branch because master shouldn't depend on a release branch.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
