### PR TITLE
fix(dev-reverse-proxy): try to run global caddy first

### DIFF
--- a/dev-reverse-proxy/package.json
+++ b/dev-reverse-proxy/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {
-    "start:dev": "./caddy run"
+    "start:dev": "caddy run || ./caddy run"
   }
 }


### PR DESCRIPTION
### Component/Part
Dev reverse proxy

### Description
This PR fixes the reverse proxy start command to prioritize a global caddy over a local.

https://asciinema.org/a/gzQ3DLjU7yj8rAjSin47CuwH3

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
