### PR TITLE
fix: replace bootstrap icon html with utf-8 icon

### DIFF
--- a/frontend/src/components/markdown-renderer/extensions/headline-anchors-markdown-extension.ts
+++ b/frontend/src/components/markdown-renderer/extensions/headline-anchors-markdown-extension.ts
@@ -14,7 +14,7 @@ export class HeadlineAnchorsMarkdownExtension extends MarkdownRendererExtension 
   public configureMarkdownIt(markdownIt: MarkdownIt): void {
     anchor(markdownIt, {
       permalink: anchor.permalink.ariaHidden({
-        symbol: '<i class="fa fa-link"></i>',
+        symbol: '🔗',
         class: 'heading-anchor text-dark',
         renderHref: (slug: string): string => `#${slug}`,
         placement: 'before'


### PR DESCRIPTION
### Component/Part
Renderer

### Description
This PR fixes the display of the headline link icon

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
