### PR TITLE
Disconnect message transporter on editor leave

### DIFF
--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-realtime-connection.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-realtime-connection.ts
@@ -94,6 +94,8 @@ export const useRealtimeConnection = (): MessageTransporter => {
     return () => window.removeEventListener('beforeunload', disconnectCallback)
   }, [messageTransporter])
 
+  useEffect(() => () => messageTransporter.disconnect(), [messageTransporter])
+
   useEffect(() => {
     const connectedListener = messageTransporter.doAsSoonAsReady(() => setRealtimeConnectionState(true))
     const disconnectedListener = messageTransporter.on('disconnected', () => setRealtimeConnectionState(false), {


### PR DESCRIPTION
### Component/Part
Frontend

### Description

If you leave the editor without reloading the page then the connection isn't closed properly.
This PR fixes this.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
