### PR TITLE
misc: remove features page buttons

### DIFF
--- a/frontend/cypress/e2e/intro.spec.ts
+++ b/frontend/cypress/e2e/intro.spec.ts
@@ -26,17 +26,6 @@ describe('Intro page', () => {
     })
   })
 
-  describe('features button', () => {
-    it('is hidden when logged in', () => {
-      cy.getByCypressId('features-button').should('not.exist')
-    })
-
-    it('is visible when logged out', () => {
-      cy.logout()
-      cy.getByCypressId('features-button').should('exist')
-    })
-  })
-
   describe('sign in button', () => {
     it('is hidden when logged in', () => {
       cy.getByCypressId('sign-in-button').should('not.exist')

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -57,7 +57,6 @@
   },
   "landing": {
     "intro": {
-      "exploreFeatures": "Explore all features",
       "markdownWhileLoading": "Loading...",
       "markdownLoadingError": "Error while fetching intro content"
     },
@@ -262,7 +261,6 @@
       },
       "documents": {
         "title": "Documents",
-        "features": "Features",
         "yamlMetadata": "YAML Metadata",
         "slideExample": "Slide Example"
       }

--- a/frontend/src/components/editor-page/app-bar/help-button/links-tab-content.tsx
+++ b/frontend/src/components/editor-page/app-bar/help-button/links-tab-content.tsx
@@ -73,14 +73,6 @@ export const LinksTabContent: React.FC = () => {
           <ul className='list-unstyled'>
             <li>
               <TranslatedInternalLink
-                i18nKey='editor.help.documents.features'
-                href='/n/features'
-                icon={IconDot}
-                className='text-primary'
-              />
-            </li>
-            <li>
-              <TranslatedInternalLink
                 i18nKey='editor.help.documents.yamlMetadata'
                 href='/n/yaml-metadata'
                 icon={IconDot}

--- a/frontend/src/components/intro-page/cover-buttons/cover-buttons.tsx
+++ b/frontend/src/components/intro-page/cover-buttons/cover-buttons.tsx
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { useApplicationState } from '../../../hooks/common/use-application-state'
-import { cypressId } from '../../../utils/cypress-attribute'
-import { ShowIf } from '../../common/show-if/show-if'
 import { SignInButton } from '../../landing-layout/navigation/sign-in-button'
-import './cover-buttons.module.scss'
-import Link from 'next/link'
+import styles from './cover-buttons.module.scss'
 import React from 'react'
-import { Button } from 'react-bootstrap'
-import { Trans, useTranslation } from 'react-i18next'
 
 export const CoverButtons: React.FC = () => {
-  useTranslation()
   const userExists = useApplicationState((state) => !!state.user)
-  const anyAuthProviderActivated = useApplicationState((state) => state.config.authProviders.length > 0)
 
   if (userExists) {
     return null
@@ -24,17 +17,7 @@ export const CoverButtons: React.FC = () => {
 
   return (
     <div className='mb-5'>
-      <SignInButton className='cover-button' variant='success' size='lg' />
-      <ShowIf condition={anyAuthProviderActivated}>
-        <span className='m-2'>
-          <Trans i18nKey='common.or' />
-        </span>
-      </ShowIf>
-      <Link href='/n/features' passHref={true}>
-        <Button {...cypressId('features-button')} className='cover-button' variant='primary' size='lg'>
-          <Trans i18nKey='landing.intro.exploreFeatures' />
-        </Button>
-      </Link>
+      <SignInButton className={styles['cover-button']} variant='success' size='lg' />
     </div>
   )
 }

--- a/frontend/src/components/landing-layout/navigation/user-dropdown.tsx
+++ b/frontend/src/components/landing-layout/navigation/user-dropdown.tsx
@@ -11,7 +11,6 @@ import { SignOutDropdownButton } from './sign-out-dropdown-button'
 import Link from 'next/link'
 import React from 'react'
 import { Dropdown } from 'react-bootstrap'
-import { Lightning as IconLightning } from 'react-bootstrap-icons'
 import { Person as IconPerson } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -33,12 +32,6 @@ export const UserDropdown: React.FC = () => {
       </Dropdown.Toggle>
 
       <Dropdown.Menu className='text-start'>
-        <Link href={'/n/features'} passHref={true} legacyBehavior={true}>
-          <Dropdown.Item dir='auto' {...cypressId('user-dropdown-features-button')}>
-            <UiIcon icon={IconLightning} className='mx-2' />
-            <Trans i18nKey='editor.help.documents.features' />
-          </Dropdown.Item>
-        </Link>
         <Link href={'/profile'} passHref={true} legacyBehavior={true}>
           <Dropdown.Item dir='auto' {...cypressId('user-dropdown-profile-button')}>
             <UiIcon icon={IconPerson} className='mx-2' />


### PR DESCRIPTION
### Component/Part
frontend

### Description
This PR removes the buttons for the "features" page as it won't be part of HedgeDoc 2 anymore. It has been replaced by the cheat sheet and the features page in the docs (#3655).

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

