### PR TITLE
build: use node18 tsconfig preset

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -81,7 +81,7 @@
     "@nestjs/schematics": "9.0.4",
     "@nestjs/testing": "9.3.12",
     "@trivago/prettier-plugin-sort-imports": "4.1.1",
-    "@tsconfig/node12": "1.0.11",
+    "@tsconfig/node18": "1.0.1",
     "@types/cli-color": "2.0.2",
     "@types/cookie": "0.5.1",
     "@types/cookie-signature": "1.1.0",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": [
+    "@tsconfig/node18/tsconfig.json"
+  ],
   "compilerOptions": {
     "declaration": true,
     "removeComments": true,
@@ -12,6 +14,7 @@
     "incremental": true,
     "strict": true,
     "strictPropertyInitialization": false,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "useDefineForClassFields": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,7 +2208,7 @@ __metadata:
     "@nestjs/typeorm": 9.0.1
     "@nestjs/websockets": 9.3.12
     "@trivago/prettier-plugin-sort-imports": 4.1.1
-    "@tsconfig/node12": 1.0.11
+    "@tsconfig/node18": 1.0.1
     "@types/bcrypt": 5.0.0
     "@types/cli-color": 2.0.2
     "@types/cookie": 0.5.1
@@ -4127,7 +4127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node12@npm:1.0.11, @tsconfig/node12@npm:^1.0.7":
+"@tsconfig/node12@npm:^1.0.7":
   version: 1.0.11
   resolution: "@tsconfig/node12@npm:1.0.11"
   checksum: 5ce29a41b13e7897a58b8e2df11269c5395999e588b9a467386f99d1d26f6c77d1af2719e407621412520ea30517d718d5192a32403b8dfcc163bf33e40a338a
@@ -4145,6 +4145,13 @@ __metadata:
   version: 1.0.3
   resolution: "@tsconfig/node16@npm:1.0.3"
   checksum: 3a8b657dd047495b7ad23437d6afd20297ce90380ff0bdee93fc7d39a900dbd8d9e26e53ff6b465e7967ce2adf0b218782590ce9013285121e6a5928fbd6819f
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node18@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@tsconfig/node18@npm:1.0.1"
+  checksum: aba11b453e40b03a33321e5b2bd51ba2d5213503bb95f1ecd56a5dd0be31eef1ab9ddfe06b4eae99075692641de905d57a38d671a9288bacac82327d393de1e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
tsconfig

### Description
Because of https://github.com/typeorm/typeorm/pull/9884, we need to manually disable useDefineForClassFields

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
