### PR TITLE
fix(backend): fix extraction body values in permission controllers

### DIFF
--- a/backend/src/api/private/notes/notes.controller.ts
+++ b/backend/src/api/private/notes/notes.controller.ts
@@ -205,7 +205,7 @@ export class NotesController {
     @RequestUser() user: User,
     @RequestNote() note: Note,
     @Param('userName') username: string,
-    @Body() canEdit: boolean,
+    @Body('canEdit') canEdit: boolean,
   ): Promise<NotePermissionsDto> {
     const permissionUser = await this.userService.getUserByUsername(username);
     const returnedNote = await this.permissionService.setUserPermission(
@@ -285,7 +285,7 @@ export class NotesController {
   async changeOwner(
     @RequestUser() user: User,
     @RequestNote() note: Note,
-    @Body() newOwner: string,
+    @Body('newOwner') newOwner: string,
   ): Promise<NoteDto> {
     const owner = await this.userService.getUserByUsername(newOwner);
     return await this.noteService.toNoteDto(

--- a/backend/src/api/public/notes/notes.controller.ts
+++ b/backend/src/api/public/notes/notes.controller.ts
@@ -384,7 +384,7 @@ export class NotesController {
   async changeOwner(
     @RequestUser() user: User,
     @RequestNote() note: Note,
-    @Body() newOwner: string,
+    @Body('newOwner') newOwner: string,
   ): Promise<NoteDto> {
     const owner = await this.userService.getUserByUsername(newOwner);
     return await this.noteService.toNoteDto(

--- a/frontend/src/api/permissions/index.ts
+++ b/frontend/src/api/permissions/index.ts
@@ -12,16 +12,16 @@ import type { NotePermissions } from '@hedgedoc/commons'
  * Sets the owner of a note.
  *
  * @param noteId The id of the note.
- * @param owner The username of the new owner.
+ * @param newOwner The username of the new owner.
  * @return The updated {@link NotePermissions}.
  * @throws {Error} when the api request wasn't successful.
  */
-export const setNoteOwner = async (noteId: string, owner: string): Promise<NotePermissions> => {
+export const setNoteOwner = async (noteId: string, newOwner: string): Promise<NotePermissions> => {
   const response = await new PutApiRequestBuilder<NotePermissions, OwnerChangeDto>(
     `notes/${noteId}/metadata/permissions/owner`
   )
     .withJsonBody({
-      owner
+      newOwner
     })
     .sendRequest()
   return response.asParsedJsonObject()

--- a/frontend/src/api/permissions/types.ts
+++ b/frontend/src/api/permissions/types.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 export interface OwnerChangeDto {
-  owner: string
+  newOwner: string
 }
 
 export interface PermissionSetDto {


### PR DESCRIPTION
### Component/Part
Backend permission controllers

### Description
This PR fixes the body value extraction in the permission controllers

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
