### PR TITLE
fix: change sessionstate type to prevent unset values

### DIFF
--- a/backend/src/api/private/auth/auth.controller.ts
+++ b/backend/src/api/private/auth/auth.controller.ts
@@ -26,6 +26,7 @@ import { RegisterDto } from '../../../identity/local/register.dto';
 import { UpdatePasswordDto } from '../../../identity/local/update-password.dto';
 import { SessionGuard } from '../../../identity/session.guard';
 import { ConsoleLoggerService } from '../../../logger/console-logger.service';
+import { SessionState } from '../../../session/session.service';
 import { User } from '../../../users/user.entity';
 import { UsersService } from '../../../users/users.service';
 import { LoginEnabledGuard } from '../../utils/login-enabled.guard';
@@ -34,10 +35,7 @@ import { RegistrationEnabledGuard } from '../../utils/registration-enabled.guard
 import { RequestUser } from '../../utils/request-user.decorator';
 
 type RequestWithSession = Request & {
-  session: {
-    authProvider: string;
-    user: string;
-  };
+  session: SessionState;
 };
 
 @ApiTags('auth')
@@ -65,7 +63,7 @@ export class AuthController {
     );
     // ToDo: Figure out how to rollback user if anything with this calls goes wrong
     await this.identityService.createLocalIdentity(user, registerDto.password);
-    request.session.user = registerDto.username;
+    request.session.username = registerDto.username;
     request.session.authProvider = 'local';
   }
 
@@ -96,7 +94,7 @@ export class AuthController {
     @Body() loginDto: LoginDto,
   ): void {
     // There is no further testing needed as we only get to this point if LocalAuthGuard was successful
-    request.session.user = loginDto.username;
+    request.session.username = loginDto.username;
     request.session.authProvider = 'local';
   }
 
@@ -110,7 +108,7 @@ export class AuthController {
     @Body() loginDto: LdapLoginDto,
   ): void {
     // There is no further testing needed as we only get to this point if LocalAuthGuard was successful
-    request.session.user = loginDto.username;
+    request.session.username = loginDto.username;
     request.session.authProvider = 'ldap';
   }
 

--- a/backend/src/api/utils/session-authprovider.decorator.ts
+++ b/backend/src/api/utils/session-authprovider.decorator.ts
@@ -10,6 +10,8 @@ import {
 } from '@nestjs/common';
 import { Request } from 'express';
 
+import { SessionState } from '../../session/session.service';
+
 /**
  * Extracts the auth provider identifier from a session inside a request
  *
@@ -19,9 +21,7 @@ import { Request } from 'express';
 export const SessionAuthProvider = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
     const request: Request & {
-      session: {
-        authProvider: string;
-      };
+      session: SessionState;
     } = ctx.switchToHttp().getRequest();
     if (!request.session?.authProvider) {
       // We should have an auth provider here, otherwise something is wrong

--- a/backend/src/realtime/websocket/websocket.gateway.ts
+++ b/backend/src/realtime/websocket/websocket.gateway.ts
@@ -110,6 +110,9 @@ export class WebsocketGateway implements OnGatewayConnection {
     const username = await this.sessionService.fetchUsernameForSessionId(
       sessionId.get(),
     );
+    if (username === undefined) {
+      return null;
+    }
     return await this.userService.getUserByUsername(username);
   }
 }

--- a/backend/src/session/session.service.spec.ts
+++ b/backend/src/session/session.service.spec.ts
@@ -36,7 +36,7 @@ describe('SessionService', () => {
     jest.resetModules();
     jest.restoreAllMocks();
     const mockedExistingSession = Mock.of<SessionState>({
-      user: mockUsername,
+      username: mockUsername,
     });
     mockedTypeormStore = Mock.of<TypeormStore>({
       connect: jest.fn(() => mockedTypeormStore),

--- a/backend/src/session/session.service.ts
+++ b/backend/src/session/session.service.ts
@@ -22,7 +22,7 @@ import { HEDGEDOC_SESSION } from '../utils/session';
 
 export interface SessionState {
   cookie: unknown;
-  user: string;
+  username?: string;
   authProvider: string;
 }
 
@@ -58,10 +58,10 @@ export class SessionService {
    * @param sessionId The session id for which the owning user should be found
    * @return A Promise that either resolves with the username or rejects with an error
    */
-  fetchUsernameForSessionId(sessionId: string): Promise<string> {
+  fetchUsernameForSessionId(sessionId: string): Promise<string | undefined> {
     return new Promise((resolve, reject) => {
       this.typeormStore.get(sessionId, (error?: Error, result?: SessionState) =>
-        error || !result ? reject(error) : resolve(result.user),
+        error || !result ? reject(error) : resolve(result.username),
       );
     });
   }


### PR DESCRIPTION
### Component/Part
Backend - Session management

### Description
This PR changes the type of the session state to prevent unset values when not logged in..

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
