### PR TITLE
feat(frontend): add size property to wait spinner component

### DIFF
--- a/frontend/src/components/common/wait-spinner/wait-spinner.tsx
+++ b/frontend/src/components/common/wait-spinner/wait-spinner.tsx
@@ -7,13 +7,17 @@ import { UiIcon } from '../icons/ui-icon'
 import React from 'react'
 import { ArrowRepeat as IconArrowRepeat } from 'react-bootstrap-icons'
 
+export interface WaitSpinnerProps {
+  size?: string | number
+}
+
 /**
  * Renders a indefinitely spinning spinner.
  */
-export const WaitSpinner: React.FC = () => {
+export const WaitSpinner: React.FC<WaitSpinnerProps> = ({ size }) => {
   return (
     <div className={'m-3 d-flex align-items-center justify-content-center'}>
-      <UiIcon icon={IconArrowRepeat} spin={true} />
+      <UiIcon icon={IconArrowRepeat} spin={true} size={size} />
     </div>
   )
 }


### PR DESCRIPTION
### Component/Part
frontend wait spinner component

### Description
This PR adds a size prop to the wait spinner component

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Extracted from #3270 to make the PR easier to read.
