### PR TITLE
fix deprecated netlify plugin

### DIFF
--- a/.github/workflows/frontend-netlify-deploy-main.yml
+++ b/.github/workflows/frontend-netlify-deploy-main.yml
@@ -9,7 +9,7 @@ on:
     branches: [ develop ]
 
 env:
-  NETLIFY_VERSION: 12.0.11
+  NETLIFY_VERSION: 13.2.2
   NODEJS_VERSION: 18
 
 defaults:

--- a/.github/workflows/frontend-netlify-deploy-main.yml
+++ b/.github/workflows/frontend-netlify-deploy-main.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   NETLIFY_VERSION: 13.2.2
+  NETLIFY_NEXTJS_PLUGIN_VERSION: 4.33.0
   NODEJS_VERSION: 18
 
 defaults:
@@ -56,7 +57,7 @@ jobs:
         run: rm -r .next/cache
 
       - name: Install netlify CLI
-        run: "npm install -g netlify-cli@${{ env.NETLIFY_VERSION }}"
+        run: "yarn add --dev netlify-cli@${{ env.NETLIFY_VERSION }} @netlify/plugin-nextjs@${{ env.NETLIFY_NEXTJS_PLUGIN_VERSION }}"
 
       - name: Run netlify CLI deployment
         env:

--- a/.github/workflows/frontend-netlify-deploy-pr.yml
+++ b/.github/workflows/frontend-netlify-deploy-pr.yml
@@ -28,6 +28,7 @@ permissions:
 
 env:
   NETLIFY_VERSION: 13.2.2
+  NETLIFY_NEXTJS_PLUGIN_VERSION: 4.33.0
   NODEJS_VERSION: 18
 
 defaults:
@@ -89,7 +90,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Install netlify CLI
-        run: "npm install -g netlify-cli@${{ env.NETLIFY_VERSION }}"
+        run: "yarn add --dev netlify-cli@${{ env.NETLIFY_VERSION }} @netlify/plugin-nextjs@${{ env.NETLIFY_NEXTJS_PLUGIN_VERSION }}"
 
       - name: Run netlify CLI
         env:

--- a/.github/workflows/frontend-netlify-deploy-pr.yml
+++ b/.github/workflows/frontend-netlify-deploy-pr.yml
@@ -27,7 +27,7 @@ permissions:
   deployments: write
 
 env:
-  NETLIFY_VERSION: 12.0.11
+  NETLIFY_VERSION: 13.2.2
   NODEJS_VERSION: 18
 
 defaults:

--- a/renovate.json
+++ b/renovate.json
@@ -81,8 +81,8 @@
   "regexManagers": [
     {
       "fileMatch": [
-        ".github/workflows/deploy-main.yml$",
-        ".github/workflows/deploy-pr.yml$"
+        ".github/workflows/frontend-netlify-deploy-main.yml$",
+        ".github/workflows/frontend-netlify-deploy-pr.yml$"
       ],
       "matchStrings": [
         "NETLIFY_VERSION=(?<currentValue>.*?)\\n"

--- a/renovate.json
+++ b/renovate.json
@@ -92,6 +92,17 @@
     },
     {
       "fileMatch": [
+        ".github/workflows/frontend-netlify-deploy-main.yml$",
+        ".github/workflows/frontend-netlify-deploy-pr.yml$"
+      ],
+      "matchStrings": [
+        "NETLIFY_NEXTJS_PLUGIN_VERSION=(?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@netlify/plugin-nextjs"
+    },
+    {
+      "fileMatch": [
         ".github/workflows/deploy-main.yml$",
         ".github/workflows/deploy-pr.yml$"
       ],


### PR DESCRIPTION
### Component/Part
Netlify deployment

### Description
This PR fixed the netlify deployment by manually installing the nextjs plugin.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
