### PR TITLE
improve S3 backend

### DIFF
--- a/backend/src/config/media.config.spec.ts
+++ b/backend/src/config/media.config.spec.ts
@@ -15,7 +15,7 @@ describe('mediaConfig', () => {
   const accessKeyId = 'accessKeyId';
   const secretAccessKey = 'secretAccessKey';
   const bucket = 'bucket';
-  const endPoint = 'endPoint';
+  const endPoint = 'https://endPoint';
   // Azure
   const azureConnectionString = 'connectionString';
   const container = 'container';
@@ -228,6 +228,46 @@ describe('mediaConfig', () => {
         );
         expect(() => mediaConfig()).toThrow(
           '"HD_MEDIA_BACKEND_S3_ENDPOINT" is required',
+        );
+        restore();
+      });
+      it('when HD_MEDIA_BACKEND_S3_ENDPOINT is not an URI', async () => {
+        const restore = mockedEnv(
+          {
+            /* eslint-disable @typescript-eslint/naming-convention */
+            HD_MEDIA_BACKEND: BackendType.S3,
+            HD_MEDIA_BACKEND_S3_ACCESS_KEY: accessKeyId,
+            HD_MEDIA_BACKEND_S3_SECRET_KEY: secretAccessKey,
+            HD_MEDIA_BACKEND_S3_BUCKET: bucket,
+            HD_MEDIA_BACKEND_S3_ENDPOINT: 'wrong-uri',
+            /* eslint-enable @typescript-eslint/naming-convention */
+          },
+          {
+            clear: true,
+          },
+        );
+        expect(() => mediaConfig()).toThrow(
+          '"HD_MEDIA_BACKEND_S3_ENDPOINT" must be a valid uri with a scheme matching the ^https? pattern',
+        );
+        restore();
+      });
+      it('when HD_MEDIA_BACKEND_S3_ENDPOINT is an URI with a non-http(s) protocol', async () => {
+        const restore = mockedEnv(
+          {
+            /* eslint-disable @typescript-eslint/naming-convention */
+            HD_MEDIA_BACKEND: BackendType.S3,
+            HD_MEDIA_BACKEND_S3_ACCESS_KEY: accessKeyId,
+            HD_MEDIA_BACKEND_S3_SECRET_KEY: secretAccessKey,
+            HD_MEDIA_BACKEND_S3_BUCKET: bucket,
+            HD_MEDIA_BACKEND_S3_ENDPOINT: 'ftps://example.org',
+            /* eslint-enable @typescript-eslint/naming-convention */
+          },
+          {
+            clear: true,
+          },
+        );
+        expect(() => mediaConfig()).toThrow(
+          '"HD_MEDIA_BACKEND_S3_ENDPOINT" must be a valid uri with a scheme matching the ^https? pattern',
         );
         restore();
       });

--- a/backend/src/config/media.config.ts
+++ b/backend/src/config/media.config.ts
@@ -56,7 +56,9 @@ const mediaSchema = Joi.object({
         accessKeyId: Joi.string().label('HD_MEDIA_BACKEND_S3_ACCESS_KEY'),
         secretAccessKey: Joi.string().label('HD_MEDIA_BACKEND_S3_SECRET_KEY'),
         bucket: Joi.string().label('HD_MEDIA_BACKEND_S3_BUCKET'),
-        endPoint: Joi.string().uri().label('HD_MEDIA_BACKEND_S3_ENDPOINT'),
+        endPoint: Joi.string()
+          .uri({ scheme: /^https?/ })
+          .label('HD_MEDIA_BACKEND_S3_ENDPOINT'),
       }),
       otherwise: Joi.optional(),
     }),

--- a/backend/src/config/media.config.ts
+++ b/backend/src/config/media.config.ts
@@ -56,7 +56,7 @@ const mediaSchema = Joi.object({
         accessKeyId: Joi.string().label('HD_MEDIA_BACKEND_S3_ACCESS_KEY'),
         secretAccessKey: Joi.string().label('HD_MEDIA_BACKEND_S3_SECRET_KEY'),
         bucket: Joi.string().label('HD_MEDIA_BACKEND_S3_BUCKET'),
-        endPoint: Joi.string().label('HD_MEDIA_BACKEND_S3_ENDPOINT'),
+        endPoint: Joi.string().uri().label('HD_MEDIA_BACKEND_S3_ENDPOINT'),
       }),
       otherwise: Joi.optional(),
     }),

--- a/backend/src/media/backends/s3-backend.spec.ts
+++ b/backend/src/media/backends/s3-backend.spec.ts
@@ -1,0 +1,212 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import * as MinioModule from 'minio';
+import { Client, ClientOptions, UploadedObjectInfo } from 'minio';
+import { Mock } from 'ts-mockery';
+
+import { MediaConfig } from '../../config/media.config';
+import { ConsoleLoggerService } from '../../logger/console-logger.service';
+import { BackendType } from './backend-type.enum';
+import { S3Backend } from './s3-backend';
+
+jest.mock('minio');
+describe('s3 backend', () => {
+  const mockedS3AccessKeyId = 'mockedS3AccessKeyId';
+  const mockedS3SecretAccessKey = 'mockedS3SecretAccessKey';
+  const mockedS3Bucket = 'mockedS3Bucket';
+
+  const mockedLoggerService = Mock.of<ConsoleLoggerService>({
+    setContext: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+  });
+
+  let mockedClient: Client;
+  let clientConstructorSpy: jest.SpyInstance<Client, [options: ClientOptions]>;
+
+  beforeEach(() => {
+    mockedClient = Mock.of<Client>({
+      putObject: jest.fn(),
+      removeObject: jest.fn(),
+    });
+
+    clientConstructorSpy = jest
+      .spyOn(MinioModule, 'Client')
+      .mockImplementation(() => mockedClient);
+  });
+
+  function mockMediaConfig(endPoint: string): MediaConfig {
+    return Mock.of<MediaConfig>({
+      backend: {
+        use: BackendType.S3,
+        s3: {
+          accessKeyId: mockedS3AccessKeyId,
+          secretAccessKey: mockedS3SecretAccessKey,
+          bucket: mockedS3Bucket,
+          endPoint: endPoint,
+        },
+      },
+    });
+  }
+
+  describe('constructor', () => {
+    it('can be created with a valid https url without port', () => {
+      const mediaConfig = mockMediaConfig('https://s3.example.org');
+      new S3Backend(mockedLoggerService, mediaConfig);
+      expect(clientConstructorSpy).toHaveBeenCalledWith({
+        endPoint: 's3.example.org',
+        useSSL: true,
+        port: undefined,
+        accessKey: mockedS3AccessKeyId,
+        secretKey: mockedS3SecretAccessKey,
+      } as ClientOptions);
+    });
+
+    it('can be created with a valid https url with port', () => {
+      const mediaConfig = mockMediaConfig('https://s3.example.org:9000');
+      new S3Backend(mockedLoggerService, mediaConfig);
+      expect(clientConstructorSpy).toHaveBeenCalledWith({
+        endPoint: 's3.example.org',
+        useSSL: true,
+        port: 9000,
+        accessKey: mockedS3AccessKeyId,
+        secretKey: mockedS3SecretAccessKey,
+      } as ClientOptions);
+    });
+
+    it('can be created with a valid http url without port', () => {
+      const mediaConfig = mockMediaConfig('http://s3.example.org');
+      new S3Backend(mockedLoggerService, mediaConfig);
+      expect(clientConstructorSpy).toHaveBeenCalledWith({
+        endPoint: 's3.example.org',
+        useSSL: false,
+        port: undefined,
+        accessKey: mockedS3AccessKeyId,
+        secretKey: mockedS3SecretAccessKey,
+      } as ClientOptions);
+    });
+
+    it('can be created with a valid http url with port', () => {
+      const mediaConfig = mockMediaConfig('http://s3.example.org:9000');
+      new S3Backend(mockedLoggerService, mediaConfig);
+      expect(clientConstructorSpy).toHaveBeenCalledWith({
+        endPoint: 's3.example.org',
+        useSSL: false,
+        port: 9000,
+        accessKey: mockedS3AccessKeyId,
+        secretKey: mockedS3SecretAccessKey,
+      } as ClientOptions);
+    });
+
+    it('will treat every non-https endpoint as not secure', () => {
+      const mediaConfig = mockMediaConfig('smtps://s3.example.org');
+      new S3Backend(mockedLoggerService, mediaConfig);
+      expect(clientConstructorSpy).toHaveBeenCalledWith({
+        endPoint: 's3.example.org',
+        useSSL: false,
+        port: undefined,
+        accessKey: mockedS3AccessKeyId,
+        secretKey: mockedS3SecretAccessKey,
+      } as ClientOptions);
+    });
+
+    it('will ignore paths in the endpoint', () => {
+      const mediaConfig = mockMediaConfig('https://s3.example.org/subpath');
+      new S3Backend(mockedLoggerService, mediaConfig);
+      expect(clientConstructorSpy).toHaveBeenCalledWith({
+        endPoint: 's3.example.org',
+        useSSL: true,
+        port: undefined,
+        accessKey: mockedS3AccessKeyId,
+        secretKey: mockedS3SecretAccessKey,
+      } as ClientOptions);
+    });
+
+    it('will crash if endpoint has no protocol', () => {
+      const mediaConfig = mockMediaConfig('s3.example.org');
+      expect(() => new S3Backend(mockedLoggerService, mediaConfig)).toThrow();
+    });
+  });
+
+  describe('save', () => {
+    it('can save a file', async () => {
+      const mediaConfig = mockMediaConfig('https://s3.example.org');
+      const saveSpy = jest
+        .spyOn(mockedClient, 'putObject')
+        .mockImplementation(() =>
+          Promise.resolve(Mock.of<UploadedObjectInfo>({})),
+        );
+
+      const sut = new S3Backend(mockedLoggerService, mediaConfig);
+
+      const mockedBuffer = Mock.of<Buffer>({});
+      const mockedFileName = 'mockedFileName';
+      const [url, backendData] = await sut.saveFile(
+        mockedBuffer,
+        mockedFileName,
+      );
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        mockedS3Bucket,
+        mockedFileName,
+        mockedBuffer,
+      );
+      expect(url).toBe('https://s3.example.org/mockedS3Bucket/mockedFileName');
+      expect(backendData).toBeNull();
+    });
+
+    it("will throw a MediaBackendError if the s3 client couldn't save the file", async () => {
+      const mediaConfig = mockMediaConfig('https://s3.example.org');
+      const saveSpy = jest
+        .spyOn(mockedClient, 'putObject')
+        .mockImplementation(() => Promise.reject(new Error('mocked error')));
+
+      const sut = new S3Backend(mockedLoggerService, mediaConfig);
+
+      const mockedBuffer = Mock.of<Buffer>({});
+      const mockedFileName = 'mockedFileName';
+      await expect(() =>
+        sut.saveFile(mockedBuffer, mockedFileName),
+      ).rejects.toThrow("Could not save 'mockedFileName' on S3");
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        mockedS3Bucket,
+        mockedFileName,
+        mockedBuffer,
+      );
+    });
+  });
+  describe('delete', () => {
+    it('can delete a file', async () => {
+      const mediaConfig = mockMediaConfig('https://s3.example.org');
+      const deleteSpy = jest
+        .spyOn(mockedClient, 'removeObject')
+        .mockImplementation(() => Promise.resolve());
+      const mockedFileName = 'mockedFileName';
+
+      const sut = new S3Backend(mockedLoggerService, mediaConfig);
+      await sut.deleteFile(mockedFileName);
+
+      expect(deleteSpy).toHaveBeenCalledWith(mockedS3Bucket, mockedFileName);
+    });
+
+    it("will throw a MediaBackendError if the client couldn't delete the file", async () => {
+      const mediaConfig = mockMediaConfig('https://s3.example.org');
+      const deleteSpy = jest
+        .spyOn(mockedClient, 'removeObject')
+        .mockImplementation(() => Promise.reject(new Error('mocked error')));
+      const mockedFileName = 'mockedFileName';
+
+      const sut = new S3Backend(mockedLoggerService, mediaConfig);
+
+      await expect(() => sut.deleteFile(mockedFileName)).rejects.toThrow(
+        "Could not delete 'mockedFileName' on S3",
+      );
+
+      expect(deleteSpy).toHaveBeenCalledWith(mockedS3Bucket, mockedFileName);
+    });
+  });
+});

--- a/backend/src/media/backends/s3-backend.ts
+++ b/backend/src/media/backends/s3-backend.ts
@@ -59,7 +59,7 @@ export class S3Backend implements MediaBackend {
     }
   }
 
-  async deleteFile(fileName: string, _: BackendData): Promise<void> {
+  async deleteFile(fileName: string): Promise<void> {
     try {
       await this.client.removeObject(this.config.bucket, fileName);
       const url = this.getUrl(fileName);

--- a/backend/src/media/backends/s3-backend.ts
+++ b/backend/src/media/backends/s3-backend.ts
@@ -73,8 +73,10 @@ export class S3Backend implements MediaBackend {
 
   private getUrl(fileName: string): string {
     const url = new URL(this.config.endPoint);
-    const port = url.port !== '' ? `:${url.port}` : '';
-    const bucket = this.config.bucket;
-    return `${url.protocol}//${url.hostname}${port}${url.pathname}${bucket}/${fileName}`;
+    if (!url.pathname.endsWith('/')) {
+      url.pathname += '/';
+    }
+    url.pathname += `${this.config.bucket}/${fileName}`;
+    return url.toString();
   }
 }

--- a/backend/src/media/backends/s3-backend.ts
+++ b/backend/src/media/backends/s3-backend.ts
@@ -29,13 +29,12 @@ export class S3Backend implements MediaBackend {
       this.config = mediaConfig.backend.s3;
       const url = new URL(this.config.endPoint);
       const secure = url.protocol === 'https:'; // url.protocol contains a trailing ':'
-      const endpoint = `${url.hostname}${url.pathname}`;
       let port = parseInt(url.port);
       if (isNaN(port)) {
         port = secure ? 443 : 80;
       }
       this.client = new Client({
-        endPoint: endpoint.substr(0, endpoint.length - 1), // remove trailing '/'
+        endPoint: url.hostname,
         port: port,
         useSSL: secure,
         accessKey: this.config.accessKeyId,

--- a/docs/content/config/media/s3.md
+++ b/docs/content/config/media/s3.md
@@ -14,6 +14,8 @@ HD_MEDIA_BACKEND_S3_BUCKET="<BUCKET>"
 HD_MEDIA_BACKEND_S3_ENDPOINT="<ENDPOINT>"
 ```
 
-If you use Amazon S3, `<ENDPOINT>` should contain your [Amazon Region](https://docs.aws.amazon.com/general/latest/gr/s3.html).
+`<ENDPOINT>` should be an URL and contain the protocol, the domain and if necessary the port.
+For example: `https://s3.example.org` or `http://s3.example.org:9000`
 
-For example: If your Amazon Region is `us-east-2`, your endpoint `<ENDPOINT>` should be `s3.us-east-2.amazonaws.com`.
+If you use Amazon S3, `<ENDPOINT>` should contain your [Amazon Region](https://docs.aws.amazon.com/general/latest/gr/s3.html).
+For example: If your Amazon Region is `us-east-2`, your endpoint `<ENDPOINT>` should be `https://s3.us-east-2.amazonaws.com`.


### PR DESCRIPTION
### Component/Part
S3 backend

### Description

The minio lib already handles port fallbacks.
It also expects "endpoint" to be a single host instead of a path. (see https://github.com/minio/minio-js/blob/master/src/main/minio.js#L269)

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
