### PR TITLE
fix: height of loading screen

### DIFF
--- a/frontend/src/components/application-loader/application-loader.module.scss
+++ b/frontend/src/components/application-loader/application-loader.module.scss
@@ -5,13 +5,11 @@
  */
 
 .loader {
-  height: 100%;
+  height: 100vh;
   width: 100%;
 
-  &.middle, .middle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-  }
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
 }

--- a/frontend/src/components/application-loader/loading-screen/loading-screen.tsx
+++ b/frontend/src/components/application-loader/loading-screen/loading-screen.tsx
@@ -21,7 +21,7 @@ export interface LoadingScreenProps {
  */
 export const LoadingScreen: React.FC<LoadingScreenProps> = ({ errorMessage }) => {
   return (
-    <div className={`${styles.loader} ${styles.middle} text-light overflow-hidden`}>
+    <div className={`${styles.loader} text-light`}>
       <div className='mb-3 text-light'>
         <span className={`d-block`}>
           <LoadingAnimation error={!!errorMessage} />


### PR DESCRIPTION
### Component/Part
Frontend Loading screen

### Description
This PR fixes the loading screen height.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
