### PR TITLE
fix(frontend): new note button doesn't use /new anymore

### DIFF
--- a/frontend/src/components/common/new-note-button/new-note-button.tsx
+++ b/frontend/src/components/common/new-note-button/new-note-button.tsx
@@ -3,10 +3,12 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { createNote } from '../../../api/notes'
 import { cypressId } from '../../../utils/cypress-attribute'
+import { useUiNotifications } from '../../notifications/ui-notification-boundary'
 import { IconButton } from '../icon-button/icon-button'
-import Link from 'next/link'
-import React from 'react'
+import { useRouter } from 'next/router'
+import React, { useCallback } from 'react'
 import { FileEarmarkPlus as IconPlus } from 'react-bootstrap-icons'
 import { Trans } from 'react-i18next'
 
@@ -14,11 +16,27 @@ import { Trans } from 'react-i18next'
  * Links to the "new note" endpoint
  */
 export const NewNoteButton: React.FC = () => {
+  const { showErrorNotification } = useUiNotifications()
+  const router = useRouter()
+  const createNewNoteAndRedirect = useCallback((): void => {
+    createNote('')
+      .then((note) => {
+        const to = `/n/${note.metadata.primaryAddress}`
+        return router?.push(to)
+      })
+      .catch((error: Error) => {
+        showErrorNotification(error.message)
+      })
+  }, [router, showErrorNotification])
+
   return (
-    <Link href={'/new'} passHref={true}>
-      <IconButton {...cypressId('new-note-button')} iconSize={1.5} size={'sm'} icon={IconPlus}>
-        <Trans i18nKey='navigation.newNote' />
-      </IconButton>
-    </Link>
+    <IconButton
+      {...cypressId('new-note-button')}
+      iconSize={1.5}
+      size={'sm'}
+      icon={IconPlus}
+      onClick={createNewNoteAndRedirect}>
+      <Trans i18nKey='navigation.newNote' />
+    </IconButton>
   )
 }

--- a/frontend/src/components/common/redirect.tsx
+++ b/frontend/src/components/common/redirect.tsx
@@ -11,6 +11,7 @@ import React, { useEffect } from 'react'
 
 export interface RedirectProps {
   to: string
+  replace?: boolean
 }
 
 const logger = new Logger('Redirect')
@@ -19,15 +20,16 @@ const logger = new Logger('Redirect')
  * Redirects the user to another URL. Can be external or internal.
  *
  * @param to The target URL
+ * @param replace Defines if the current browser history entry should be replaced or not
  */
-export const Redirect: React.FC<RedirectProps> = ({ to }) => {
+export const Redirect: React.FC<RedirectProps> = ({ to, replace }) => {
   const router = useRouter()
 
   useEffect(() => {
-    router?.push(to).catch((error: Error) => {
+    ;(replace ? router.replace(to) : router.push(to)).catch((error: Error) => {
       logger.error(`Error while redirecting to ${to}`, error)
     })
-  })
+  }, [replace, router, to])
 
   return (
     <span {...testId('redirect')}>

--- a/frontend/src/pages/new.tsx
+++ b/frontend/src/pages/new.tsx
@@ -37,7 +37,7 @@ export const NewNotePage: NextPage = () => {
         />
       }>
       <ShowIf condition={!!value}>
-        <Redirect to={`/n/${(value as Note).metadata.primaryAddress}`} />
+        <Redirect to={`/n/${(value as Note).metadata.primaryAddress}`} replace={true} />
       </ShowIf>
     </CustomAsyncLoadingBoundary>
   )

--- a/frontend/src/pages/new.tsx
+++ b/frontend/src/pages/new.tsx
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { createNote } from '../api/notes'
+import type { Note } from '../api/notes/types'
 import { LoadingScreen } from '../components/application-loader/loading-screen/loading-screen'
 import { CustomAsyncLoadingBoundary } from '../components/common/async-loading-boundary/custom-async-loading-boundary'
 import { Redirect } from '../components/common/redirect'
+import { ShowIf } from '../components/common/show-if/show-if'
 import { CommonErrorPage } from '../components/error-pages/common-error-page'
 import { useSingleStringUrlParameter } from '../hooks/common/use-single-string-url-parameter'
 import type { NextPage } from 'next'
+import React from 'react'
 import { useAsync } from 'react-use'
 
 /**
@@ -33,7 +36,9 @@ export const NewNotePage: NextPage = () => {
           descriptionI18nKey={'errors.noteCreationFailed.description'}
         />
       }>
-      {value ? <Redirect to={`/n/${value.metadata.primaryAddress}`} /> : null}
+      <ShowIf condition={!!value}>
+        <Redirect to={`/n/${(value as Note).metadata.primaryAddress}`} />
+      </ShowIf>
     </CustomAsyncLoadingBoundary>
   )
 }


### PR DESCRIPTION
### Component/Part
new note button

### Description
This led to problems, if user clicked the back button in their browser. This implementation doesn't add functional routes in between new notes, but pushes the new note directly in the history.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
