### PR TITLE
feat: use css vars in sidebar

### DIFF
--- a/frontend/src/components/editor-page/sidebar/sidebar-button/sidebar-button.module.scss
+++ b/frontend/src/components/editor-page/sidebar/sidebar-button/sidebar-button.module.scss
@@ -5,25 +5,25 @@
  */
 
 .sidebar-button {
-  @import '../style/variables.scss';
-
-  height: $height;
-  flex: 0 0 $height;
+  height: var(--sidebar-entry-height);
+  flex: 0 0 var(--sidebar-entry-height);
   width: 100%;
   display: flex;
   align-items: center;
-  border: solid 1px rgba(0, 0, 0, 0.15);
+  border: solid 1px var(--sidebar-separator-color);
+  border-left: none;
   user-select: none;
   cursor: pointer;
   background: transparent;
   padding: 0;
   transition: height 0.2s, flex-basis 0.2s;
   overflow: hidden;
+  color: var(--bs-dark);
 
   &.hide {
     flex-basis: 0;
-    height: 0px;
-    border-width: 0px;
+    height: 0;
+    border-width: 0;
 
     .sidebar-icon {
       opacity: 0;
@@ -37,8 +37,8 @@
   .sidebar-icon {
     transition: opacity 0.2s;
     opacity: 1;
-    height: $height;
-    width: $height;
+    height: var(--sidebar-entry-height);
+    width: var(--sidebar-entry-height);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -57,27 +57,20 @@
     width: 0;
   }
 
-  @mixin colors {
-    color: var(--bs-dark);
-
-    &.sidebar-button-primary {
-      color: var(--bs-light);
-      background: var(--bs-primary);
-
-      &:hover {
-        color: var(--bs-primary);
-        background:  var(--bs-light);
-      }
-    }
+  &.sidebar-button-primary {
+    color: var(--bs-light);
+    background: var(--bs-primary);
 
     &:hover {
-      color: var(--bs-light);
-      background:  var(--bs-primary);
+      color: var(--bs-primary);
+      background: var(--bs-light);
     }
   }
 
-  $entry-hover-bg: darken(black, 10%);
-  @include colors;
+  &:hover {
+    color: var(--bs-light);
+    background: var(--bs-primary);
+  }
 }
 
 

--- a/frontend/src/components/editor-page/sidebar/style/sidebar.module.scss
+++ b/frontend/src/components/editor-page/sidebar/style/sidebar.module.scss
@@ -5,9 +5,15 @@
  */
 
 .slide-sidebar {
-  @import "./variables.scss";
+  --sidebar-entry-height: 40px;
+  --sidebar-menu-width: 250px;
+  --sidebar-separator-color: rgba(0, 0, 0, 0.15);
 
-  flex: 0 0 $height;
+  :global(body.dark) & {
+    --sidebar-separator-color: rgba(255,255,255,0.2);
+  }
+
+  flex: 0 0 var(--sidebar-entry-height);
   position: relative;
 
   .sidebar-inner {
@@ -17,15 +23,16 @@
     flex-direction: column;
     position: absolute;
     z-index: 999;
-    width: $menu-width;
+    width: var(--sidebar-menu-width);
     top: 0;
     left: 0;
     transition: left 0.3s;
     box-shadow: 0 0 0 rgba(0, 0, 0, 0.15);
+    border-left: solid 1px var(--sidebar-separator-color);
 
     &:hover, &.show {
       box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
-      left: (-$menu-width + $height);
+      left: calc(0px - var(--sidebar-menu-width) + var(--sidebar-entry-height));
     }
 
     background: var(--bs-light);

--- a/frontend/src/components/editor-page/sidebar/style/variables.scss
+++ b/frontend/src/components/editor-page/sidebar/style/variables.scss
@@ -1,8 +1,0 @@
-/*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
- *
- * SPDX-License-Identifier: AGPL-3.0-only
- */
-
-$height: 40px;
-$menu-width: 175px;


### PR DESCRIPTION
### Component/Part
Frontend -> Sidebar

### Description
This PR improves the sidebar code by replacing the scss variables with css vars.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
