### PR TITLE
fix(logout): redirect to login page

### DIFF
--- a/frontend/src/components/landing-layout/navigation/sign-out-dropdown-button.tsx
+++ b/frontend/src/components/landing-layout/navigation/sign-out-dropdown-button.tsx
@@ -8,6 +8,7 @@ import { clearUser } from '../../../redux/user/methods'
 import { cypressId } from '../../../utils/cypress-attribute'
 import { UiIcon } from '../../common/icons/ui-icon'
 import { useUiNotifications } from '../../notifications/ui-notification-boundary'
+import { useRouter } from 'next/router'
 import React, { useCallback } from 'react'
 import { Dropdown } from 'react-bootstrap'
 import { BoxArrowRight as IconBoxArrowRight } from 'react-bootstrap-icons'
@@ -19,11 +20,14 @@ import { Trans, useTranslation } from 'react-i18next'
 export const SignOutDropdownButton: React.FC = () => {
   useTranslation()
   const { showErrorNotification } = useUiNotifications()
+  const router = useRouter()
 
   const onSignOut = useCallback(() => {
     clearUser()
-    doLogout().catch(showErrorNotification('login.logoutFailed'))
-  }, [showErrorNotification])
+    doLogout()
+      .then(() => router.push('/login'))
+      .catch(showErrorNotification('login.logoutFailed'))
+  }, [showErrorNotification, router])
 
   return (
     <Dropdown.Item dir='auto' onClick={onSignOut} {...cypressId('user-dropdown-sign-out-button')}>


### PR DESCRIPTION
### Component/Part
login/logout

### Description
This PR adds the missing redirect back to the login page after clicking log out.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
