### PR TITLE
feat: submit own user data on realtime user state set

### DIFF
--- a/backend/src/realtime/realtime-note/realtime-user-status-adapter.spec.ts
+++ b/backend/src/realtime/realtime-note/realtime-user-status-adapter.spec.ts
@@ -77,28 +77,34 @@ describe('realtime user status adapter', () => {
 
     const expectedMessage1: Message<MessageType.REALTIME_USER_STATE_SET> = {
       type: MessageType.REALTIME_USER_STATE_SET,
-      payload: [
-        {
-          active: true,
-          cursor: {
-            from: 0,
-            to: 0,
-          },
-          styleIndex: 1,
-          username: username2,
-          displayName: username2,
+      payload: {
+        ownUser: {
+          styleIndex: 0,
+          displayName: username1,
         },
-        {
-          active: true,
-          cursor: {
-            from: 0,
-            to: 0,
+        users: [
+          {
+            active: true,
+            cursor: {
+              from: 0,
+              to: 0,
+            },
+            styleIndex: 1,
+            username: username2,
+            displayName: username2,
           },
-          styleIndex: 2,
-          username: username3,
-          displayName: username3,
-        },
-      ],
+          {
+            active: true,
+            cursor: {
+              from: 0,
+              to: 0,
+            },
+            styleIndex: 2,
+            username: username3,
+            displayName: username3,
+          },
+        ],
+      },
     };
     expect(sendMessage1Spy).toHaveBeenNthCalledWith(1, expectedMessage1);
     expect(sendMessage2Spy).toHaveBeenCalledTimes(0);
@@ -125,54 +131,66 @@ describe('realtime user status adapter', () => {
 
     const expectedMessage2: Message<MessageType.REALTIME_USER_STATE_SET> = {
       type: MessageType.REALTIME_USER_STATE_SET,
-      payload: [
-        {
-          active: true,
-          cursor: {
-            from: newFrom,
-            to: newTo,
-          },
-          styleIndex: 0,
-          username: username1,
-          displayName: username1,
+      payload: {
+        ownUser: {
+          styleIndex: 1,
+          displayName: username2,
         },
-        {
-          active: true,
-          cursor: {
-            from: 0,
-            to: 0,
+        users: [
+          {
+            active: true,
+            cursor: {
+              from: newFrom,
+              to: newTo,
+            },
+            styleIndex: 0,
+            username: username1,
+            displayName: username1,
           },
-          styleIndex: 2,
-          username: username3,
-          displayName: username3,
-        },
-      ],
+          {
+            active: true,
+            cursor: {
+              from: 0,
+              to: 0,
+            },
+            styleIndex: 2,
+            username: username3,
+            displayName: username3,
+          },
+        ],
+      },
     };
 
     const expectedMessage3: Message<MessageType.REALTIME_USER_STATE_SET> = {
       type: MessageType.REALTIME_USER_STATE_SET,
-      payload: [
-        {
-          active: true,
-          cursor: {
-            from: newFrom,
-            to: newTo,
-          },
-          styleIndex: 0,
-          username: username1,
-          displayName: username1,
+      payload: {
+        ownUser: {
+          styleIndex: 2,
+          displayName: username3,
         },
-        {
-          active: true,
-          cursor: {
-            from: 0,
-            to: 0,
+        users: [
+          {
+            active: true,
+            cursor: {
+              from: newFrom,
+              to: newTo,
+            },
+            styleIndex: 0,
+            username: username1,
+            displayName: username1,
           },
-          styleIndex: 1,
-          username: username2,
-          displayName: username2,
-        },
-      ],
+          {
+            active: true,
+            cursor: {
+              from: 0,
+              to: 0,
+            },
+            styleIndex: 1,
+            username: username2,
+            displayName: username2,
+          },
+        ],
+      },
     };
 
     expect(sendMessage1Spy).toHaveBeenCalledTimes(0);
@@ -191,34 +209,46 @@ describe('realtime user status adapter', () => {
 
     const expectedMessage1: Message<MessageType.REALTIME_USER_STATE_SET> = {
       type: MessageType.REALTIME_USER_STATE_SET,
-      payload: [
-        {
-          active: true,
-          cursor: {
-            from: 0,
-            to: 0,
-          },
-          styleIndex: 2,
-          username: username3,
-          displayName: username3,
+      payload: {
+        ownUser: {
+          styleIndex: 0,
+          displayName: username1,
         },
-      ],
+        users: [
+          {
+            active: true,
+            cursor: {
+              from: 0,
+              to: 0,
+            },
+            styleIndex: 2,
+            username: username3,
+            displayName: username3,
+          },
+        ],
+      },
     };
 
     const expectedMessage3: Message<MessageType.REALTIME_USER_STATE_SET> = {
       type: MessageType.REALTIME_USER_STATE_SET,
-      payload: [
-        {
-          active: true,
-          cursor: {
-            from: 0,
-            to: 0,
-          },
-          styleIndex: 0,
-          username: username1,
-          displayName: username1,
+      payload: {
+        ownUser: {
+          styleIndex: 2,
+          displayName: username3,
         },
-      ],
+        users: [
+          {
+            active: true,
+            cursor: {
+              from: 0,
+              to: 0,
+            },
+            styleIndex: 0,
+            username: username1,
+            displayName: username1,
+          },
+        ],
+      },
     };
 
     expect(sendMessage1Spy).toHaveBeenNthCalledWith(1, expectedMessage1);

--- a/backend/src/realtime/realtime-note/realtime-user-status-adapter.ts
+++ b/backend/src/realtime/realtime-note/realtime-user-status-adapter.ts
@@ -94,13 +94,21 @@ export class RealtimeUserStatusAdapter {
   }
 
   private sendCompleteStateToClient(client: RealtimeConnection): void {
-    const payload = this.collectAllConnectionsExcept(client).map(
+    const realtimeUsers = this.collectAllConnectionsExcept(client).map(
       (client) => client.getRealtimeUserStateAdapter().realtimeUser,
     );
 
     client.getTransporter().sendMessage({
       type: MessageType.REALTIME_USER_STATE_SET,
-      payload,
+      payload: {
+        users: realtimeUsers,
+        ownUser: {
+          displayName:
+            client.getRealtimeUserStateAdapter().realtimeUser.displayName,
+          styleIndex:
+            client.getRealtimeUserStateAdapter().realtimeUser.styleIndex,
+        },
+      },
     });
   }
 

--- a/commons/src/message-transporters/message.ts
+++ b/commons/src/message-transporters/message.ts
@@ -22,7 +22,13 @@ export enum MessageType {
 export interface MessagePayloads {
   [MessageType.NOTE_CONTENT_STATE_REQUEST]: number[]
   [MessageType.NOTE_CONTENT_UPDATE]: number[]
-  [MessageType.REALTIME_USER_STATE_SET]: RealtimeUser[]
+  [MessageType.REALTIME_USER_STATE_SET]: {
+    users: RealtimeUser[]
+    ownUser: {
+      displayName: string
+      styleIndex: number
+    }
+  }
   [MessageType.REALTIME_USER_SINGLE_UPDATE]: RemoteCursor
 }
 

--- a/frontend/src/components/editor-page/editor-pane/codemirror-extensions/remote-cursors/receive-remote-cursor-view-plugin.ts
+++ b/frontend/src/components/editor-page/editor-pane/codemirror-extensions/remote-cursors/receive-remote-cursor-view-plugin.ts
@@ -20,7 +20,7 @@ export class ReceiveRemoteCursorViewPlugin implements PluginValue {
     this.listener = messageTransporter.on(
       MessageType.REALTIME_USER_STATE_SET,
       ({ payload }) => {
-        const cursors: RemoteCursor[] = payload.map((user) => ({
+        const cursors: RemoteCursor[] = payload.users.map((user) => ({
           from: user.cursor.from,
           to: user.cursor.to,
           displayName: user.displayName,

--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-receive-realtime-users.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-receive-realtime-users.ts
@@ -21,7 +21,12 @@ export const useReceiveRealtimeUsers = (messageTransporter: MessageTransporter):
   useEffect(() => {
     const listener = messageTransporter.on(
       MessageType.REALTIME_USER_STATE_SET,
-      (payload) => setRealtimeUsers(payload.payload),
+      (message) =>
+        setRealtimeUsers(
+          message.payload.users,
+          message.payload.ownUser.styleIndex,
+          message.payload.ownUser.displayName
+        ),
       { objectify: true }
     ) as Listener
 

--- a/frontend/src/redux/realtime/methods.ts
+++ b/frontend/src/redux/realtime/methods.ts
@@ -11,10 +11,14 @@ import type { RealtimeUser } from '@hedgedoc/commons'
 /**
  * Dispatches an event to add a user
  */
-export const setRealtimeUsers = (users: RealtimeUser[]): void => {
+export const setRealtimeUsers = (users: RealtimeUser[], ownStyleIndex: number, ownDisplayName: string): void => {
   const action: SetRealtimeUsersAction = {
     type: RealtimeStatusActionType.SET_REALTIME_USERS,
-    users
+    users,
+    ownUser: {
+      styleIndex: ownStyleIndex,
+      displayName: ownDisplayName
+    }
   }
   store.dispatch(action)
 }

--- a/frontend/src/redux/realtime/reducers.ts
+++ b/frontend/src/redux/realtime/reducers.ts
@@ -10,7 +10,11 @@ import type { Reducer } from 'redux'
 const initialState: RealtimeStatus = {
   isSynced: false,
   isConnected: false,
-  onlineUsers: []
+  onlineUsers: [],
+  ownUser: {
+    displayName: '',
+    styleIndex: 0
+  }
 }
 
 /**
@@ -28,7 +32,8 @@ export const RealtimeStatusReducer: Reducer<RealtimeStatus, RealtimeStatusAction
     case RealtimeStatusActionType.SET_REALTIME_USERS:
       return {
         ...state,
-        onlineUsers: action.users
+        onlineUsers: action.users,
+        ownUser: action.ownUser
       }
     case RealtimeStatusActionType.SET_REALTIME_CONNECTION_STATUS:
       return {

--- a/frontend/src/redux/realtime/types.ts
+++ b/frontend/src/redux/realtime/types.ts
@@ -16,6 +16,10 @@ export enum RealtimeStatusActionType {
 export interface SetRealtimeUsersAction extends Action<RealtimeStatusActionType> {
   type: RealtimeStatusActionType.SET_REALTIME_USERS
   users: RealtimeUser[]
+  ownUser: {
+    styleIndex: number
+    displayName: string
+  }
 }
 
 export interface SetRealtimeConnectionStatusAction extends Action<RealtimeStatusActionType> {
@@ -36,6 +40,10 @@ export interface RealtimeStatus {
   onlineUsers: RealtimeUser[]
   isConnected: boolean
   isSynced: boolean
+  ownUser: {
+    displayName: string
+    styleIndex: number
+  }
 }
 
 export type RealtimeStatusActions =


### PR DESCRIPTION
### Component/Part
Realtime users

### Description
This PR adds the own style index when receiving the realtime user state.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
