### PR TITLE
[1.x] Add /_health endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -181,7 +181,7 @@ app.use(flash())
 
 // passport
 app.use(passport.initialize())
-app.use(useUnless(['/status', '/metrics'], passport.session()))
+app.use(useUnless(['/status', '/metrics', '/_health'], passport.session()))
 
 // check uri is valid before going further
 app.use(require('./lib/web/middleware/checkURIValid'))

--- a/lib/web/statusRouter.js
+++ b/lib/web/statusRouter.js
@@ -12,6 +12,16 @@ const { urlencodedParser } = require('./utils')
 
 const statusRouter = module.exports = Router()
 
+statusRouter.get('/_health', function (req, res) {
+  res.set({
+    'Cache-Control': 'private', // only cache by client
+    'X-Robots-Tag': 'noindex, nofollow' // prevent crawling
+  })
+  res.send({
+    ready: !realtime.maintenance
+  })
+})
+
 // get status
 statusRouter.get('/status', function (req, res, next) {
   realtime.getStatus(function (data) {

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -5,6 +5,7 @@
 ### Enhancements
 - Extend boolean environment variable parsing with other positive answers and case insensitivity.
 - Allow setting of `documentMaxLength` via `CMD_DOCUMENT_MAX_LENGTH` environment variable.
+- Add dedicated healthcheck endpoint at /_health that is less resource intensive than /status.
 
 ## <i class="fa fa-tag"></i> 1.9.7 <i class="fa fa-calendar-o"></i> 2023-02-19
 


### PR DESCRIPTION
### Component/Part
Healthcheck / status router

### Description
This PR adds a dedicated /_health endpoint. This endpoint returns the internal readiness state used by the realtime code to indicate whether HedgeDoc is performing properly. As it only returns the state of a variable, it is less resource hungry compared to a call to /status for checking the health of HedgeDoc.

By prepending the route with an underscore, it should not be conflicting with already created pads in FreeURL mode.

Another PR for the container repository will follow.

### Steps
- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#3421 
