### PR TITLE
chore(ci): update cypress/browsers image in e2e workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -141,7 +141,7 @@ jobs:
     needs: frontend-build
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node18.12.0-chrome106-ff106
+      image: cypress/browsers:node-18.14.1-chrome-111.0.5563.64-1-ff-111.0-edge-111.0.1661.43-1
       options: --shm-size=2g
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR updates the cypress/browser image in the e2e workflow.
Sadly renovate can't handle this because the image doesn't follow a scheme.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
