### PR TITLE
fix(frontend): remove parenthesis around •

### DIFF
--- a/frontend/src/components/editor-page/head-meta-properties/note-and-app-title-head.tsx
+++ b/frontend/src/components/editor-page/head-meta-properties/note-and-app-title-head.tsx
@@ -18,7 +18,7 @@ export const NoteAndAppTitleHead: React.FC = () => {
   const showDot = useHasMarkdownContentBeenChangedInBackground()
 
   const noteAndAppTitle = useMemo(() => {
-    return (showDot ? '(•) ' : '') + noteTitle + ' - ' + appTitle
+    return (showDot ? '• ' : '') + noteTitle + ' - ' + appTitle
   }, [appTitle, noteTitle, showDot])
 
   return (


### PR DESCRIPTION
### Component/Part
Note title

### Description
This PR removes the parenthesis around `•`, if the note was edited while the user worked in another tab.

This was the way it was in HedgeDoc 1. It was deemed to be better than the parenthesis version in a debug session.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x