### PR TITLE
fix(frontend): use tabs instead of pills for settings modal

### DIFF
--- a/frontend/src/components/layout/settings-dialog/settings-modal.tsx
+++ b/frontend/src/components/layout/settings-dialog/settings-modal.tsx
@@ -30,7 +30,7 @@ export const SettingsModal: React.FC<CommonModalProps> = ({ show, onHide }) => {
       titleI18nKey={'settings.title'}
       showCloseButton={true}>
       <Modal.Body>
-        <Tabs navbar={false} variant={'pills'} defaultActiveKey={'global'}>
+        <Tabs navbar={false} variant={'tabs'} defaultActiveKey={'global'}>
           <Tab title={t('settings.global.label')} eventKey={'global'}>
             <GlobalSettingsTabContent />
           </Tab>


### PR DESCRIPTION
### Component/Part
settings modal

### Description
This way the button don't look so strange and this is more like the class is intended.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x