### PR TITLE
docs: indent imgur warning correctly

### DIFF
--- a/docs/content/config/media/imgur.md
+++ b/docs/content/config/media/imgur.md
@@ -1,8 +1,8 @@
 # Imgur
 
 !!! warning "Imgur saves anonymous images for only 6 month"
-Imgur will delete images not associated with any account 6 month after the last access. This means that if you use imgur as your image backend, you may lose images uploaded by you or your users.
-See this [FAQ entry](https://help.imgur.com/hc/en-us/articles/14415587638029-Imgur-Terms-of-Service-Update-April-19-2023-)
+    Imgur will delete images not associated with any account 6 month after the last access. This means that if you use imgur as your image backend, you may lose images uploaded by you or your users.
+    See this [FAQ entry](https://help.imgur.com/hc/en-us/articles/14415587638029-Imgur-Terms-of-Service-Update-April-19-2023-)
 
 You can use [Imgur](https://imgur.com) to handle your image uploads in HedgeDoc.
 


### PR DESCRIPTION
### Component/Part
docs

### Description
This PR fixes the imgur documentation.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

