### PR TITLE
fix(turbo): add npm task for test:ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "dotenv -- turbo run build",
     "lint": "dotenv -- turbo run lint",
     "format": "dotenv -- turbo run format",
-    "start:dev": "dotenv -- turbo run start:dev"
+    "start:dev": "dotenv -- turbo run start:dev",
+    "test:ci": "dotenv -- turbo run test:ci"
   },
   "packageManager": "yarn@3.4.1",
   "resolutions": {


### PR DESCRIPTION
### Component/Part
Repository

### Description
This PR adds a npm task for `test:ci` to the root package.json

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
