### PR TITLE
Only show non-guest users in the sidebar #2953

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -411,7 +411,8 @@
         "error": "An error occurred while fetching the revisions of this note.",
         "errorUser": "An error occurred while fetching the user information for this revision.",
         "length": "Length",
-        "download": "Download selected revision"
+        "download": "Download selected revision",
+        "guestCount": "Anonymous authors or guests"
       },
       "clipboardImport": {
         "title": "Import from clipboard",

--- a/frontend/src/components/editor-page/document-bar/revisions/revision-list-entry.tsx
+++ b/frontend/src/components/editor-page/document-bar/revisions/revision-list-entry.tsx
@@ -17,6 +17,7 @@ import { ListGroup } from 'react-bootstrap'
 import { Clock as IconClock } from 'react-bootstrap-icons'
 import { FileText as IconFileText } from 'react-bootstrap-icons'
 import { Person as IconPerson } from 'react-bootstrap-icons'
+import { PersonPlus as IconPersonPlus } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
 import { useAsync } from 'react-use'
 
@@ -73,6 +74,10 @@ export const RevisionListEntry: React.FC<RevisionListEntryProps> = ({ active, on
           <WaitSpinner />
         </ShowIf>
         <ShowIf condition={!revisionAuthors.error && !revisionAuthors.loading}>{revisionAuthors.value}</ShowIf>
+      </span>
+      <span>
+        <UiIcon icon={IconPersonPlus} className='mx-2' />
+        <Trans i18nKey={'editor.modal.revision.guestCount'} />: {revision.anonymousAuthorCount}
       </span>
     </ListGroup.Item>
   )


### PR DESCRIPTION
### Component/Part
Frontend

### Description
Only show non-guest users in the sidebar

### Steps
- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: develop for 2.x
  - Signed-off-by: Shan Michel <yuplasmas@gmail.com>

### Related Issue(s)
#2953

### Last pull request link:
I was trying to squash all my push and commits with git reset methods and since It reversed all my changes thus my pull request got automatically closed, I'm sorry last pull request got closed: https://github.com/hedgedoc/hedgedoc/pull/3813.