### PR TITLE
build: enable frontend source maps

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -90,7 +90,8 @@ const rawNextConfig = {
   swcMinify: false, //Otherwise emoji picker is minified incorrectly
   experimental: {
     outputFileTracingRoot: path.join(__dirname, '../')
-  }
+  },
+  productionBrowserSourceMaps: true
 }
 const completeNextConfig = withBundleAnalyzer(rawNextConfig)
 


### PR DESCRIPTION
### Component/Part
Next config

### Description
Currently, frontend stack traces are unhelpful in production builds, because they only include minified code.

By enabling source maps for production builds, we enhance debuggability and error-reports.

Ref: https://nextjs.org/docs/advanced-features/source-maps

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
