### PR TITLE
feat(frontend): show indicator in document title for background changes

### DIFF
--- a/backend/src/realtime/realtime-note/realtime-user-status-adapter.ts
+++ b/backend/src/realtime/realtime-note/realtime-user-status-adapter.ts
@@ -78,10 +78,23 @@ export class RealtimeUserStatusAdapter {
       },
     ) as Listener;
 
+    const realtimeUserSetActivityListener = connection.getTransporter().on(
+      MessageType.REALTIME_USER_SET_ACTIVITY,
+      (message) => {
+        if (this.realtimeUser.active === message.payload.active) {
+          return;
+        }
+        this.realtimeUser.active = message.payload.active;
+        this.sendRealtimeUserStatusUpdateEvent(connection);
+      },
+      { objectify: true },
+    ) as Listener;
+
     connection.getTransporter().on('disconnected', () => {
       transporterMessagesListener.off();
       transporterRequestMessageListener.off();
       clientRemoveListener.off();
+      realtimeUserSetActivityListener.off();
     });
   }
 

--- a/commons/src/message-transporters/message.ts
+++ b/commons/src/message-transporters/message.ts
@@ -16,6 +16,8 @@ export enum MessageType {
   REALTIME_USER_STATE_SET = 'REALTIME_USER_STATE_SET',
   REALTIME_USER_SINGLE_UPDATE = 'REALTIME_USER_SINGLE_UPDATE',
   REALTIME_USER_STATE_REQUEST = 'REALTIME_USER_STATE_REQUEST',
+  REALTIME_USER_SET_ACTIVITY = 'REALTIME_USER_SET_ACTIVITY',
+
   READY = 'READY'
 }
 
@@ -30,6 +32,10 @@ export interface MessagePayloads {
     }
   }
   [MessageType.REALTIME_USER_SINGLE_UPDATE]: RemoteCursor
+
+  [MessageType.REALTIME_USER_SET_ACTIVITY]: {
+    active: boolean
+  }
 }
 
 export type Message<T extends MessageType> = T extends keyof MessagePayloads

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -269,7 +269,7 @@
     },
     "onlineStatus": {
       "online": "Online",
-      "noUsers": "No users online"
+      "you": "(You)"
     },
     "error": {
       "locked": {

--- a/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
+++ b/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
@@ -27,6 +27,7 @@ import { useOnNoteDeleted } from './hooks/yjs/use-on-note-deleted'
 import { useRealtimeConnection } from './hooks/yjs/use-realtime-connection'
 import { useRealtimeDoc } from './hooks/yjs/use-realtime-doc'
 import { useReceiveRealtimeUsers } from './hooks/yjs/use-receive-realtime-users'
+import { useSendRealtimeActivity } from './hooks/yjs/use-send-realtime-activity'
 import { useYDocSyncClientAdapter } from './hooks/yjs/use-y-doc-sync-client-adapter'
 import { useLinter } from './linter/linter'
 import { MaxLengthWarning } from './max-length-warning/max-length-warning'
@@ -78,6 +79,7 @@ export const EditorPane: React.FC<EditorPaneProps> = ({ scrollState, onScroll, o
 
   useBindYTextToRedux(realtimeDoc)
   useReceiveRealtimeUsers(messageTransporter)
+  useSendRealtimeActivity(messageTransporter)
 
   const extensions = useMemo(
     () => [

--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-send-realtime-activity.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-send-realtime-activity.ts
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useIsDocumentVisible } from '../../../../../hooks/common/use-is-document-visible'
+import type { MessageTransporter } from '@hedgedoc/commons'
+import { MessageType } from '@hedgedoc/commons'
+import { useEffect } from 'react'
+import { useIdle } from 'react-use'
+
+const INACTIVITY_TIMEOUT_SECONDS = 30
+
+/**
+ * Sends the activity state (based on the fact if the tab is focused) to the backend.
+ *
+ * @param messageTransporter The message transporter that handles the connection to the backend
+ */
+export const useSendRealtimeActivity = (messageTransporter: MessageTransporter) => {
+  const active = useIsDocumentVisible()
+  const idling = useIdle(INACTIVITY_TIMEOUT_SECONDS * 1000)
+
+  useEffect(() => {
+    messageTransporter.doAsSoonAsReady(() => {
+      messageTransporter.sendMessage({
+        type: MessageType.REALTIME_USER_SET_ACTIVITY,
+        payload: {
+          active: active && !idling
+        }
+      })
+    })
+  }, [active, idling, messageTransporter])
+}

--- a/frontend/src/components/editor-page/head-meta-properties/hooks/use-has-markdown-content-been-changed-in-background.spec.tsx
+++ b/frontend/src/components/editor-page/head-meta-properties/hooks/use-has-markdown-content-been-changed-in-background.spec.tsx
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import * as UseIsDocumentVisibleModule from '../../../../hooks/common/use-is-document-visible'
+import * as UseNoteMarkdownContent from '../../../../hooks/common/use-note-markdown-content'
+import { useHasMarkdownContentBeenChangedInBackground } from './use-has-markdown-content-been-changed-in-background'
+import { render } from '@testing-library/react'
+import React, { Fragment } from 'react'
+
+jest.mock('../../../../hooks/common/use-is-document-visible')
+jest.mock('../../../../hooks/common/use-note-markdown-content')
+
+describe('use has markdown content been changed in background', () => {
+  const TestComponent: React.FC = () => {
+    const visible = useHasMarkdownContentBeenChangedInBackground()
+    return <Fragment>{String(visible)}</Fragment>
+  }
+
+  let documentVisible = true
+  let noteContent = 'content'
+
+  beforeEach(() => {
+    jest.spyOn(UseIsDocumentVisibleModule, 'useIsDocumentVisible').mockImplementation(() => documentVisible)
+    jest.spyOn(UseNoteMarkdownContent, 'useNoteMarkdownContent').mockImplementation(() => noteContent)
+  })
+
+  it('returns the correct value', () => {
+    documentVisible = true
+    noteContent = 'content1'
+    const view = render(<TestComponent />)
+    expect(view.container.textContent).toBe('false')
+    expect(view.container.textContent).toBe('false') //intentionally no change
+
+    noteContent = 'content2'
+    view.rerender(<TestComponent />)
+    expect(view.container.textContent).toBe('false')
+
+    documentVisible = false
+    view.rerender(<TestComponent />)
+    expect(view.container.textContent).toBe('false')
+
+    noteContent = 'content3'
+    view.rerender(<TestComponent />)
+    expect(view.container.textContent).toBe('true')
+
+    noteContent = 'content2'
+    view.rerender(<TestComponent />)
+    expect(view.container.textContent).toBe('true')
+
+    documentVisible = true
+    view.rerender(<TestComponent />)
+    expect(view.container.textContent).toBe('false')
+  })
+})

--- a/frontend/src/components/editor-page/head-meta-properties/hooks/use-has-markdown-content-been-changed-in-background.ts
+++ b/frontend/src/components/editor-page/head-meta-properties/hooks/use-has-markdown-content-been-changed-in-background.ts
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useIsDocumentVisible } from '../../../../hooks/common/use-is-document-visible'
+import { useNoteMarkdownContent } from '../../../../hooks/common/use-note-markdown-content'
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Determines if the markdown content has been changed while the browser tab hasn't been active.
+ */
+export const useHasMarkdownContentBeenChangedInBackground = (): boolean => {
+  const [backgroundChangesHappened, setBackgroundChangesHappened] = useState(false)
+  const documentVisible = useIsDocumentVisible()
+  const currentContent = useNoteMarkdownContent()
+  const lastContent = useRef<string>('')
+
+  useEffect(() => {
+    if (lastContent.current === currentContent || documentVisible) {
+      lastContent.current = currentContent
+      setBackgroundChangesHappened(false)
+      return
+    }
+    lastContent.current = currentContent
+    setBackgroundChangesHappened(true)
+  }, [currentContent, documentVisible])
+
+  return backgroundChangesHappened
+}

--- a/frontend/src/components/editor-page/head-meta-properties/note-and-app-title-head.tsx
+++ b/frontend/src/components/editor-page/head-meta-properties/note-and-app-title-head.tsx
@@ -5,6 +5,7 @@
  */
 import { useAppTitle } from '../../../hooks/common/use-app-title'
 import { useNoteTitle } from '../../../hooks/common/use-note-title'
+import { useHasMarkdownContentBeenChangedInBackground } from './hooks/use-has-markdown-content-been-changed-in-background'
 import Head from 'next/head'
 import React, { useMemo } from 'react'
 
@@ -14,10 +15,11 @@ import React, { useMemo } from 'react'
 export const NoteAndAppTitleHead: React.FC = () => {
   const noteTitle = useNoteTitle()
   const appTitle = useAppTitle()
+  const showDot = useHasMarkdownContentBeenChangedInBackground()
 
   const noteAndAppTitle = useMemo(() => {
-    return noteTitle + ' - ' + appTitle
-  }, [appTitle, noteTitle])
+    return (showDot ? '(•) ' : '') + noteTitle + ' - ' + appTitle
+  }, [appTitle, noteTitle, showDot])
 
   return (
     <Head>

--- a/frontend/src/components/editor-page/sidebar/user-line/user-line.module.scss
+++ b/frontend/src/components/editor-page/sidebar/user-line/user-line.module.scss
@@ -20,11 +20,3 @@
   flex: 1 1 0;
   overflow: hidden;
 }
-
-.active-indicator-container {
-  height: 100%;
-  display: flex;
-  flex: 0 0 20px;
-  align-items: center;
-  justify-content: center;
-}

--- a/frontend/src/components/editor-page/sidebar/user-line/user-line.tsx
+++ b/frontend/src/components/editor-page/sidebar/user-line/user-line.tsx
@@ -9,22 +9,28 @@ import { createCursorCssClass } from '../../editor-pane/codemirror-extensions/re
 import { ActiveIndicator } from '../users-online-sidebar-menu/active-indicator'
 import styles from './user-line.module.scss'
 import React, { useMemo } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
 
 export interface UserLineProps {
   username: string | null
   displayName: string
   active: boolean
+  own?: boolean
   color: number
 }
 
 /**
  * Represents a user in the realtime activity status.
  *
- * @param username The name of the user to show.
- * @param color The color of the user's edits.
- * @param status The user's current online status.
+ * @param username The username of the user to show
+ * @param color The color of the user's edits
+ * @param status The user's current online status
+ * @param displayName The actual name that should be displayed
+ * @param own defines if this user line renders the own user or another one
  */
-export const UserLine: React.FC<UserLineProps> = ({ username, displayName, active, color }) => {
+export const UserLine: React.FC<UserLineProps> = ({ username, displayName, active, own = false, color }) => {
+  useTranslation()
+
   const avatar = useMemo(() => {
     if (username) {
       return (
@@ -48,9 +54,13 @@ export const UserLine: React.FC<UserLineProps> = ({ username, displayName, activ
         )}`}
       />
       {avatar}
-      <div className={styles['active-indicator-container']}>
+      {own ? (
+        <span className={'px-1'}>
+          <Trans i18nKey={'editor.onlineStatus.you'}></Trans>
+        </span>
+      ) : (
         <ActiveIndicator active={active} />
-      </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/editor-page/sidebar/users-online-sidebar-menu/active-indicator.module.scss
+++ b/frontend/src/components/editor-page/sidebar/users-online-sidebar-menu/active-indicator.module.scss
@@ -18,3 +18,11 @@
     background-color: #d20000;
   }
 }
+
+.active-indicator-container {
+  height: 100%;
+  display: flex;
+  flex: 0 0 20px;
+  align-items: center;
+  justify-content: center;
+}

--- a/frontend/src/components/editor-page/sidebar/users-online-sidebar-menu/active-indicator.tsx
+++ b/frontend/src/components/editor-page/sidebar/users-online-sidebar-menu/active-indicator.tsx
@@ -16,5 +16,9 @@ export interface ActiveIndicatorProps {
  * @param status The state of the indicator to render
  */
 export const ActiveIndicator: React.FC<ActiveIndicatorProps> = ({ active }) => {
-  return <span className={`${styles['activeIndicator']} ${active ? styles.active : styles.inactive}`} />
+  return (
+    <div className={styles['active-indicator-container']}>
+      <span className={`${styles['activeIndicator']} ${active ? styles.active : styles.inactive}`} />
+    </div>
+  )
 }

--- a/frontend/src/components/editor-page/sidebar/users-online-sidebar-menu/own-user-line.tsx
+++ b/frontend/src/components/editor-page/sidebar/users-online-sidebar-menu/own-user-line.tsx
@@ -18,7 +18,7 @@ export const OwnUserLine: React.FC = () => {
 
   return (
     <SidebarButton>
-      <UserLine displayName={ownDisplayname} username={ownUsername} color={ownStyleIndex} active={true} />
+      <UserLine displayName={ownDisplayname} username={ownUsername} color={ownStyleIndex} active={true} own={true} />
     </SidebarButton>
   )
 }

--- a/frontend/src/hooks/common/use-is-document-visible.spec.tsx
+++ b/frontend/src/hooks/common/use-is-document-visible.spec.tsx
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useIsDocumentVisible } from './use-is-document-visible'
+import { fireEvent, render } from '@testing-library/react'
+import React, { Fragment } from 'react'
+
+describe('use is document visible', () => {
+  const TestComponent: React.FC = () => {
+    const visible = useIsDocumentVisible()
+    return <Fragment>{String(visible)}</Fragment>
+  }
+
+  it('returns the correct value', () => {
+    const view = render(<TestComponent />)
+    expect(view.container.textContent).toBe('true')
+    fireEvent(window, new Event('blur'))
+    expect(view.container.textContent).toBe('false')
+    fireEvent(window, new Event('focus'))
+    expect(view.container.textContent).toBe('true')
+  })
+})

--- a/frontend/src/hooks/common/use-is-document-visible.ts
+++ b/frontend/src/hooks/common/use-is-document-visible.ts
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useEffect, useState } from 'react'
+
+/**
+ * Uses the browsers visiblity API to determine if the tab is active or now.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
+ */
+export const useIsDocumentVisible = (): boolean => {
+  const [documentVisible, setDocumentVisible] = useState(true)
+
+  useEffect(() => {
+    const onFocus = () => setDocumentVisible(true)
+    const onBlur = () => setDocumentVisible(false)
+    window.addEventListener('focus', onFocus)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      document.removeEventListener('focus', onFocus)
+      document.removeEventListener('blur', onBlur)
+    }
+  }, [])
+
+  return documentVisible
+}


### PR DESCRIPTION
### Component/Part
Frontend

### Description
This PR adds an indicator to the window title that is visible if the document has been changed while the tab was inactive.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #3652 
