### PR TITLE
fix: editorconfig

### DIFF
--- a/frontend/.editorconfig
+++ b/frontend/.editorconfig
@@ -65,7 +65,7 @@ ij_editorconfig_space_before_colon = false
 ij_editorconfig_space_before_comma = false
 ij_editorconfig_spaces_around_assignment_operators = true
 
-[{*.ats, *.ts, *.tsx}]
+[{*.ats,*.ts,*.tsx}]
 indent_size = 2
 tab_width = 2
 ij_continuation_indent_size = 2
@@ -226,7 +226,6 @@ ij_typescript_ternary_operation_wrap = off
 ij_typescript_union_types_wrap = normal
 ij_typescript_use_chained_calls_group_indents = false
 ij_typescript_use_double_quotes = false
-ij_typescript_use_explicit_js_extension = global
 ij_typescript_use_path_mapping = always
 ij_typescript_use_public_modifier = false
 ij_typescript_use_semicolon_after_statement = false
@@ -393,7 +392,6 @@ ij_javascript_ternary_operation_wrap = off
 ij_javascript_union_types_wrap = on_every_item
 ij_javascript_use_chained_calls_group_indents = false
 ij_javascript_use_double_quotes = true
-ij_javascript_use_explicit_js_extension = global
 ij_javascript_use_path_mapping = always
 ij_javascript_use_public_modifier = false
 ij_javascript_use_semicolon_after_statement = true
@@ -441,9 +439,8 @@ ij_html_space_after_tag_name = false
 ij_html_space_around_equality_in_attribute = false
 ij_html_space_inside_empty_tag = false
 ij_html_text_wrap = normal
-ij_html_uniform_ident = false
 
-[{*.markdown, *.md}]
+[{*.markdown,*.md}]
 ij_markdown_force_one_space_after_blockquote_symbol = true
 ij_markdown_force_one_space_after_header_symbol = true
 ij_markdown_force_one_space_after_list_bullet = true
@@ -456,7 +453,7 @@ ij_markdown_min_lines_around_block_elements = 1
 ij_markdown_min_lines_around_header = 1
 ij_markdown_min_lines_between_paragraphs = 1
 
-[{*.yaml, *.yml}]
+[{*.yaml,*.yml}]
 indent_size = 2
 ij_yaml_align_values_properties = do_not_align
 ij_yaml_autoinsert_sequence_marker = true


### PR DESCRIPTION
### Component/Part
editorconfig

### Description
WebStorm 2023.1 seems to be more strict regarding the .editorconfig.
The spaces in the file type definition will be interpreted now, causing no .ts file to match anymore for example.
This PR also removes lines that were highlighted by WebStorm as deprecated and removed entries.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
