### PR TITLE
feat(editor): extract the spell check codemirror extension into separate hook

### DIFF
--- a/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
+++ b/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
@@ -13,6 +13,7 @@ import type { ScrollProps } from '../synced-scroll/scroll-props'
 import styles from './extended-codemirror/codemirror.module.scss'
 import { useCodeMirrorFileInsertExtension } from './hooks/code-mirror-extensions/use-code-mirror-file-insert-extension'
 import { useCodeMirrorScrollWatchExtension } from './hooks/code-mirror-extensions/use-code-mirror-scroll-watch-extension'
+import { useCodeMirrorSpellCheckExtension } from './hooks/code-mirror-extensions/use-code-mirror-spell-check-extension'
 import { useOnImageUploadFromRenderer } from './hooks/image-upload-from-renderer/use-on-image-upload-from-renderer'
 import { useCodeMirrorTablePasteExtension } from './hooks/table-paste/use-code-mirror-table-paste-extension'
 import { useApplyScrollState } from './hooks/use-apply-scroll-state'
@@ -59,6 +60,7 @@ export const EditorPane: React.FC<ScrollProps> = ({ scrollState, onScroll, onMak
   const editorScrollExtension = useCodeMirrorScrollWatchExtension(onScroll)
   const tablePasteExtensions = useCodeMirrorTablePasteExtension()
   const fileInsertExtension = useCodeMirrorFileInsertExtension()
+  const spellCheckExtension = useCodeMirrorSpellCheckExtension()
   const cursorActivityExtension = useCursorActivityCallback()
 
   const codeMirrorRef = useCodeMirrorReference()
@@ -84,7 +86,6 @@ export const EditorPane: React.FC<ScrollProps> = ({ scrollState, onScroll, onMak
   const yjsExtension = useCodeMirrorYjsExtension(yText, awareness)
   const [firstEditorUpdateExtension, firstUpdateHappened] = useOnFirstEditorUpdateExtension()
   useInsertNoteContentIntoYTextInMockModeEffect(firstUpdateHappened, websocketConnection)
-  const spellCheck = useApplicationState((state) => state.editorConfig.spellCheck)
   const linter = useLinter()
 
   const extensions = useMemo(
@@ -104,7 +105,7 @@ export const EditorPane: React.FC<ScrollProps> = ({ scrollState, onScroll, onMak
       updateViewContext,
       yjsExtension,
       firstEditorUpdateExtension,
-      EditorView.contentAttributes.of({ spellcheck: String(spellCheck) })
+      spellCheckExtension
     ],
     [
       linter,
@@ -115,7 +116,7 @@ export const EditorPane: React.FC<ScrollProps> = ({ scrollState, onScroll, onMak
       updateViewContext,
       yjsExtension,
       firstEditorUpdateExtension,
-      spellCheck
+      spellCheckExtension
     ]
   )
 

--- a/frontend/src/components/editor-page/editor-pane/hooks/code-mirror-extensions/use-code-mirror-spell-check-extension.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/code-mirror-extensions/use-code-mirror-spell-check-extension.ts
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useApplicationState } from '../../../../../hooks/common/use-application-state'
+import type { Extension } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { useMemo } from 'react'
+
+/**
+ * Creates a {@link Extension codemirror extension} that activates or deactivates the browser spell check.
+ */
+export const useCodeMirrorSpellCheckExtension = (): Extension => {
+  const spellCheck = useApplicationState((state) => state.editorConfig.spellCheck)
+
+  return useMemo(() => EditorView.contentAttributes.of({ spellcheck: String(spellCheck) }), [spellCheck])
+}


### PR DESCRIPTION
### Component/Part
Editor

### Description
This PR extracts the codemirror spell check extension into a separate hook.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
