### PR TITLE
docs(imgur): add warning about new imgur policy

### DIFF
--- a/docs/content/config/media/imgur.md
+++ b/docs/content/config/media/imgur.md
@@ -1,5 +1,9 @@
 # Imgur
 
+!!! warning "Imgur saves anonymous images for only 6 month"
+Imgur will delete images not associated with any account 6 month after the last access. This means that if you use imgur as your image backend, you may lose images uploaded by you or your users.
+See this [FAQ entry](https://help.imgur.com/hc/en-us/articles/14415587638029-Imgur-Terms-of-Service-Update-April-19-2023-)
+
 You can use [Imgur](https://imgur.com) to handle your image uploads in HedgeDoc.
 
 All you need for that is to register an application with Imgur and get a client id:


### PR DESCRIPTION
### Component/Part
Docs

### Description
This PRi mproves the documentation for the imgur media backend.

Because imgur will delete images 6 month after the last access, we should tell our users about this change to help them make a informed decision about their media backend choice…

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
see #3942
