### PR TITLE
fix: use callback hook in checkbox editor component to cache function

### DIFF
--- a/frontend/src/extensions/extra-integrations/task-list/set-checkbox-in-cheatsheet.tsx
+++ b/frontend/src/extensions/extra-integrations/task-list/set-checkbox-in-cheatsheet.tsx
@@ -10,22 +10,29 @@ import type { TaskCheckedEventPayload } from './event-emitting-task-list-checkbo
 import { findCheckBox } from './find-check-box'
 import { TaskListCheckboxAppExtension } from './task-list-checkbox-app-extension'
 import type React from 'react'
+import { useCallback } from 'react'
 
 /**
  * Receives task-checkbox-change events and modify the current editor content.
  */
 export const SetCheckboxInCheatsheet: React.FC<CheatsheetExtensionComponentProps> = ({ setContent }) => {
-  useExtensionEventEmitterHandler(TaskListCheckboxAppExtension.EVENT_NAME, (event: TaskCheckedEventPayload) => {
-    setContent((previousContent) => {
-      return findCheckBox(previousContent, event.lineInMarkdown)
-        .map(
-          ([startIndex, endIndex]) =>
-            previousContent.slice(0, startIndex) +
-            createCheckboxContent(event.newCheckedState) +
-            previousContent.slice(endIndex)
+  useExtensionEventEmitterHandler(
+    TaskListCheckboxAppExtension.EVENT_NAME,
+    useCallback(
+      (event: TaskCheckedEventPayload) => {
+        setContent((previousContent) =>
+          findCheckBox(previousContent, event.lineInMarkdown)
+            .map(
+              ([startIndex, endIndex]) =>
+                previousContent.slice(0, startIndex) +
+                createCheckboxContent(event.newCheckedState) +
+                previousContent.slice(endIndex)
+            )
+            .orElse(previousContent)
         )
-        .orElse(previousContent)
-    })
-  })
+      },
+      [setContent]
+    )
+  )
   return null
 }


### PR DESCRIPTION
### Component/Part
Frontend 

### Description
This PR fixes a bug in the checkbox editor component that receive events and should prevent unnecessary run of the effect.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
