### PR TITLE
fix(backend): keep log output in dev mode

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -15,6 +15,7 @@
     "strict": true,
     "strictPropertyInitialization": false,
     "resolveJsonModule": true,
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "preserveWatchOutput": true
   }
 }


### PR DESCRIPTION
### Component/Part
backend dev mode

### Description
This PR instructs typescript / nestjs to keep the log output and not clear the terminal.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
