### PR TITLE
build: add eslint rule forbidding TypeORM Equal constructor

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -52,10 +52,9 @@ module.exports = {
     jest: true,
   },
   rules: {
-    "prettier/prettier": ["error",
-      require('./.prettierrc.json')
-    ],
+    'prettier/prettier': ['error', require('./.prettierrc.json')],
     'local-rules/correct-logger-context': 'error',
+    'local-rules/no-typeorm-equal': 'error',
     'func-style': ['error', 'declaration'],
     '@typescript-eslint/no-unused-vars': [
       'warn',

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -14,7 +14,7 @@ module.exports = {
       fixable: 'code',
       type: 'problem',
       docs: {
-        recommended: true
+        recommended: true,
       },
       schema: [],
     },
@@ -45,11 +45,39 @@ module.exports = {
                 fix: function (fixer) {
                   return fixer.replaceText(
                     node.arguments[1],
-                    `'${correctContext}'`,
+                    `'${correctContext}'`
                   );
                 },
               });
             }
+          }
+        },
+      };
+    },
+  },
+  'no-typeorm-equal': {
+    meta: {
+      type: 'problem',
+      fixable: 'code',
+      messages: {
+        noEqual:
+          'TypeORMs Equal constructor is buggy and therefore not allowed.',
+      },
+    },
+    create: function (context) {
+      return {
+        Identifier: function (node) {
+          if (node.name === 'Equal' && node.parent.type === 'CallExpression') {
+            context.report({
+              node: node,
+              messageId: 'noEqual',
+              fix: function (fixer) {
+                return fixer.replaceText(
+                  node.parent,
+                  `{ id: ${node.parent.arguments[0].name}.id }`
+                );
+              },
+            });
           }
         },
       };


### PR DESCRIPTION
### Component/Part
ESLint

### Description
TypeORMs Equal constructor is buggy and should not be used. This introduces a ESLint rule that checks for that.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
