### PR TITLE
fix: exclude the link icon from the first heading extraction text

### DIFF
--- a/frontend/global-styles/markdown-tweaks.scss
+++ b/frontend/global-styles/markdown-tweaks.scss
@@ -37,6 +37,7 @@
 
   h1, h2, h3, h4, h5, h6 {
     .heading-anchor {
+      user-select: none;
       font-size: 0.75em;
       margin-top: 0.25em;
       opacity: 0.3;

--- a/frontend/src/components/markdown-renderer/hooks/use-extract-first-headline.ts
+++ b/frontend/src/components/markdown-renderer/hooks/use-extract-first-headline.ts
@@ -14,9 +14,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
  * @return the plain text content
  */
 const extractInnerText = (node: ChildNode | null): string => {
-  if (!node) {
-    return ''
-  } else if (isKatexMathMlElement(node)) {
+  if (!node || isKatexMathMlElement(node) || isHeadlineLinkElement(node)) {
     return ''
   } else if (node.childNodes && node.childNodes.length > 0) {
     return extractInnerTextFromChildren(node)
@@ -32,6 +30,12 @@ const extractInnerText = (node: ChildNode | null): string => {
  * @param node The node that might be a katex mathml element
  */
 const isKatexMathMlElement = (node: ChildNode): boolean => (node as HTMLElement).classList?.contains('katex-mathml')
+
+/**
+ * Determines if the given {@link ChildNode node} is the link icon of a heading.
+ * @param node The node to check
+ */
+const isHeadlineLinkElement = (node: ChildNode): boolean => (node as HTMLElement).classList?.contains('heading-anchor')
 
 /**
  * Extracts the text content of the children of the given {@link ChildNode node}.


### PR DESCRIPTION
### Component/Part
Frontend rendering

### Description
This PR fixes the first heading extraction.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
