### PR TITLE
Is owner

### DIFF
--- a/frontend/cypress/support/visit-test-editor.ts
+++ b/frontend/cypress/support/visit-test-editor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -22,7 +22,7 @@ beforeEach(() => {
       createTime: '2021-04-24T09:27:51.000Z',
       editedBy: [],
       permissions: {
-        owner: null,
+        owner: 'mock',
         sharedToUsers: [],
         sharedToGroups: []
       }

--- a/frontend/src/components/common/modals/__snapshots__/deletion-moadal.test.tsx.snap
+++ b/frontend/src/components/common/modals/__snapshots__/deletion-moadal.test.tsx.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DeletionModal disables deletion when user is not owner 1`] = `
+<div
+  class="modal-dialog text-dark "
+  data-testid="commonModal"
+>
+  <div
+    class="modal-content"
+  >
+    <div
+      class="modal-header"
+    >
+      <div
+        class="modal-title h4"
+      >
+        <span />
+      </div>
+      <button
+        aria-label="Close"
+        class="btn-close"
+        type="button"
+      />
+    </div>
+    <div
+      class="text-dark modal-body"
+    >
+      testText
+    </div>
+    <div
+      class="modal-footer"
+    >
+      <button
+        class="btn btn-danger"
+        disabled=""
+        type="button"
+      >
+        testDeletionButton
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DeletionModal renders correctly with deletionButtonI18nKey 1`] = `
 <div
   class="modal-dialog text-dark "

--- a/frontend/src/components/common/modals/deletion-moadal.test.tsx
+++ b/frontend/src/components/common/modals/deletion-moadal.test.tsx
@@ -1,15 +1,37 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { mockNoteOwnership } from '../../../test-utils/note-ownership'
 import { mockI18n } from '../../markdown-renderer/test-utils/mock-i18n'
 import { DeletionModal } from './deletion-modal'
 import { render, screen } from '@testing-library/react'
 
 describe('DeletionModal', () => {
-  it('renders correctly with deletionButtonI18nKey', async () => {
+  beforeEach(async () => {
     await mockI18n()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    jest.resetModules()
+  })
+
+  it('renders correctly with deletionButtonI18nKey', async () => {
+    mockNoteOwnership('test', 'test')
+    const onConfirm = jest.fn()
+    render(
+      <DeletionModal onConfirm={onConfirm} deletionButtonI18nKey={'testDeletionButton'} show={true}>
+        testText
+      </DeletionModal>
+    )
+    const modal = await screen.findByTestId('commonModal')
+    expect(modal).toMatchSnapshot()
+  })
+
+  it('disables deletion when user is not owner', async () => {
+    mockNoteOwnership('test2', 'test')
     const onConfirm = jest.fn()
     render(
       <DeletionModal onConfirm={onConfirm} deletionButtonI18nKey={'testDeletionButton'} show={true}>

--- a/frontend/src/components/common/modals/deletion-modal.tsx
+++ b/frontend/src/components/common/modals/deletion-modal.tsx
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { useIsOwner } from '../../../hooks/common/use-is-owner'
 import { cypressId } from '../../../utils/cypress-attribute'
 import type { CommonModalProps } from './common-modal'
 import { CommonModal } from './common-modal'
@@ -40,6 +41,7 @@ export const DeletionModal: React.FC<PropsWithChildren<DeletionModalProps>> = ({
   ...props
 }) => {
   useTranslation()
+  const isOwner = useIsOwner()
 
   return (
     <CommonModal
@@ -51,7 +53,7 @@ export const DeletionModal: React.FC<PropsWithChildren<DeletionModalProps>> = ({
       {...props}>
       <Modal.Body className='text-dark'>{children}</Modal.Body>
       <Modal.Footer>
-        <Button {...cypressId('deletionModal.confirmButton')} variant='danger' onClick={onConfirm}>
+        <Button {...cypressId('deletionModal.confirmButton')} variant='danger' onClick={onConfirm} disabled={!isOwner}>
           <Trans i18nKey={deletionButtonI18nKey} />
         </Button>
       </Modal.Footer>

--- a/frontend/src/components/editor-page/document-bar/aliases/__snapshots__/aliases-list-entry.test.tsx.snap
+++ b/frontend/src/components/editor-page/document-bar/aliases/__snapshots__/aliases-list-entry.test.tsx.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AliasesListEntry disables button in AliasesListEntry if it's not primary 1`] = `
+<div>
+  <li
+    class="list-group-item d-flex flex-row justify-content-between align-items-center"
+  >
+    test-primary
+    <div>
+      <button
+        class="me-2 btn btn-light"
+        data-testid="aliasButtonMakePrimary"
+        disabled=""
+        title="editor.modal.aliases.makePrimary"
+        type="button"
+      >
+        BootstrapIconMock_StarFill
+      </button>
+      <button
+        class="text-danger btn btn-light"
+        data-testid="aliasButtonRemove"
+        disabled=""
+        title="editor.modal.aliases.removeAlias"
+        type="button"
+      >
+        BootstrapIconMock_X
+      </button>
+    </div>
+  </li>
+</div>
+`;
+
+exports[`AliasesListEntry disables button in AliasesListEntry if it's primary 1`] = `
+<div>
+  <li
+    class="list-group-item d-flex flex-row justify-content-between align-items-center"
+  >
+    test-primary
+    <div>
+      <button
+        class="me-2 text-warning btn btn-light"
+        data-testid="aliasIsPrimary"
+        disabled=""
+        title="editor.modal.aliases.isPrimary"
+        type="button"
+      >
+        BootstrapIconMock_Star
+      </button>
+      <button
+        class="text-danger btn btn-light"
+        data-testid="aliasButtonRemove"
+        disabled=""
+        title="editor.modal.aliases.removeAlias"
+        type="button"
+      >
+        BootstrapIconMock_X
+      </button>
+    </div>
+  </li>
+</div>
+`;
+
 exports[`AliasesListEntry renders an AliasesListEntry that is not primary 1`] = `
 <div>
   <li

--- a/frontend/src/components/editor-page/document-bar/aliases/aliases-add-form.tsx
+++ b/frontend/src/components/editor-page/document-bar/aliases/aliases-add-form.tsx
@@ -1,10 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { addAlias } from '../../../../api/alias'
 import { useApplicationState } from '../../../../hooks/common/use-application-state'
+import { useIsOwner } from '../../../../hooks/common/use-is-owner'
 import { useOnInputChange } from '../../../../hooks/common/use-on-input-change'
 import { updateMetadata } from '../../../../redux/note-details/methods'
 import { testId } from '../../../../utils/test-id'
@@ -25,6 +26,7 @@ export const AliasesAddForm: React.FC = () => {
   const { t } = useTranslation()
   const { showErrorNotification } = useUiNotifications()
   const noteId = useApplicationState((state) => state.noteDetails.id)
+  const isOwner = useIsOwner()
   const [newAlias, setNewAlias] = useState('')
 
   const onAddAlias = useCallback(
@@ -54,6 +56,7 @@ export const AliasesAddForm: React.FC = () => {
           placeholder={t('editor.modal.aliases.addAlias') ?? undefined}
           onChange={onNewAliasInputChange}
           isInvalid={!newAliasValid}
+          disabled={!isOwner}
           required={true}
           {...testId('addAliasInput')}
         />
@@ -61,7 +64,7 @@ export const AliasesAddForm: React.FC = () => {
           type={'submit'}
           variant='light'
           className={'text-secondary ms-2'}
-          disabled={!newAliasValid || newAlias === ''}
+          disabled={!isOwner || !newAliasValid || newAlias === ''}
           title={t('editor.modal.aliases.addAlias') ?? undefined}
           {...testId('addAliasButton')}>
           <UiIcon icon={IconPlus} />

--- a/frontend/src/components/editor-page/document-bar/aliases/aliases-list-entry.tsx
+++ b/frontend/src/components/editor-page/document-bar/aliases/aliases-list-entry.tsx
@@ -1,10 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { deleteAlias, markAliasAsPrimary } from '../../../../api/alias'
 import type { Alias } from '../../../../api/alias/types'
+import { useIsOwner } from '../../../../hooks/common/use-is-owner'
 import { updateMetadata } from '../../../../redux/note-details/methods'
 import { testId } from '../../../../utils/test-id'
 import { UiIcon } from '../../../common/icons/ui-icon'
@@ -29,6 +30,7 @@ export interface AliasesListEntryProps {
 export const AliasesListEntry: React.FC<AliasesListEntryProps> = ({ alias }) => {
   const { t } = useTranslation()
   const { showErrorNotification } = useUiNotifications()
+  const isOwner = useIsOwner()
 
   const onRemoveClick = useCallback(() => {
     deleteAlias(alias.name)
@@ -60,6 +62,7 @@ export const AliasesListEntry: React.FC<AliasesListEntryProps> = ({ alias }) => 
           <Button
             className={'me-2'}
             variant='light'
+            disabled={!isOwner}
             title={t('editor.modal.aliases.makePrimary') ?? undefined}
             onClick={onMakePrimaryClick}
             {...testId('aliasButtonMakePrimary')}>
@@ -69,6 +72,7 @@ export const AliasesListEntry: React.FC<AliasesListEntryProps> = ({ alias }) => 
         <Button
           variant='light'
           className={'text-danger'}
+          disabled={!isOwner}
           title={t('editor.modal.aliases.removeAlias') ?? undefined}
           onClick={onRemoveClick}
           {...testId('aliasButtonRemove')}>

--- a/frontend/src/components/editor-page/document-bar/permissions/permission-add-entry-field.tsx
+++ b/frontend/src/components/editor-page/document-bar/permissions/permission-add-entry-field.tsx
@@ -1,10 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { useOnInputChange } from '../../../../hooks/common/use-on-input-change'
 import { UiIcon } from '../../../common/icons/ui-icon'
+import type { PermissionDisabledProps } from './permission-disabled.prop'
 import React, { useCallback, useState } from 'react'
 import { Button, FormControl, InputGroup } from 'react-bootstrap'
 import { Plus as IconPlus } from 'react-bootstrap-icons'
@@ -20,8 +21,13 @@ export interface PermissionAddEntryFieldProps {
  *
  * @param onAddEntry Callback that is fired with the entered username as identifier of the entry to add.
  * @param i18nKey The localization key for the submit button.
+ * @param disabled If the user is not the owner, functionality is disabled.
  */
-export const PermissionAddEntryField: React.FC<PermissionAddEntryFieldProps> = ({ onAddEntry, i18nKey }) => {
+export const PermissionAddEntryField: React.FC<PermissionAddEntryFieldProps & PermissionDisabledProps> = ({
+  onAddEntry,
+  i18nKey,
+  disabled
+}) => {
   const { t } = useTranslation()
 
   const [newEntryIdentifier, setNewEntryIdentifier] = useState('')
@@ -34,8 +40,18 @@ export const PermissionAddEntryField: React.FC<PermissionAddEntryFieldProps> = (
   return (
     <li className={'list-group-item'}>
       <InputGroup className={'me-1 mb-1'}>
-        <FormControl value={newEntryIdentifier} placeholder={t(i18nKey) ?? undefined} onChange={onChange} />
-        <Button variant='light' className={'text-secondary ms-2'} title={t(i18nKey) ?? undefined} onClick={onSubmit}>
+        <FormControl
+          value={newEntryIdentifier}
+          placeholder={t(i18nKey) ?? undefined}
+          onChange={onChange}
+          disabled={disabled}
+        />
+        <Button
+          variant='light'
+          className={'text-secondary ms-2'}
+          title={t(i18nKey) ?? undefined}
+          onClick={onSubmit}
+          disabled={disabled}>
           <UiIcon icon={IconPlus} />
         </Button>
       </InputGroup>

--- a/frontend/src/components/editor-page/document-bar/permissions/permission-disabled.prop.ts
+++ b/frontend/src/components/editor-page/document-bar/permissions/permission-disabled.prop.ts
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export interface PermissionDisabledProps {
+  disabled: boolean
+}

--- a/frontend/src/components/editor-page/document-bar/permissions/permission-entry-buttons.tsx
+++ b/frontend/src/components/editor-page/document-bar/permissions/permission-entry-buttons.tsx
@@ -1,9 +1,10 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { UiIcon } from '../../../common/icons/ui-icon'
+import type { PermissionDisabledProps } from './permission-disabled.prop'
 import { AccessLevel } from './types'
 import React, { useMemo } from 'react'
 import { Button, ToggleButtonGroup } from 'react-bootstrap'
@@ -41,14 +42,16 @@ export interface PermissionEntryButtonsProps {
  * @param onSetReadOnly Callback that is fired when the entry is changed to read-only permission.
  * @param onSetWriteable Callback that is fired when the entry is changed to writeable permission.
  * @param onRemove Callback that is fired when the entry is removed.
+ * @param disabled If the user is not the owner, functionality is disabled.
  */
-export const PermissionEntryButtons: React.FC<PermissionEntryButtonsProps> = ({
+export const PermissionEntryButtons: React.FC<PermissionEntryButtonsProps & PermissionDisabledProps> = ({
   name,
   type,
   currentSetting,
   onSetReadOnly,
   onSetWriteable,
-  onRemove
+  onRemove,
+  disabled
 }) => {
   const { t } = useTranslation()
 
@@ -74,18 +77,21 @@ export const PermissionEntryButtons: React.FC<PermissionEntryButtonsProps> = ({
       <Button
         variant='light'
         className={'text-danger me-2'}
+        disabled={disabled}
         title={t(i18nKeys.remove, { name }) ?? undefined}
         onClick={onRemove}>
         <UiIcon icon={IconX} />
       </Button>
       <ToggleButtonGroup type='radio' name='edit-mode' value={currentSetting}>
         <Button
+          disabled={disabled}
           title={t(i18nKeys.setReadOnly, { name }) ?? undefined}
           variant={currentSetting === AccessLevel.READ_ONLY ? 'secondary' : 'outline-secondary'}
           onClick={onSetReadOnly}>
           <UiIcon icon={IconEye} />
         </Button>
         <Button
+          disabled={disabled}
           title={t(i18nKeys.setWriteable, { name }) ?? undefined}
           variant={currentSetting === AccessLevel.WRITEABLE ? 'secondary' : 'outline-secondary'}
           onClick={onSetWriteable}>

--- a/frontend/src/components/editor-page/document-bar/permissions/permission-entry-special-group.tsx
+++ b/frontend/src/components/editor-page/document-bar/permissions/permission-entry-special-group.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -8,6 +8,7 @@ import { useApplicationState } from '../../../../hooks/common/use-application-st
 import { setNotePermissionsFromServer } from '../../../../redux/note-details/methods'
 import { IconButton } from '../../../common/icon-button/icon-button'
 import { useUiNotifications } from '../../../notifications/ui-notification-boundary'
+import type { PermissionDisabledProps } from './permission-disabled.prop'
 import { AccessLevel, SpecialGroup } from './types'
 import React, { useCallback, useMemo } from 'react'
 import { ToggleButtonGroup } from 'react-bootstrap'
@@ -26,8 +27,13 @@ export interface PermissionEntrySpecialGroupProps {
  *
  * @param level The access level that is currently set for the group.
  * @param type The type of the special group. Must be either {@link SpecialGroup.EVERYONE} or {@link SpecialGroup.LOGGED_IN}.
+ * @param disabled If the user is not the owner, functionality is disabled.
  */
-export const PermissionEntrySpecialGroup: React.FC<PermissionEntrySpecialGroupProps> = ({ level, type }) => {
+export const PermissionEntrySpecialGroup: React.FC<PermissionEntrySpecialGroupProps & PermissionDisabledProps> = ({
+  level,
+  type,
+  disabled
+}) => {
   const noteId = useApplicationState((state) => state.noteDetails.primaryAddress)
   const { t } = useTranslation()
   const { showErrorNotification } = useUiNotifications()
@@ -75,6 +81,7 @@ export const PermissionEntrySpecialGroup: React.FC<PermissionEntrySpecialGroupPr
             title={t('editor.modal.permissions.denyGroup', { name }) ?? undefined}
             variant={level === AccessLevel.NONE ? 'secondary' : 'outline-secondary'}
             onClick={onSetEntryDenied}
+            disabled={disabled}
             className={'p-1'}
           />
           <IconButton
@@ -82,6 +89,7 @@ export const PermissionEntrySpecialGroup: React.FC<PermissionEntrySpecialGroupPr
             title={t('editor.modal.permissions.viewOnlyGroup', { name }) ?? undefined}
             variant={level === AccessLevel.READ_ONLY ? 'secondary' : 'outline-secondary'}
             onClick={onSetEntryReadOnly}
+            disabled={disabled}
             className={'p-1'}
           />
           <IconButton
@@ -89,6 +97,7 @@ export const PermissionEntrySpecialGroup: React.FC<PermissionEntrySpecialGroupPr
             title={t('editor.modal.permissions.editGroup', { name }) ?? undefined}
             variant={level === AccessLevel.WRITEABLE ? 'secondary' : 'outline-secondary'}
             onClick={onSetEntryWriteable}
+            disabled={disabled}
             className={'p-1'}
           />
         </ToggleButtonGroup>

--- a/frontend/src/components/editor-page/document-bar/permissions/permission-entry-user.tsx
+++ b/frontend/src/components/editor-page/document-bar/permissions/permission-entry-user.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -11,6 +11,7 @@ import { setNotePermissionsFromServer } from '../../../../redux/note-details/met
 import { ShowIf } from '../../../common/show-if/show-if'
 import { UserAvatarForUser } from '../../../common/user-avatar/user-avatar-for-user'
 import { useUiNotifications } from '../../../notifications/ui-notification-boundary'
+import type { PermissionDisabledProps } from './permission-disabled.prop'
 import { PermissionEntryButtons, PermissionType } from './permission-entry-buttons'
 import { AccessLevel } from './types'
 import React, { useCallback } from 'react'
@@ -24,8 +25,12 @@ export interface PermissionEntryUserProps {
  * Permission entry for a user that can be set to read-only or writeable and can be removed.
  *
  * @param entry The permission entry.
+ * @param disabled If the user is not the owner, functionality is disabled.
  */
-export const PermissionEntryUser: React.FC<PermissionEntryUserProps> = ({ entry }) => {
+export const PermissionEntryUser: React.FC<PermissionEntryUserProps & PermissionDisabledProps> = ({
+  entry,
+  disabled
+}) => {
   const noteId = useApplicationState((state) => state.noteDetails.primaryAddress)
   const { showErrorNotification } = useUiNotifications()
 
@@ -72,6 +77,7 @@ export const PermissionEntryUser: React.FC<PermissionEntryUserProps> = ({ entry 
           onSetReadOnly={onSetEntryReadOnly}
           onSetWriteable={onSetEntryWriteable}
           onRemove={onRemoveEntry}
+          disabled={disabled}
         />
       </li>
     </ShowIf>

--- a/frontend/src/components/editor-page/document-bar/permissions/permission-modal.tsx
+++ b/frontend/src/components/editor-page/document-bar/permissions/permission-modal.tsx
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { useIsOwner } from '../../../../hooks/common/use-is-owner'
 import type { ModalVisibilityProps } from '../../../common/modals/common-modal'
 import { CommonModal } from '../../../common/modals/common-modal'
 import { PermissionSectionOwner } from './permission-section-owner'
@@ -18,12 +19,13 @@ import { Modal } from 'react-bootstrap'
  * @param onHide Callback that is fired when the modal is about to be closed.
  */
 export const PermissionModal: React.FC<ModalVisibilityProps> = ({ show, onHide }) => {
+  const isOwner = useIsOwner()
   return (
     <CommonModal show={show} onHide={onHide} showCloseButton={true} titleI18nKey={'editor.modal.permissions.title'}>
       <Modal.Body>
-        <PermissionSectionOwner />
-        <PermissionSectionUsers />
-        <PermissionSectionSpecialGroups />
+        <PermissionSectionOwner disabled={!isOwner} />
+        <PermissionSectionUsers disabled={!isOwner} />
+        <PermissionSectionSpecialGroups disabled={!isOwner} />
       </Modal.Body>
     </CommonModal>
   )

--- a/frontend/src/components/editor-page/document-bar/permissions/permission-owner-info.tsx
+++ b/frontend/src/components/editor-page/document-bar/permissions/permission-owner-info.tsx
@@ -1,11 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { useApplicationState } from '../../../../hooks/common/use-application-state'
 import { UiIcon } from '../../../common/icons/ui-icon'
 import { UserAvatarForUsername } from '../../../common/user-avatar/user-avatar-for-username'
+import type { PermissionDisabledProps } from './permission-disabled.prop'
 import React, { Fragment } from 'react'
 import { Button } from 'react-bootstrap'
 import { Pencil as IconPencil } from 'react-bootstrap-icons'
@@ -19,8 +20,12 @@ export interface PermissionOwnerInfoProps {
  * Content for the owner section of the permission modal that shows the current note owner.
  *
  * @param onEditOwner Callback that is fired when the user chooses to change the note owner.
+ * @param disabled If the user is not the owner, functionality is disabled.
  */
-export const PermissionOwnerInfo: React.FC<PermissionOwnerInfoProps> = ({ onEditOwner }) => {
+export const PermissionOwnerInfo: React.FC<PermissionOwnerInfoProps & PermissionDisabledProps> = ({
+  onEditOwner,
+  disabled
+}) => {
   const { t } = useTranslation()
   const noteOwner = useApplicationState((state) => state.noteDetails.permissions.owner)
 
@@ -29,6 +34,7 @@ export const PermissionOwnerInfo: React.FC<PermissionOwnerInfoProps> = ({ onEdit
       <UserAvatarForUsername username={noteOwner} />
       <Button
         variant='light'
+        disabled={disabled}
         title={t('editor.modal.permissions.ownerChange.button') ?? undefined}
         onClick={onEditOwner}>
         <UiIcon icon={IconPencil} />

--- a/frontend/src/components/editor-page/document-bar/permissions/permission-section-owner.tsx
+++ b/frontend/src/components/editor-page/document-bar/permissions/permission-section-owner.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -7,6 +7,7 @@ import { setNoteOwner } from '../../../../api/permissions'
 import { useApplicationState } from '../../../../hooks/common/use-application-state'
 import { setNotePermissionsFromServer } from '../../../../redux/note-details/methods'
 import { useUiNotifications } from '../../../notifications/ui-notification-boundary'
+import type { PermissionDisabledProps } from './permission-disabled.prop'
 import { PermissionOwnerChange } from './permission-owner-change'
 import { PermissionOwnerInfo } from './permission-owner-info'
 import React, { Fragment, useCallback, useState } from 'react'
@@ -14,8 +15,10 @@ import { Trans } from 'react-i18next'
 
 /**
  * Section in the permissions modal for managing the owner of a note.
+ *
+ * @param disabled If the user is not the owner, functionality is disabled.
  */
-export const PermissionSectionOwner: React.FC = () => {
+export const PermissionSectionOwner: React.FC<PermissionDisabledProps> = ({ disabled }) => {
   const noteId = useApplicationState((state) => state.noteDetails.primaryAddress)
   const [changeOwner, setChangeOwner] = useState(false)
   const { showErrorNotification } = useUiNotifications()
@@ -48,7 +51,7 @@ export const PermissionSectionOwner: React.FC = () => {
           {changeOwner ? (
             <PermissionOwnerChange onConfirmOwnerChange={onOwnerChange} />
           ) : (
-            <PermissionOwnerInfo onEditOwner={onSetChangeOwner} />
+            <PermissionOwnerInfo onEditOwner={onSetChangeOwner} disabled={disabled} />
           )}
         </li>
       </ul>

--- a/frontend/src/components/editor-page/document-bar/permissions/permission-section-special-groups.tsx
+++ b/frontend/src/components/editor-page/document-bar/permissions/permission-section-special-groups.tsx
@@ -1,9 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { useApplicationState } from '../../../../hooks/common/use-application-state'
+import { useIsOwner } from '../../../../hooks/common/use-is-owner'
+import type { PermissionDisabledProps } from './permission-disabled.prop'
 import { PermissionEntrySpecialGroup } from './permission-entry-special-group'
 import { AccessLevel, SpecialGroup } from './types'
 import React, { Fragment, useMemo } from 'react'
@@ -11,10 +13,13 @@ import { Trans, useTranslation } from 'react-i18next'
 
 /**
  * Section of the permission modal for managing special group access to the note.
+ *
+ * @param disabled If the user is not the owner, functionality is disabled.
  */
-export const PermissionSectionSpecialGroups: React.FC = () => {
+export const PermissionSectionSpecialGroups: React.FC<PermissionDisabledProps> = ({ disabled }) => {
   useTranslation()
   const groupPermissions = useApplicationState((state) => state.noteDetails.permissions.sharedToGroups)
+  const isOwner = useIsOwner()
 
   const specialGroupEntries = useMemo(() => {
     const groupEveryone = groupPermissions.find((entry) => entry.groupName === SpecialGroup.EVERYONE)
@@ -40,8 +45,16 @@ export const PermissionSectionSpecialGroups: React.FC = () => {
         <Trans i18nKey={'editor.modal.permissions.sharedWithElse'} />
       </h5>
       <ul className={'list-group'}>
-        <PermissionEntrySpecialGroup level={specialGroupEntries.loggedIn} type={SpecialGroup.LOGGED_IN} />
-        <PermissionEntrySpecialGroup level={specialGroupEntries.everyone} type={SpecialGroup.EVERYONE} />
+        <PermissionEntrySpecialGroup
+          level={specialGroupEntries.loggedIn}
+          type={SpecialGroup.LOGGED_IN}
+          disabled={!isOwner}
+        />
+        <PermissionEntrySpecialGroup
+          level={specialGroupEntries.everyone}
+          type={SpecialGroup.EVERYONE}
+          disabled={disabled}
+        />
       </ul>
     </Fragment>
   )

--- a/frontend/src/components/editor-page/document-bar/permissions/permission-section-users.tsx
+++ b/frontend/src/components/editor-page/document-bar/permissions/permission-section-users.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -8,22 +8,27 @@ import { useApplicationState } from '../../../../hooks/common/use-application-st
 import { setNotePermissionsFromServer } from '../../../../redux/note-details/methods'
 import { useUiNotifications } from '../../../notifications/ui-notification-boundary'
 import { PermissionAddEntryField } from './permission-add-entry-field'
+import type { PermissionDisabledProps } from './permission-disabled.prop'
 import { PermissionEntryUser } from './permission-entry-user'
 import React, { Fragment, useCallback, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 /**
  * Section of the permission modal for managing user access to the note.
+ *
+ * @param disabled If the user is not the owner, functionality is disabled.
  */
-export const PermissionSectionUsers: React.FC = () => {
+export const PermissionSectionUsers: React.FC<PermissionDisabledProps> = ({ disabled }) => {
   useTranslation()
   const userPermissions = useApplicationState((state) => state.noteDetails.permissions.sharedToUsers)
   const noteId = useApplicationState((state) => state.noteDetails.primaryAddress)
   const { showErrorNotification } = useUiNotifications()
 
   const userEntries = useMemo(() => {
-    return userPermissions.map((entry) => <PermissionEntryUser key={entry.username} entry={entry} />)
-  }, [userPermissions])
+    return userPermissions.map((entry) => (
+      <PermissionEntryUser key={entry.username} entry={entry} disabled={disabled} />
+    ))
+  }, [userPermissions, disabled])
 
   const onAddEntry = useCallback(
     (username: string) => {
@@ -43,7 +48,11 @@ export const PermissionSectionUsers: React.FC = () => {
       </h5>
       <ul className={'list-group'}>
         {userEntries}
-        <PermissionAddEntryField onAddEntry={onAddEntry} i18nKey={'editor.modal.permissions.addUser'} />
+        <PermissionAddEntryField
+          onAddEntry={onAddEntry}
+          i18nKey={'editor.modal.permissions.addUser'}
+          disabled={disabled}
+        />
       </ul>
     </Fragment>
   )

--- a/frontend/src/hooks/common/use-is-owner.ts
+++ b/frontend/src/hooks/common/use-is-owner.ts
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useApplicationState } from './use-application-state'
+import { useMemo } from 'react'
+
+/**
+ * Determines if the current user is the owner of the current note.
+ *
+ * @return True, if the current user is owner.
+ */
+export const useIsOwner = (): boolean => {
+  const owner = useApplicationState((state) => state.noteDetails.permissions.owner)
+  const me: string | undefined = useApplicationState((state) => state.user?.username)
+
+  return useMemo(() => !!me && owner === me, [owner, me])
+}

--- a/frontend/src/test-utils/note-ownership.ts
+++ b/frontend/src/test-utils/note-ownership.ts
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import * as useApplicationStateModule from '../hooks/common/use-application-state'
+import type { ApplicationState } from '../redux/application-state'
+
+jest.mock('../hooks/common/use-application-state')
+export const mockNoteOwnership = (ownUsername: string, noteOwner: string) => {
+  jest.spyOn(useApplicationStateModule, 'useApplicationState').mockImplementation((fn) => {
+    return fn({
+      noteDetails: {
+        permissions: {
+          owner: noteOwner
+        }
+      },
+      user: {
+        username: ownUsername
+      }
+    } as ApplicationState)
+  })
+}


### PR DESCRIPTION
### Component/Part
isOwner

### Description
This PR add the isOwner hook and deactivates different buttons and textfields if the user is not the owner…

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x