### PR TITLE
Fix premature note cleanup on error

### DIFF
--- a/lib/realtime.js
+++ b/lib/realtime.js
@@ -363,13 +363,6 @@ function connectNextSocket () {
   }, 1)
 }
 
-function interruptConnection (socket, noteId, socketId) {
-  if (notes[noteId]) delete notes[noteId]
-  if (users[socketId]) delete users[socketId]
-  if (socket) { clearSocketQueue(connectionSocketQueue, socket) } else { connectionSocketQueue.shift() }
-  connectNextSocket()
-}
-
 function checkViewPermission (req, note) {
   if (note.permission === 'private') {
     if (req.user && req.user.logged_in && req.user.id === note.owner) { return true } else { return false }
@@ -386,13 +379,8 @@ let isDisconnectBusy = false
 const disconnectSocketQueue = []
 
 function finishConnection (socket, noteId, socketId) {
-  // if no valid info provided will drop the client
-  if (!socket || !notes[noteId] || !users[socketId]) {
-    return interruptConnection(socket, noteId, socketId)
-  }
   // check view permission
   if (!checkViewPermission(socket.request, notes[noteId])) {
-    interruptConnection(socket, noteId, socketId)
     return failConnection(403, 'connection forbidden', socket)
   }
   const note = notes[noteId]
@@ -460,6 +448,13 @@ function startConnection (socket) {
       },
       include
     }).then(function (note) {
+      // if client disconnected while we waited for the note, disconnect() cleaned up users[socket.id]
+      if (!users[socket.id]) {
+        clearSocketQueue(connectionSocketQueue, socket)
+        connectNextSocket()
+        return
+      }
+
       if (!note) {
         return failConnection(404, 'note not found', socket)
       }

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -10,6 +10,9 @@ You now need Node 16 to run HedgeDoc. We don't support more recent versions of N
 - Allow setting of `documentMaxLength` via `CMD_DOCUMENT_MAX_LENGTH` environment variable.
 - Add dedicated healthcheck endpoint at /_health that is less resource intensive than /status.
 
+### Bugfixes
+- Fix that permission errors can break existing connections to a note, causing inconsistent note content and changes not being saved
+
 ## <i class="fa fa-tag"></i> 1.9.7 <i class="fa fa-calendar-o"></i> 2023-02-19
 
 ### Bugfixes


### PR DESCRIPTION
### Component/Part
Backend (realtime)

### Description

This PR fixes that `interruptConnection()` cleans up note state without first checking if other clients are still connected to the note.

The call to `interruptConnection()` in case of a permission error causes the behavior described in #3894. Since `failConnection()` is also called in this case and since it performs the same cleanup as `interruptConnection()`, but with properly checking for other clients, I removed the call to `interruptConnection()`.

It took me some time to understand why the other call to `interruptConnection()` was added in the first place, whether/when it is executed and if it could cause the same problem as the other call:

```js
function finishConnection (socket, noteId, socketId) {
  // if no valid info provided will drop the client
  if (!socket || !notes[noteId] || !users[socketId]) {
    return interruptConnection(socket, noteId, socketId)
  }
  // ...
```

`!socket` can never be true otherwise the function call `finishConnection(socket, noteId, socket.id)` would have already crashed. `!notes[noteId]` can never be true, because right before the call to `finishConnection()`, `notes[noteId]` is either populated or it is estabilshed that `notes[noteId]` is already populated.

However, if the client is the first client for a note, `startConnection()` fetches the note object asynchronously. If the client disconnects before the promise is resolved, `disconnect()` would have cleaned up `users[socketId]` before the call to `finishConnection()` and the third condition would be true. This also matches the [commit that introduced this check](https://github.com/hedgedoc/hedgedoc/commit/d3a23ad72f1cdde4e7b87e8d79c678b27d98b8c2) ("Fixed realtime.js finishConnection user might be undefined issue"). So in this case cleanup of the `notes` global and `clearSocketQueue()`/`connectNextSocket()` are neccesary.

Anyway, I don't think this call to `interruptConnection()` (and the unconditional `delete notes[noteId]`) does any harm, since it only happens if the client is the first client for a note, but I couldn't resist refactoring it.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #3894, probably fixes #1992