### PR TITLE
fix: suppress yjs double import warning

### DIFF
--- a/.yarn/patches/yjs-npm-13.5.52-a5c64d9068.patch
+++ b/.yarn/patches/yjs-npm-13.5.52-a5c64d9068.patch
@@ -1,0 +1,33 @@
+# This warning should indicate that you mix cjs and mjs imports.
+# While this is a nice feature it has a weird side effect:
+# Jest triggers this check and floods the console every time a test imports yjs.
+# This happens between all test suites and every time you call jest.resetModules().
+# Nothing breaks here. Jest does what it should.
+# Therefore this commit suppresses this warning in test mode.
+
+diff --git a/dist/yjs.cjs b/dist/yjs.cjs
+index a296aa30408893dc8cc59a083f4dc716aded29d0..068e2b9dee30f9c59e6edb8285788be66b202978 100644
+--- a/dist/yjs.cjs
++++ b/dist/yjs.cjs
+@@ -9893,7 +9893,7 @@ const glo = /** @type {any} */ (typeof globalThis !== 'undefined'
+
+ const importIdentifier = '__ $YJS$ __';
+
+-if (glo[importIdentifier] === true) {
++if (glo[importIdentifier] === true && process.env.NODE_ENV !== 'test') {
+   /**
+    * Dear reader of this message. Please take this seriously.
+    *
+diff --git a/dist/yjs.mjs b/dist/yjs.mjs
+index 005cc66e8dcd8aef9b2adf7a0eadc5a61b86667e..cbf100dc0b91ff9f61b544cc5c7cbf1be1388a28 100644
+--- a/dist/yjs.mjs
++++ b/dist/yjs.mjs
+@@ -9858,7 +9858,7 @@ const glo = /** @type {any} */ (typeof globalThis !== 'undefined'
+
+ const importIdentifier = '__ $YJS$ __';
+
+-if (glo[importIdentifier] === true) {
++if (glo[importIdentifier] === true && process.env.NODE_ENV !== 'test') {
+   /**
+    * Dear reader of this message. Please take this seriously.
+    *

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@codemirror/lint": "6.2.0",
     "@codemirror/theme-one-dark": "6.1.1",
     "@types/react": "18.0.35",
-    "eventemitter2@6.4.9": "patch:eventemitter2@npm%3A6.4.9#./.yarn/patches/eventemitter2-npm-6.4.9-ba37798a18.patch"
+    "eventemitter2@6.4.9": "patch:eventemitter2@npm%3A6.4.9#./.yarn/patches/eventemitter2-npm-6.4.9-ba37798a18.patch",
+    "yjs@13.5.52": "patch:yjs@npm%3A13.5.52#./.yarn/patches/yjs-npm-13.5.52-a5c64d9068.patch"
   },
   "devDependencies": {
     "dotenv-cli": "7.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19218,6 +19218,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yjs@patch:yjs@npm%3A13.5.52#./.yarn/patches/yjs-npm-13.5.52-a5c64d9068.patch::locator=hedgedoc%40workspace%3A.":
+  version: 13.5.52
+  resolution: "yjs@patch:yjs@npm%3A13.5.52#./.yarn/patches/yjs-npm-13.5.52-a5c64d9068.patch::version=13.5.52&hash=e7d95b&locator=hedgedoc%40workspace%3A."
+  dependencies:
+    lib0: ^0.2.72
+  checksum: d65bf903e8369607d8d3633ac3b155bf10c751c4a36d9613f78510d1e5d25a271bb2b8d503c803f62f7c0f17e0f219681e4d3a2337a07227298be6fee1f9e0a1
+  languageName: node
+  linkType: hard
+
 "yn@npm:3.1.1":
   version: 3.1.1
   resolution: "yn@npm:3.1.1"


### PR DESCRIPTION
### Component/Part
YJS Import

### Description

This warning should indicate that you mix cjs and mjs imports. While this is a nice feature it has a weird side effect: Jest triggers this check and floods the console every time a test imports yjs.
This happens between all test suites and every time you call `jest.resetModules()`.
Nothing breaks here. Jest does what it should.
Therefore this PR suppresses this warning in test mode.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
