### PR TITLE
feat(renderer): Add intermediate class for markdown renderer extensions with event emitter

### DIFF
--- a/frontend/src/components/markdown-renderer/extensions/base/event-markdown-renderer-extension.ts
+++ b/frontend/src/components/markdown-renderer/extensions/base/event-markdown-renderer-extension.ts
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { MarkdownRendererExtension } from './markdown-renderer-extension'
+import type { EventEmitter2 } from 'eventemitter2'
+
+/**
+ * Base class for Markdown renderer extensions that need an event emitter.
+ */
+export abstract class EventMarkdownRendererExtension extends MarkdownRendererExtension {
+  constructor(protected readonly eventEmitter: EventEmitter2) {
+    super()
+  }
+}

--- a/frontend/src/components/markdown-renderer/extensions/base/markdown-renderer-extension.ts
+++ b/frontend/src/components/markdown-renderer/extensions/base/markdown-renderer-extension.ts
@@ -5,15 +5,12 @@
  */
 import type { NodeProcessor } from '../../node-preprocessors/node-processor'
 import type { ComponentReplacer } from '../../replace-components/component-replacer'
-import type { EventEmitter2 } from 'eventemitter2'
 import type MarkdownIt from 'markdown-it'
 
 /**
  * Base class for Markdown extensions.
  */
 export abstract class MarkdownRendererExtension {
-  constructor(protected readonly eventEmitter?: EventEmitter2) {}
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public configureMarkdownIt(markdownIt: MarkdownIt): void {
     return

--- a/frontend/src/components/markdown-renderer/extensions/table-of-contents/table-of-contents-markdown-extension.ts
+++ b/frontend/src/components/markdown-renderer/extensions/table-of-contents/table-of-contents-markdown-extension.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { tocSlugify } from '../../../editor-page/table-of-contents/toc-slugify'
-import { MarkdownRendererExtension } from '../base/markdown-renderer-extension'
+import { EventMarkdownRendererExtension } from '../base/event-markdown-renderer-extension'
 import type { TocAst } from '@hedgedoc/markdown-it-plugins'
 import { toc } from '@hedgedoc/markdown-it-plugins'
 import equal from 'fast-deep-equal'
@@ -13,7 +13,7 @@ import type MarkdownIt from 'markdown-it'
 /**
  * Adds table of content to the markdown rendering.
  */
-export class TableOfContentsMarkdownExtension extends MarkdownRendererExtension {
+export class TableOfContentsMarkdownExtension extends EventMarkdownRendererExtension {
   public static readonly EVENT_NAME = 'TocChange'
   private lastAst: TocAst | undefined = undefined
 

--- a/frontend/src/components/markdown-renderer/hooks/use-markdown-extensions.ts
+++ b/frontend/src/components/markdown-renderer/hooks/use-markdown-extensions.ts
@@ -28,6 +28,9 @@ export const useMarkdownExtensions = (
   const extensionEventEmitter = useExtensionEventEmitter()
   const frontendConfig = useFrontendConfig()
   return useMemo(() => {
+    if (!extensionEventEmitter) {
+      throw new Error("can't build markdown render extensions without event emitter.")
+    }
     return [
       ...optionalAppExtensions.flatMap((extension) =>
         extension.buildMarkdownRendererExtensions({

--- a/frontend/src/extensions/base/app-extension.ts
+++ b/frontend/src/extensions/base/app-extension.ts
@@ -14,7 +14,7 @@ import { Fragment } from 'react'
 
 export interface MarkdownRendererExtensionOptions {
   frontendConfig: FrontendConfig
-  eventEmitter?: EventEmitter2
+  eventEmitter: EventEmitter2
 }
 
 export abstract class AppExtension {

--- a/frontend/src/extensions/extra-integrations/task-list/task-list-markdown-extension.ts
+++ b/frontend/src/extensions/extra-integrations/task-list/task-list-markdown-extension.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { MarkdownRendererExtension } from '../../../components/markdown-renderer/extensions/base/markdown-renderer-extension'
+import { EventMarkdownRendererExtension } from '../../../components/markdown-renderer/extensions/base/event-markdown-renderer-extension'
 import type { ComponentReplacer } from '../../../components/markdown-renderer/replace-components/component-replacer'
 import { TaskListReplacer } from './task-list-replacer'
 import { taskLists } from '@hedgedoc/markdown-it-plugins'
@@ -12,7 +12,7 @@ import type MarkdownIt from 'markdown-it'
 /**
  * Adds support for interactive checkbox lists to the markdown rendering using the github checklist syntax.
  */
-export class TaskListMarkdownExtension extends MarkdownRendererExtension {
+export class TaskListMarkdownExtension extends EventMarkdownRendererExtension {
   public configureMarkdownIt(markdownIt: MarkdownIt): void {
     taskLists(markdownIt, {
       enabled: true,


### PR DESCRIPTION
### Component/Part
Renderer

### Description
This PR adds an intermediate class for markdown renderer extensions that require event emitters

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
