### PR TITLE
fix: prevent splitter panels from being selected when resizing

### DIFF
--- a/frontend/src/components/editor-page/splitter/splitter.module.scss
+++ b/frontend/src/components/editor-page/splitter/splitter.module.scss
@@ -14,6 +14,12 @@
   flex-direction: column;
 }
 
+.resizing {
+  .left, .right {
+    user-select: none;
+  }
+}
+
 .move-overlay {
   position: absolute;
   height: 100%;

--- a/frontend/src/components/editor-page/splitter/splitter.tsx
+++ b/frontend/src/components/editor-page/splitter/splitter.tsx
@@ -135,7 +135,11 @@ export const Splitter: React.FC<SplitterProps> = ({ additionalContainerClassName
   useKeyboardShortcuts(setRelativeSplitValue)
 
   return (
-    <div ref={splitContainer} className={`flex-fill flex-row d-flex ${additionalContainerClassName || ''}`}>
+    <div
+      ref={splitContainer}
+      className={`flex-fill flex-row d-flex ${additionalContainerClassName || ''}${
+        resizingInProgress ? ' ' + styles.resizing : ''
+      }`}>
       <ShowIf condition={resizingInProgress}>
         <div
           className={styles['move-overlay']}


### PR DESCRIPTION
### Component/Part
Frontend splitter

### Description
This PR fixes a bug that made it possible to select content while the splitter handle was dragged.

### Steps


- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x


Fixes #3605
