### PR TITLE
Zxcvbn renovate group

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -44,7 +44,7 @@
     "@types/node-fetch": "2.6.3",
     "@types/passport-http-bearer": "1.0.37",
     "@zxcvbn-ts/core": "3.0.0",
-    "@zxcvbn-ts/language-common": "2.0.1",
+    "@zxcvbn-ts/language-common": "3.0.0",
     "@zxcvbn-ts/language-en": "3.0.0",
     "base32-encode": "1.2.0",
     "bcrypt": "5.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,7 +43,7 @@
     "@types/minio": "7.0.18",
     "@types/node-fetch": "2.6.3",
     "@types/passport-http-bearer": "1.0.37",
-    "@zxcvbn-ts/core": "2.2.1",
+    "@zxcvbn-ts/core": "3.0.0",
     "@zxcvbn-ts/language-common": "2.0.1",
     "@zxcvbn-ts/language-en": "3.0.0",
     "base32-encode": "1.2.0",

--- a/backend/src/identity/identity.service.ts
+++ b/backend/src/identity/identity.service.ts
@@ -5,9 +5,20 @@
  */
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { zxcvbnAsync, zxcvbnOptions } from '@zxcvbn-ts/core';
-import zxcvbnCommonPackage from '@zxcvbn-ts/language-common';
-import zxcvbnEnPackage from '@zxcvbn-ts/language-en';
+import {
+  OptionsGraph,
+  OptionsType,
+  zxcvbnAsync,
+  zxcvbnOptions,
+} from '@zxcvbn-ts/core';
+import {
+  adjacencyGraphs,
+  dictionary as zxcvbnCommonDictionary,
+} from '@zxcvbn-ts/language-common';
+import {
+  dictionary as zxcvbnEnDictionary,
+  translations as zxcvbnEnTranslations,
+} from '@zxcvbn-ts/language-en';
 import { Repository } from 'typeorm';
 
 import authConfiguration, { AuthConfig } from '../config/auth.config';
@@ -34,13 +45,13 @@ export class IdentityService {
     private authConfig: AuthConfig,
   ) {
     this.logger.setContext(IdentityService.name);
-    const options = {
+    const options: OptionsType = {
       dictionary: {
-        ...zxcvbnCommonPackage.dictionary,
-        ...zxcvbnEnPackage.dictionary,
+        ...zxcvbnCommonDictionary,
+        ...zxcvbnEnDictionary,
       },
-      graphs: zxcvbnCommonPackage.adjacencyGraphs,
-      translations: zxcvbnEnPackage.translations,
+      graphs: adjacencyGraphs as OptionsGraph,
+      translations: zxcvbnEnTranslations,
     };
     zxcvbnOptions.setOptions(options);
   }

--- a/renovate.json
+++ b/renovate.json
@@ -76,6 +76,12 @@
       "matchPackagePatterns": [
         "^@testing-library/"
       ]
+    },
+    {
+      "groupName": "zxcvbn-ts",
+      "matchPackagePatterns": [
+        "^@zxcvbn-ts/"
+      ]
     }
   ],
   "regexManagers": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2284,7 +2284,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.59.2
     "@typescript-eslint/parser": 5.59.2
     "@zxcvbn-ts/core": 3.0.0
-    "@zxcvbn-ts/language-common": 2.0.1
+    "@zxcvbn-ts/language-common": 3.0.0
     "@zxcvbn-ts/language-en": 3.0.0
     base32-encode: 1.2.0
     bcrypt: 5.1.0
@@ -5530,10 +5530,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zxcvbn-ts/language-common@npm:2.0.1":
-  version: 2.0.1
-  resolution: "@zxcvbn-ts/language-common@npm:2.0.1"
-  checksum: 75bbda3b4f453f977c0f1457aa5e4bbb3e4065ef0e0ec1ab5e5270544ab88d9962d32493ae6ad2dbd847cb50e723e60e42fc0f62100d979029c4bed8b7a3c189
+"@zxcvbn-ts/language-common@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@zxcvbn-ts/language-common@npm:3.0.0"
+  checksum: 6c39aea4ada0f7051ed11fb8d49ec487acc0ff627f56a2b31ae517db68790e5c44e8213cd7670cdbbf157a37658d9e53b425fdce154ff1dfd8da9113aa23a5be
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2283,7 +2283,7 @@ __metadata:
     "@types/ws": 8.5.4
     "@typescript-eslint/eslint-plugin": 5.59.2
     "@typescript-eslint/parser": 5.59.2
-    "@zxcvbn-ts/core": 2.2.1
+    "@zxcvbn-ts/core": 3.0.0
     "@zxcvbn-ts/language-common": 2.0.1
     "@zxcvbn-ts/language-en": 3.0.0
     base32-encode: 1.2.0
@@ -5521,12 +5521,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zxcvbn-ts/core@npm:2.2.1":
-  version: 2.2.1
-  resolution: "@zxcvbn-ts/core@npm:2.2.1"
+"@zxcvbn-ts/core@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@zxcvbn-ts/core@npm:3.0.0"
   dependencies:
     fastest-levenshtein: 1.0.16
-  checksum: 972429f83052c79521985151f9ad1b8d05d25d4c578e6a308ad01c27f58fce61b8e0bdb124ae490f6b3d87e2f15a749bba880c7d07841649903d0c669abe663e
+  checksum: 00e98d2abef26354902c61cc4acd014a70b514b1f0ceff80bb69674d338774ef52613dc9f0aa6fa5c922d56bb4cf447a5e37fdfc62c7f1ca1dc19c4584f62f4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
Renovate

### Description
This PR updates the zxcvbn packages and adds a new renovate group for them.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
