### PR TITLE
fix(editor): catch error when refreshing note metadata

### DIFF
--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-on-metadata-updated.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-on-metadata-updated.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { updateMetadata } from '../../../../../redux/note-details/methods'
+import { useUiNotifications } from '../../../../notifications/ui-notification-boundary'
 import type { MessageTransporter } from '@hedgedoc/commons'
 import { MessageType } from '@hedgedoc/commons'
 import type { Listener } from 'eventemitter2'
@@ -15,12 +16,20 @@ import { useEffect } from 'react'
  * @param websocketConnection The websocket connection that emits the metadata changed event
  */
 export const useOnMetadataUpdated = (websocketConnection: MessageTransporter): void => {
+  const { showErrorNotification } = useUiNotifications()
+
   useEffect(() => {
-    const listener = websocketConnection.on(MessageType.METADATA_UPDATED, () => void updateMetadata(), {
-      objectify: true
-    }) as Listener
+    const listener = websocketConnection.on(
+      MessageType.METADATA_UPDATED,
+      () => {
+        updateMetadata().catch(showErrorNotification('common.errorWhileLoading', { name: 'note metadata refresh' }))
+      },
+      {
+        objectify: true
+      }
+    ) as Listener
     return () => {
       listener.off()
     }
-  }, [websocketConnection])
+  }, [showErrorNotification, websocketConnection])
 }


### PR DESCRIPTION
### Component/Part
Editor

### Description
This PR catches an error that can occur when refreshing the note metadata.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
