### PR TITLE
Permissions e2e tests

### DIFF
--- a/backend/src/permissions/permissions.service.spec.ts
+++ b/backend/src/permissions/permissions.service.spec.ts
@@ -1015,6 +1015,13 @@ describe('PermissionsService', () => {
       expect(eventEmitterEmitSpy).toHaveBeenCalled();
     });
     describe('works', () => {
+      it('with user not added if owner', async () => {
+        const user = User.create('test', 'Testy') as User;
+        const note = Note.create(user) as Note;
+        const resultNote = await service.setUserPermission(note, user, true);
+        expect(await resultNote.userPermissions).toHaveLength(0);
+      });
+
       it('with user not added before and editable', async () => {
         const note = Note.create(null) as Note;
         const user = User.create('test', 'Testy') as User;

--- a/backend/src/permissions/permissions.service.ts
+++ b/backend/src/permissions/permissions.service.ts
@@ -235,6 +235,9 @@ export class PermissionsService {
     permissionUser: User,
     canEdit: boolean,
   ): Promise<Note> {
+    if (await this.isOwner(permissionUser, note)) {
+      return note;
+    }
     const permissions = await note.userPermissions;
     const permission = await this.findPermissionForUser(
       permissions,


### PR DESCRIPTION
### Component/Part
Backend permissions api

### Description
This PR adds e2e tests to the permissions api 

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
