### PR TITLE
fix(renovate): fix ignored filename in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
     "type: maintenance"
   ],
   "ignorePaths": [
-    "docker/docker_compose.yml"
+    "docker/docker-compose.yml"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
### Component/Part
Renovate

### Description
This PR fixes the renovate config to ignore the correct file

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
