### PR TITLE
fix(landing-layout): links in the user-dropdown not working

### DIFF
--- a/frontend/src/components/landing-layout/navigation/user-dropdown.tsx
+++ b/frontend/src/components/landing-layout/navigation/user-dropdown.tsx
@@ -33,13 +33,13 @@ export const UserDropdown: React.FC = () => {
       </Dropdown.Toggle>
 
       <Dropdown.Menu className='text-start'>
-        <Link href={'/n/features'} passHref={true}>
+        <Link href={'/n/features'} passHref={true} legacyBehavior={true}>
           <Dropdown.Item dir='auto' {...cypressId('user-dropdown-features-button')}>
             <UiIcon icon={IconLightning} className='mx-2' />
             <Trans i18nKey='editor.help.documents.features' />
           </Dropdown.Item>
         </Link>
-        <Link href={'/profile'} passHref={true}>
+        <Link href={'/profile'} passHref={true} legacyBehavior={true}>
           <Dropdown.Item dir='auto' {...cypressId('user-dropdown-profile-button')}>
             <UiIcon icon={IconPerson} className='mx-2' />
             <Trans i18nKey='profile.userProfile' />


### PR DESCRIPTION
### Component/Part
Landing layout

### Description
This PR fixes the links in the user dropdown.

We use a custom component for rendering the link (Dropdown.Item), therefore we need to set both passHref and legacyBehavior

See: https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
