### PR TITLE
Refactor Custom branding

### DIFF
--- a/frontend/src/components/common/custom-branding/__snapshots__/custom-branding.spec.tsx.snap
+++ b/frontend/src/components/common/custom-branding/__snapshots__/custom-branding.spec.tsx.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`custom branding doesn't show anything if no branding is defined 1`] = `<div />`;
+
+exports[`custom branding with inline=false shows an image if branding logo is defined 1`] = `
+<div>
+  <img
+    class="regular-size"
+    src="mockBrandingUrl"
+  />
+</div>
+`;
+
+exports[`custom branding with inline=false shows an text if branding text is defined 1`] = `
+<div>
+  <span
+    class="regular-size"
+  >
+    mockedBranding
+  </span>
+</div>
+`;
+
+exports[`custom branding with inline=false will prefer the logo over the text 1`] = `
+<div>
+  <img
+    alt="mockedBranding"
+    class="regular-size"
+    src="mockBrandingUrl"
+    title="mockedBranding"
+  />
+</div>
+`;
+
+exports[`custom branding with inline=true shows an image if branding logo is defined 1`] = `
+<div>
+  <img
+    class="inline-size"
+    src="mockBrandingUrl"
+  />
+</div>
+`;
+
+exports[`custom branding with inline=true shows an text if branding text is defined 1`] = `
+<div>
+  <span
+    class="inline-size"
+  >
+    mockedBranding
+  </span>
+</div>
+`;
+
+exports[`custom branding with inline=true will prefer the logo over the text 1`] = `
+<div>
+  <img
+    alt="mockedBranding"
+    class="inline-size"
+    src="mockBrandingUrl"
+    title="mockedBranding"
+  />
+</div>
+`;
+
+exports[`custom branding with inline=undefined shows an image if branding logo is defined 1`] = `
+<div>
+  <img
+    class="regular-size"
+    src="mockBrandingUrl"
+  />
+</div>
+`;
+
+exports[`custom branding with inline=undefined shows an text if branding text is defined 1`] = `
+<div>
+  <span
+    class="regular-size"
+  >
+    mockedBranding
+  </span>
+</div>
+`;
+
+exports[`custom branding with inline=undefined will prefer the logo over the text 1`] = `
+<div>
+  <img
+    alt="mockedBranding"
+    class="regular-size"
+    src="mockBrandingUrl"
+    title="mockedBranding"
+  />
+</div>
+`;

--- a/frontend/src/components/common/custom-branding/branding.module.scss
+++ b/frontend/src/components/common/custom-branding/branding.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/frontend/src/components/common/custom-branding/custom-branding.spec.tsx
+++ b/frontend/src/components/common/custom-branding/custom-branding.spec.tsx
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import type { FrontendConfig } from '../../../api/config/types'
+import * as UseFrontendConfigMock from '../frontend-config-context/use-frontend-config'
+import { CustomBranding } from './custom-branding'
+import { render } from '@testing-library/react'
+import { Mock } from 'ts-mockery'
+
+jest.mock('../frontend-config-context/use-frontend-config')
+
+describe('custom branding', () => {
+  const mockFrontendConfigHook = (logo?: string, name?: string) => {
+    jest
+      .spyOn(UseFrontendConfigMock, 'useFrontendConfig')
+      .mockReturnValue(Mock.of<FrontendConfig>({ branding: { logo, name } }))
+  }
+
+  it("doesn't show anything if no branding is defined", () => {
+    mockFrontendConfigHook()
+    const view = render(<CustomBranding />)
+    expect(view.container).toMatchSnapshot()
+  })
+
+  describe.each([false, true, undefined])('with inline=%s', (inline) => {
+    it('shows an image if branding logo is defined', () => {
+      mockFrontendConfigHook('mockBrandingUrl')
+      const view = render(<CustomBranding inline={inline} />)
+      expect(view.container).toMatchSnapshot()
+    })
+
+    it('shows an text if branding text is defined', () => {
+      mockFrontendConfigHook(undefined, 'mockedBranding')
+      const view = render(<CustomBranding inline={inline} />)
+      expect(view.container).toMatchSnapshot()
+    })
+
+    it('will prefer the logo over the text', () => {
+      mockFrontendConfigHook('mockBrandingUrl', 'mockedBranding')
+      const view = render(<CustomBranding inline={inline} />)
+      expect(view.container).toMatchSnapshot()
+    })
+  })
+})

--- a/frontend/src/components/common/custom-branding/custom-branding.tsx
+++ b/frontend/src/components/common/custom-branding/custom-branding.tsx
@@ -4,13 +4,11 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { useFrontendConfig } from '../frontend-config-context/use-frontend-config'
-import { ShowIf } from '../show-if/show-if'
 import styles from './branding.module.scss'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 export interface BrandingProps {
   inline?: boolean
-  delimiter?: boolean
 }
 
 /**
@@ -20,32 +18,22 @@ export interface BrandingProps {
  * @param inline If the logo should be using the inline-size or the regular-size css class.
  * @param delimiter If the delimiter between the HedgeDoc logo and the branding should be shown.
  */
-export const CustomBranding: React.FC<BrandingProps> = ({ inline = false, delimiter = true }) => {
+export const CustomBranding: React.FC<BrandingProps> = ({ inline = false }) => {
   const branding = useFrontendConfig().branding
-  const showBranding = !!branding.name || !!branding.logo
 
-  const brandingDom = useMemo(() => {
-    if (branding.logo) {
-      return (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={branding.logo}
-          alt={branding.name}
-          title={branding.name}
-          className={inline ? styles['inline-size'] : styles['regular-size']}
-        />
-      )
-    } else {
-      return branding.name
-    }
-  }, [branding.logo, branding.name, inline])
-
-  return (
-    <ShowIf condition={showBranding}>
-      <ShowIf condition={delimiter}>
-        <strong className={`mx-1 ${inline ? styles['inline-size'] : styles['regular-size']}`}>@</strong>
-      </ShowIf>
-      {brandingDom}
-    </ShowIf>
-  )
+  if (!branding.name && !branding.logo) {
+    return null
+  } else if (branding.logo) {
+    return (
+      /* eslint-disable-next-line @next/next/no-img-element */
+      <img
+        src={branding.logo}
+        alt={branding.name}
+        title={branding.name}
+        className={inline ? styles['inline-size'] : styles['regular-size']}
+      />
+    )
+  } else {
+    return <span className={inline ? styles['inline-size'] : styles['regular-size']}>{branding.name}</span>
+  }
 }

--- a/frontend/src/components/common/custom-branding/custom-branding.tsx
+++ b/frontend/src/components/common/custom-branding/custom-branding.tsx
@@ -20,7 +20,7 @@ export interface BrandingProps {
  * @param inline If the logo should be using the inline-size or the regular-size css class.
  * @param delimiter If the delimiter between the HedgeDoc logo and the branding should be shown.
  */
-export const Branding: React.FC<BrandingProps> = ({ inline = false, delimiter = true }) => {
+export const CustomBranding: React.FC<BrandingProps> = ({ inline = false, delimiter = true }) => {
   const branding = useFrontendConfig().branding
   const showBranding = !!branding.name || !!branding.logo
 

--- a/frontend/src/components/editor-page/app-bar/branding.module.scss
+++ b/frontend/src/components/editor-page/app-bar/branding.module.scss
@@ -1,0 +1,13 @@
+/*!
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+.branding-separator:has(*) {
+  &::before {
+    content: '\2014';
+    margin-left: 0.25em;
+    margin-right: 0.25em;
+  }
+}

--- a/frontend/src/components/editor-page/app-bar/navbar-branding.tsx
+++ b/frontend/src/components/editor-page/app-bar/navbar-branding.tsx
@@ -10,6 +10,7 @@ import {
   HedgeDocLogoType,
   HedgeDocLogoWithText
 } from '../../common/hedge-doc-logo/hedge-doc-logo-with-text'
+import styles from './branding.module.scss'
 import Link from 'next/link'
 import React from 'react'
 import { Navbar } from 'react-bootstrap'
@@ -27,7 +28,9 @@ export const NavbarBranding: React.FC = () => {
           logoType={darkModeActivated ? HedgeDocLogoType.WB_HORIZONTAL : HedgeDocLogoType.BW_HORIZONTAL}
           size={HedgeDocLogoSize.SMALL}
         />
-        <CustomBranding inline={true} />
+        <span className={styles['branding-separator']}>
+          <CustomBranding inline={true} />
+        </span>
       </Link>
     </Navbar.Brand>
   )

--- a/frontend/src/components/editor-page/app-bar/navbar-branding.tsx
+++ b/frontend/src/components/editor-page/app-bar/navbar-branding.tsx
@@ -1,10 +1,10 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { useDarkModeState } from '../../../hooks/dark-mode/use-dark-mode-state'
-import { Branding } from '../../common/branding/branding'
+import { CustomBranding } from '../../common/custom-branding/custom-branding'
 import {
   HedgeDocLogoSize,
   HedgeDocLogoType,
@@ -27,7 +27,7 @@ export const NavbarBranding: React.FC = () => {
           logoType={darkModeActivated ? HedgeDocLogoType.WB_HORIZONTAL : HedgeDocLogoType.BW_HORIZONTAL}
           size={HedgeDocLogoSize.SMALL}
         />
-        <Branding inline={true} />
+        <CustomBranding inline={true} />
       </Link>
     </Navbar.Brand>
   )

--- a/frontend/src/pages/intro.tsx
+++ b/frontend/src/pages/intro.tsx
@@ -32,7 +32,7 @@ const IntroPage: NextPage = () => {
             <Trans i18nKey='app.slogan' />
           </p>
           <div className={'mb-5'}>
-            <CustomBranding delimiter={false} />
+            <CustomBranding />
           </div>
           <CoverButtons />
           <IntroCustomContent />

--- a/frontend/src/pages/intro.tsx
+++ b/frontend/src/pages/intro.tsx
@@ -1,9 +1,9 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { Branding } from '../components/common/branding/branding'
+import { CustomBranding } from '../components/common/custom-branding/custom-branding'
 import {
   HedgeDocLogoSize,
   HedgeDocLogoType,
@@ -32,7 +32,7 @@ const IntroPage: NextPage = () => {
             <Trans i18nKey='app.slogan' />
           </p>
           <div className={'mb-5'}>
-            <Branding delimiter={false} />
+            <CustomBranding delimiter={false} />
           </div>
           <CoverButtons />
           <IntroCustomContent />


### PR DESCRIPTION
### Component/Part
Branding

### Description
This PR refactors the custom branding component to use CSS for the delimiter and adds a test.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
