### PR TITLE
replace acceptEdits field with function

### DIFF
--- a/backend/src/realtime/realtime-note/realtime-connection.spec.ts
+++ b/backend/src/realtime/realtime-note/realtime-connection.spec.ts
@@ -43,7 +43,7 @@ describe('websocket connection', () => {
     mockedMessageTransporter = new MockedBackendMessageTransporter('');
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.resetAllMocks();
     jest.resetModules();
   });

--- a/backend/src/realtime/realtime-note/realtime-connection.spec.ts
+++ b/backend/src/realtime/realtime-note/realtime-connection.spec.ts
@@ -84,21 +84,27 @@ describe('websocket connection', () => {
     expect(sut.getRealtimeUserStateAdapter()).toBe(realtimeUserStatus);
   });
 
-  it('returns the correct sync adapter', () => {
-    const yDocSyncServerAdapter = Mock.of<YDocSyncServerAdapter>({});
-    jest
-      .spyOn(HedgeDocCommonsModule, 'YDocSyncServerAdapter')
-      .mockImplementation(() => yDocSyncServerAdapter);
+  it.each([true, false])(
+    'creates a sync adapter with acceptEdits %s',
+    (acceptEdits) => {
+      const yDocSyncServerAdapter = Mock.of<YDocSyncServerAdapter>({});
+      jest
+        .spyOn(HedgeDocCommonsModule, 'YDocSyncServerAdapter')
+        .mockImplementation((messageTransporter, doc, acceptEditsProvider) => {
+          expect((acceptEditsProvider as () => boolean)()).toBe(acceptEdits);
+          return yDocSyncServerAdapter;
+        });
 
-    const sut = new RealtimeConnection(
-      mockedMessageTransporter,
-      mockedUser,
-      mockedRealtimeNote,
-      true,
-    );
+      const sut = new RealtimeConnection(
+        mockedMessageTransporter,
+        mockedUser,
+        mockedRealtimeNote,
+        acceptEdits,
+      );
 
-    expect(sut.getSyncAdapter()).toBe(yDocSyncServerAdapter);
-  });
+      expect(sut.getSyncAdapter()).toBe(yDocSyncServerAdapter);
+    },
+  );
 
   it('removes the client from the note on transporter disconnect', () => {
     const sut = new RealtimeConnection(

--- a/backend/src/realtime/realtime-note/realtime-connection.ts
+++ b/backend/src/realtime/realtime-note/realtime-connection.ts
@@ -46,7 +46,7 @@ export class RealtimeConnection {
     this.yDocSyncAdapter = new YDocSyncServerAdapter(
       this.transporter,
       realtimeNote.getRealtimeDoc(),
-      acceptEdits,
+      () => acceptEdits,
     );
     this.realtimeUserStateAdapter = new RealtimeUserStatusAdapter(
       this.user?.username ?? null,

--- a/backend/src/realtime/realtime-note/realtime-connection.ts
+++ b/backend/src/realtime/realtime-note/realtime-connection.ts
@@ -19,8 +19,7 @@ export class RealtimeConnection {
   private readonly transporter: MessageTransporter;
   private readonly yDocSyncAdapter: YDocSyncServerAdapter;
   private readonly realtimeUserStateAdapter: RealtimeUserStatusAdapter;
-
-  private displayName: string;
+  private readonly displayName: string;
 
   /**
    * Instantiates the connection wrapper.

--- a/backend/src/realtime/realtime-note/realtime-connection.ts
+++ b/backend/src/realtime/realtime-note/realtime-connection.ts
@@ -51,7 +51,7 @@ export class RealtimeConnection {
       this.user?.username ?? null,
       this.getDisplayName(),
       this,
-      acceptEdits,
+      () => acceptEdits,
     );
   }
 

--- a/backend/src/realtime/realtime-note/realtime-connection.ts
+++ b/backend/src/realtime/realtime-note/realtime-connection.ts
@@ -35,7 +35,7 @@ export class RealtimeConnection {
     messageTransporter: MessageTransporter,
     private user: User | null,
     private realtimeNote: RealtimeNote,
-    private acceptEdits: boolean,
+    public acceptEdits: boolean,
   ) {
     this.displayName = user?.displayName ?? generateRandomName();
     this.transporter = messageTransporter;

--- a/backend/src/realtime/realtime-note/test-utils/mock-connection.ts
+++ b/backend/src/realtime/realtime-note/test-utils/mock-connection.ts
@@ -112,7 +112,8 @@ export class MockConnectionBuilder {
         this.username ?? null,
         displayName,
         connection,
-        this.includeRealtimeUserStatus === RealtimeUserState.WITH_READWRITE,
+        () =>
+          this.includeRealtimeUserStatus === RealtimeUserState.WITH_READWRITE,
       );
     }
 

--- a/commons/src/y-doc-sync/y-doc-sync-adapter.spec.ts
+++ b/commons/src/y-doc-sync/y-doc-sync-adapter.spec.ts
@@ -105,13 +105,13 @@ describe('message transporter', () => {
     const yDocSyncAdapterServerTo1 = new YDocSyncServerAdapter(
       transporterServerTo1,
       docServer,
-      true
+      () => true
     )
 
     const yDocSyncAdapterServerTo2 = new YDocSyncServerAdapter(
       transporterServerTo2,
       docServer,
-      true
+      () => true
     )
 
     const waitForClient1Sync = new Promise<void>((resolve) => {

--- a/commons/src/y-doc-sync/y-doc-sync-server-adapter.ts
+++ b/commons/src/y-doc-sync/y-doc-sync-server-adapter.ts
@@ -11,14 +11,14 @@ export class YDocSyncServerAdapter extends YDocSyncAdapter {
   constructor(
     readonly messageTransporter: MessageTransporter,
     readonly doc: RealtimeDoc,
-    readonly acceptEdits: boolean
+    private readonly acceptEditsProvider: () => boolean
   ) {
     super(messageTransporter, doc)
     this.markAsSynced()
   }
 
   protected applyIncomingUpdatePayload(update: number[]): void {
-    if (!this.acceptEdits) {
+    if (!this.acceptEditsProvider()) {
       return
     }
     super.applyIncomingUpdatePayload(update)


### PR DESCRIPTION
### Component/Part
Realtime

### Description
This PR makes some changes in the realtime connection class and the y-doc-sync-server-adapter:
  - refactors displayName to be readonly because it is set but never changed
  - turns the acceptEdits property of the sync adapter into a function and lets it read the value from the realtime connection. This makes the sync adapter a bit more stateless and reduces the number of values for accept edits to the one in the connection class.
  - makes acceptEdits in the realtime connection readonly in preparation of #3701

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
