### PR TITLE
chore(ci): update cypress browsers image

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -152,7 +152,7 @@ jobs:
     needs: frontend-build
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-18.14.1-chrome-111.0.5563.64-1-ff-111.0-edge-111.0.1661.43-1
+      image: cypress/browsers:node-18.16.0-chrome-112.0.5615.121-1-ff-112.0.1-edge-112.0.1722.48-1
       options: --shm-size=2g
     strategy:
       fail-fast: false
@@ -160,7 +160,7 @@ jobs:
         containers: [ 1, 2, 3 ]
     steps:
       - name: Install additional packages
-        run: apt-get update && apt-get install -y jq zstd screen
+        run: apt-get update && apt-get install -y jq zstd screen curl
 
       - name: Check out repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR updates the tag of the used cypress docker image in the CI.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

