### PR TITLE
feat(backend): handle username always in lowercase

### DIFF
--- a/backend/src/api/private/auth/auth.controller.ts
+++ b/backend/src/api/private/auth/auth.controller.ts
@@ -29,6 +29,7 @@ import { ConsoleLoggerService } from '../../../logger/console-logger.service';
 import { SessionState } from '../../../session/session.service';
 import { User } from '../../../users/user.entity';
 import { UsersService } from '../../../users/users.service';
+import { makeUsernameLowercase } from '../../../utils/username';
 import { LoginEnabledGuard } from '../../utils/login-enabled.guard';
 import { OpenApi } from '../../utils/openapi.decorator';
 import { RegistrationEnabledGuard } from '../../utils/registration-enabled.guard';
@@ -107,8 +108,8 @@ export class AuthController {
     @Param('ldapIdentifier') ldapIdentifier: string,
     @Body() loginDto: LdapLoginDto,
   ): void {
-    // There is no further testing needed as we only get to this point if LocalAuthGuard was successful
-    request.session.username = loginDto.username;
+    // There is no further testing needed as we only get to this point if LdapAuthGuard was successful
+    request.session.username = makeUsernameLowercase(loginDto.username);
     request.session.authProvider = 'ldap';
   }
 

--- a/backend/src/api/private/notes/notes.controller.ts
+++ b/backend/src/api/private/notes/notes.controller.ts
@@ -39,6 +39,7 @@ import { RevisionDto } from '../../../revisions/revision.dto';
 import { RevisionsService } from '../../../revisions/revisions.service';
 import { User } from '../../../users/user.entity';
 import { UsersService } from '../../../users/users.service';
+import { Username } from '../../../utils/username';
 import { GetNoteInterceptor } from '../../utils/get-note.interceptor';
 import { MarkdownBody } from '../../utils/markdown-body.decorator';
 import { OpenApi } from '../../utils/openapi.decorator';
@@ -203,7 +204,7 @@ export class NotesController {
   async setUserPermission(
     @RequestUser() user: User,
     @RequestNote() note: Note,
-    @Param('userName') username: string,
+    @Param('userName') username: Username,
     @Body('canEdit') canEdit: boolean,
   ): Promise<NotePermissionsDto> {
     const permissionUser = await this.userService.getUserByUsername(username);
@@ -221,7 +222,7 @@ export class NotesController {
   async removeUserPermission(
     @RequestUser() user: User,
     @RequestNote() note: Note,
-    @Param('userName') username: string,
+    @Param('userName') username: Username,
   ): Promise<NotePermissionsDto> {
     try {
       const permissionUser = await this.userService.getUserByUsername(username);
@@ -281,7 +282,7 @@ export class NotesController {
   async changeOwner(
     @RequestUser() user: User,
     @RequestNote() note: Note,
-    @Body('newOwner') newOwner: string,
+    @Body('newOwner') newOwner: Username,
   ): Promise<NoteDto> {
     const owner = await this.userService.getUserByUsername(newOwner);
     return await this.noteService.toNoteDto(

--- a/backend/src/api/private/users/users.controller.ts
+++ b/backend/src/api/private/users/users.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -9,6 +9,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { ConsoleLoggerService } from '../../../logger/console-logger.service';
 import { UserInfoDto } from '../../../users/user-info.dto';
 import { UsersService } from '../../../users/users.service';
+import { Username } from '../../../utils/username';
 import { OpenApi } from '../../utils/openapi.decorator';
 
 @ApiTags('users')
@@ -23,7 +24,7 @@ export class UsersController {
 
   @Get(':username')
   @OpenApi(200)
-  async getUser(@Param('username') username: string): Promise<UserInfoDto> {
+  async getUser(@Param('username') username: Username): Promise<UserInfoDto> {
     return this.userService.toUserDto(
       await this.userService.getUserByUsername(username),
     );

--- a/backend/src/api/public/notes/notes.controller.ts
+++ b/backend/src/api/public/notes/notes.controller.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -42,6 +42,7 @@ import { RevisionDto } from '../../../revisions/revision.dto';
 import { RevisionsService } from '../../../revisions/revisions.service';
 import { User } from '../../../users/user.entity';
 import { UsersService } from '../../../users/users.service';
+import { Username } from '../../../utils/username';
 import { GetNoteInterceptor } from '../../utils/get-note.interceptor';
 import { MarkdownBody } from '../../utils/markdown-body.decorator';
 import { OpenApi } from '../../utils/openapi.decorator';
@@ -264,7 +265,7 @@ export class NotesController {
   async setUserPermission(
     @RequestUser() user: User,
     @RequestNote() note: Note,
-    @Param('userName') username: string,
+    @Param('userName') username: Username,
     @Body('canEdit') canEdit: boolean,
   ): Promise<NotePermissionsDto> {
     const permissionUser = await this.userService.getUserByUsername(username);
@@ -291,7 +292,7 @@ export class NotesController {
   async removeUserPermission(
     @RequestUser() user: User,
     @RequestNote() note: Note,
-    @Param('userName') username: string,
+    @Param('userName') username: Username,
   ): Promise<NotePermissionsDto> {
     try {
       const permissionUser = await this.userService.getUserByUsername(username);
@@ -377,7 +378,7 @@ export class NotesController {
   async changeOwner(
     @RequestUser() user: User,
     @RequestNote() note: Note,
-    @Body('newOwner') newOwner: string,
+    @Body('newOwner') newOwner: Username,
   ): Promise<NoteDto> {
     const owner = await this.userService.getUserByUsername(newOwner);
     return await this.noteService.toNoteDto(

--- a/backend/src/identity/ldap/ldap-login.dto.ts
+++ b/backend/src/identity/ldap/ldap-login.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -7,7 +7,7 @@ import { IsString } from 'class-validator';
 
 export class LdapLoginDto {
   @IsString()
-  username: string;
+  username: string; // This is not of type Username, because LDAP server may use mixed case usernames
   @IsString()
   password: string;
 }

--- a/backend/src/identity/local/local.strategy.ts
+++ b/backend/src/identity/local/local.strategy.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,6 +15,7 @@ import { ConsoleLoggerService } from '../../logger/console-logger.service';
 import { UserRelationEnum } from '../../users/user-relation.enum';
 import { User } from '../../users/user.entity';
 import { UsersService } from '../../users/users.service';
+import { Username } from '../../utils/username';
 import { IdentityService } from '../identity.service';
 
 @Injectable()
@@ -31,7 +32,7 @@ export class LocalStrategy extends PassportStrategy(Strategy, 'local') {
     logger.setContext(LocalStrategy.name);
   }
 
-  async validate(username: string, password: string): Promise<User> {
+  async validate(username: Username, password: string): Promise<User> {
     try {
       const user = await this.userService.getUserByUsername(username, [
         UserRelationEnum.IDENTITIES,

--- a/backend/src/identity/local/login.dto.ts
+++ b/backend/src/identity/local/login.dto.ts
@@ -1,13 +1,16 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { IsString } from 'class-validator';
+import { IsLowercase, IsString } from 'class-validator';
+
+import { Username } from '../../utils/username';
 
 export class LoginDto {
   @IsString()
-  username: string;
+  @IsLowercase()
+  username: Username;
   @IsString()
   password: string;
 }

--- a/backend/src/identity/local/register.dto.ts
+++ b/backend/src/identity/local/register.dto.ts
@@ -1,13 +1,16 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { IsString } from 'class-validator';
+import { IsLowercase, IsString } from 'class-validator';
+
+import { Username } from '../../utils/username';
 
 export class RegisterDto {
   @IsString()
-  username: string;
+  @IsLowercase()
+  username: Username;
 
   @IsString()
   displayName: string;

--- a/backend/src/media/media-upload.dto.ts
+++ b/backend/src/media/media-upload.dto.ts
@@ -1,13 +1,14 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsDate, IsOptional, IsString } from 'class-validator';
+import { IsDate, IsLowercase, IsOptional, IsString } from 'class-validator';
 
 import { BaseDto } from '../utils/base.dto.';
+import { Username } from '../utils/username';
 
 export class MediaUploadDto extends BaseDto {
   /**
@@ -41,6 +42,7 @@ export class MediaUploadDto extends BaseDto {
    * @example "testuser5"
    */
   @IsString()
+  @IsLowercase()
   @ApiProperty()
-  username: string | null;
+  username: Username | null;
 }

--- a/backend/src/notes/note-permissions.dto.ts
+++ b/backend/src/notes/note-permissions.dto.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -8,20 +8,23 @@ import { Type } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
+  IsLowercase,
   IsOptional,
   IsString,
   ValidateNested,
 } from 'class-validator';
 
 import { BaseDto } from '../utils/base.dto.';
+import { Username } from '../utils/username';
 
 export class NoteUserPermissionEntryDto extends BaseDto {
   /**
    * Username of the User this permission applies to
    */
   @IsString()
+  @IsLowercase()
   @ApiProperty()
-  username: string;
+  username: Username;
 
   /**
    * True if the user is allowed to edit the note
@@ -38,8 +41,9 @@ export class NoteUserPermissionUpdateDto {
    * @example "john.smith"
    */
   @IsString()
+  @IsLowercase()
   @ApiProperty()
-  username: string;
+  username: Username;
 
   /**
    * True if the user should be allowed to edit the note

--- a/backend/src/realtime/realtime-note/realtime-connection.spec.ts
+++ b/backend/src/realtime/realtime-note/realtime-connection.spec.ts
@@ -13,6 +13,7 @@ import { Mock } from 'ts-mockery';
 
 import { Note } from '../../notes/note.entity';
 import { User } from '../../users/user.entity';
+import { Username } from '../../utils/username';
 import * as NameRandomizerModule from './random-word-lists/name-randomizer';
 import { RealtimeConnection } from './realtime-connection';
 import { RealtimeNote } from './realtime-note';
@@ -39,7 +40,7 @@ describe('websocket connection', () => {
   let mockedUser: User;
   let mockedMessageTransporter: MessageTransporter;
 
-  const mockedUserName = 'mockedUserName';
+  const mockedUserName: Username = 'mocked-user-name';
   const mockedDisplayName = 'mockedDisplayName';
 
   beforeEach(() => {

--- a/backend/src/realtime/realtime-note/realtime-note.service.spec.ts
+++ b/backend/src/realtime/realtime-note/realtime-note.service.spec.ts
@@ -40,9 +40,9 @@ describe('RealtimeNoteService', () => {
   let clientWithoutReadWrite: RealtimeConnection;
   let deleteIntervalSpy: jest.SpyInstance;
 
-  const readWriteUsername = 'canReadWriteUser';
-  const onlyReadUsername = 'canOnlyReadUser';
-  const noAccessUsername = 'noReadWriteUser';
+  const readWriteUsername = 'can-read-write-user';
+  const onlyReadUsername = 'can-only-read-user';
+  const noAccessUsername = 'no-read-write-user';
 
   afterAll(() => {
     jest.useRealTimers();

--- a/backend/src/realtime/realtime-note/realtime-user-status-adapter.ts
+++ b/backend/src/realtime/realtime-note/realtime-user-status-adapter.ts
@@ -11,6 +11,8 @@ import {
 } from '@hedgedoc/commons';
 import { Listener } from 'eventemitter2';
 
+import { Username } from '../../utils/username';
+
 export type OtherAdapterCollector = () => RealtimeUserStatusAdapter[];
 
 /**
@@ -20,7 +22,7 @@ export class RealtimeUserStatusAdapter {
   private readonly realtimeUser: RealtimeUser;
 
   constructor(
-    private readonly username: string | null,
+    private readonly username: Username | null,
     private readonly displayName: string,
     private collectOtherAdapters: OtherAdapterCollector,
     private messageTransporter: MessageTransporter,

--- a/backend/src/realtime/realtime-note/test-utils/mock-connection.ts
+++ b/backend/src/realtime/realtime-note/test-utils/mock-connection.ts
@@ -10,6 +10,7 @@ import {
 import { Mock } from 'ts-mockery';
 
 import { User } from '../../../users/user.entity';
+import { Username } from '../../../utils/username';
 import { RealtimeConnection } from '../realtime-connection';
 import { RealtimeNote } from '../realtime-note';
 import { RealtimeUserStatusAdapter } from '../realtime-user-status-adapter';
@@ -20,13 +21,13 @@ enum RealtimeUserState {
   WITH_READONLY,
 }
 
-const MOCK_FALLBACK_USERNAME = 'mock';
+const MOCK_FALLBACK_USERNAME: Username = 'mock';
 
 /**
  * Creates a mocked {@link RealtimeConnection realtime connection}.
  */
 export class MockConnectionBuilder {
-  private username: string | null;
+  private username: Username | null;
   private displayName: string | undefined;
   private includeRealtimeUserStatus: RealtimeUserState =
     RealtimeUserState.WITHOUT;
@@ -49,7 +50,7 @@ export class MockConnectionBuilder {
    *
    * @param username the username of the mocked user. If this value is omitted then the builder will user a {@link MOCK_FALLBACK_USERNAME fallback}.
    */
-  public withLoggedInUser(username?: string): this {
+  public withLoggedInUser(username?: Username): this {
     const newUsername = username ?? MOCK_FALLBACK_USERNAME;
     this.username = newUsername;
     this.displayName = newUsername;

--- a/backend/src/realtime/websocket/websocket.gateway.spec.ts
+++ b/backend/src/realtime/websocket/websocket.gateway.spec.ts
@@ -41,6 +41,7 @@ import { Session } from '../../users/session.entity';
 import { User } from '../../users/user.entity';
 import { UsersModule } from '../../users/users.module';
 import { UsersService } from '../../users/users.service';
+import { Username } from '../../utils/username';
 import * as websocketConnectionModule from '../realtime-note/realtime-connection';
 import { RealtimeConnection } from '../realtime-note/realtime-connection';
 import { RealtimeNote } from '../realtime-note/realtime-note';
@@ -165,7 +166,7 @@ describe('Websocket gateway', () => {
           ),
       );
 
-    const mockUsername = 'mockUsername';
+    const mockUsername: Username = 'mock-username';
     jest
       .spyOn(sessionService, 'fetchUsernameForSessionId')
       .mockImplementation((sessionId: string) =>

--- a/backend/src/session/session.service.spec.ts
+++ b/backend/src/session/session.service.spec.ts
@@ -28,7 +28,7 @@ describe('SessionService', () => {
   let authConfigMock: AuthConfig;
   let typeormStoreConstructorMock: jest.SpyInstance;
   const mockedExistingSessionId = 'mockedExistingSessionId';
-  const mockUsername = 'mockUser';
+  const mockUsername = 'mock-user';
   const mockSecret = 'mockSecret';
   let sessionService: SessionService;
 

--- a/backend/src/session/session.service.ts
+++ b/backend/src/session/session.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -19,10 +19,11 @@ import databaseConfiguration, {
 } from '../config/database.config';
 import { Session } from '../users/session.entity';
 import { HEDGEDOC_SESSION } from '../utils/session';
+import { Username } from '../utils/username';
 
 export interface SessionState {
   cookie: unknown;
-  username?: string;
+  username?: Username;
   authProvider: string;
 }
 
@@ -58,10 +59,10 @@ export class SessionService {
    * @param sessionId The session id for which the owning user should be found
    * @return A Promise that either resolves with the username or rejects with an error
    */
-  fetchUsernameForSessionId(sessionId: string): Promise<string | undefined> {
+  fetchUsernameForSessionId(sessionId: string): Promise<Username | undefined> {
     return new Promise((resolve, reject) => {
       this.typeormStore.get(sessionId, (error?: Error, result?: SessionState) =>
-        error || !result ? reject(error) : resolve(result.username),
+        error || !result ? reject(error) : resolve(result.username as Username),
       );
     });
   }

--- a/backend/src/users/user-info.dto.ts
+++ b/backend/src/users/user-info.dto.ts
@@ -1,12 +1,13 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsLowercase, IsString } from 'class-validator';
 
 import { BaseDto } from '../utils/base.dto.';
+import { Username } from '../utils/username';
 
 export class UserInfoDto extends BaseDto {
   /**
@@ -14,8 +15,9 @@ export class UserInfoDto extends BaseDto {
    * @example "john.smith"
    */
   @IsString()
+  @IsLowercase()
   @ApiProperty()
-  username: string;
+  username: Username;
 
   /**
    * The display name

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -20,6 +20,7 @@ import { HistoryEntry } from '../history/history-entry.entity';
 import { Identity } from '../identity/identity.entity';
 import { MediaUpload } from '../media/media-upload.entity';
 import { Note } from '../notes/note.entity';
+import { Username } from '../utils/username';
 
 @Entity()
 export class User {
@@ -29,7 +30,7 @@ export class User {
   @Column({
     unique: true,
   })
-  username: string;
+  username: Username;
 
   @Column()
   displayName: string;
@@ -77,7 +78,7 @@ export class User {
   private constructor() {}
 
   public static create(
-    username: string,
+    username: Username,
     displayName: string,
   ): Omit<User, 'id' | 'createdAt' | 'updatedAt'> {
     const newUser = new User();

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -9,6 +9,7 @@ import { Repository } from 'typeorm';
 
 import { AlreadyInDBError, NotInDBError } from '../errors/errors';
 import { ConsoleLoggerService } from '../logger/console-logger.service';
+import { Username } from '../utils/username';
 import {
   FullUserInfoDto,
   UserInfoDto,
@@ -29,12 +30,12 @@ export class UsersService {
   /**
    * @async
    * Create a new user with a given username and displayName
-   * @param username - the username the new user shall have
-   * @param displayName - the display name the new user shall have
+   * @param {Username} username - the username the new user shall have
+   * @param {string} displayName - the display name the new user shall have
    * @return {User} the user
    * @throws {AlreadyInDBError} the username is already taken.
    */
-  async createUser(username: string, displayName: string): Promise<User> {
+  async createUser(username: Username, displayName: string): Promise<User> {
     const user = User.create(username, displayName);
     try {
       return await this.userRepository.save(user);
@@ -77,12 +78,12 @@ export class UsersService {
   /**
    * @async
    * Get the user specified by the username
-   * @param {string} username the username by which the user is specified
+   * @param {Username} username the username by which the user is specified
    * @param {UserRelationEnum[]} [withRelations=[]] if the returned user object should contain certain relations
    * @return {User} the specified user
    */
   async getUserByUsername(
-    username: string,
+    username: Username,
     withRelations: UserRelationEnum[] = [],
   ): Promise<User> {
     const user = await this.userRepository.findOne({

--- a/backend/src/utils/username.ts
+++ b/backend/src/utils/username.ts
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export type Username = Lowercase<string>;
+
+export function makeUsernameLowercase(username: string): Username {
+  return username.toLowerCase() as Username;
+}

--- a/backend/test/private-api/auth.e2e-spec.ts
+++ b/backend/test/private-api/auth.e2e-spec.ts
@@ -16,12 +16,13 @@ import { RegisterDto } from '../../src/identity/local/register.dto';
 import { UpdatePasswordDto } from '../../src/identity/local/update-password.dto';
 import { UserRelationEnum } from '../../src/users/user-relation.enum';
 import { checkPassword } from '../../src/utils/password';
+import { Username } from '../../src/utils/username';
 import { TestSetup, TestSetupBuilder } from '../test-setup';
 
 describe('Auth', () => {
   let testSetup: TestSetup;
 
-  let username: string;
+  let username: Username;
   let displayName: string;
   let password: string;
 

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-add-entry-field.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-add-entry-field.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { useOnInputChange } from '../../../../../../hooks/common/use-on-input-change'
+import { useLowercaseOnInputChange } from '../../../../../../hooks/common/use-lowercase-on-input-change'
 import { UiIcon } from '../../../../../common/icons/ui-icon'
 import type { PermissionDisabledProps } from './permission-disabled.prop'
 import React, { useCallback, useState } from 'react'
@@ -31,7 +31,7 @@ export const PermissionAddEntryField: React.FC<PermissionAddEntryFieldProps & Pe
   const { t } = useTranslation()
 
   const [newEntryIdentifier, setNewEntryIdentifier] = useState('')
-  const onChange = useOnInputChange(setNewEntryIdentifier)
+  const onChange = useLowercaseOnInputChange(setNewEntryIdentifier)
 
   const onSubmit = useCallback(() => {
     onAddEntry(newEntryIdentifier)

--- a/frontend/src/components/login-page/auth/fields/username-field.tsx
+++ b/frontend/src/components/login-page/auth/fields/username-field.tsx
@@ -8,19 +8,26 @@ import React from 'react'
 import { Form } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 
+export interface UsernameFieldProps extends AuthFieldProps {
+  value: string
+}
+
+//TODO: This should be replaced with the common username component. See https://github.com/hedgedoc/hedgedoc/issues/4128
 /**
  * Renders an input field for a username.
  *
  * @param onChange Hook that is called when the input is changed.
  * @param invalid True indicates that the username is invalid, false otherwise.
+ * @param value the username value
  */
-export const UsernameField: React.FC<AuthFieldProps> = ({ onChange, invalid }) => {
+export const UsernameField: React.FC<UsernameFieldProps> = ({ onChange, invalid, value }) => {
   const { t } = useTranslation()
 
   return (
     <Form.Group>
       <Form.Control
         isInvalid={invalid}
+        value={value}
         type='text'
         size='sm'
         placeholder={t('login.auth.username') ?? undefined}

--- a/frontend/src/components/login-page/auth/via-ldap.tsx
+++ b/frontend/src/components/login-page/auth/via-ldap.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { doLdapLogin } from '../../../api/auth/ldap'
+import { useLowercaseOnInputChange } from '../../../hooks/common/use-lowercase-on-input-change'
 import { useOnInputChange } from '../../../hooks/common/use-on-input-change'
 import { PasswordField } from './fields/password-field'
 import { UsernameField } from './fields/username-field'
@@ -38,7 +39,7 @@ export const ViaLdap: React.FC<ViaLdapProps> = ({ providerName, identifier }) =>
     [username, password, identifier]
   )
 
-  const onUsernameChange = useOnInputChange(setUsername)
+  const onUsernameChange = useLowercaseOnInputChange(setUsername)
   const onPasswordChange = useOnInputChange(setPassword)
 
   return (
@@ -48,7 +49,7 @@ export const ViaLdap: React.FC<ViaLdapProps> = ({ providerName, identifier }) =>
           <Trans i18nKey='login.signInVia' values={{ service: providerName }} />
         </Card.Title>
         <Form onSubmit={onLoginSubmit}>
-          <UsernameField onChange={onUsernameChange} invalid={!!error} />
+          <UsernameField onChange={onUsernameChange} invalid={!!error} value={username} />
           <PasswordField onChange={onPasswordChange} invalid={!!error} />
           <Alert className='small' show={!!error} variant='danger'>
             <Trans i18nKey={error} />

--- a/frontend/src/components/login-page/auth/via-local.tsx
+++ b/frontend/src/components/login-page/auth/via-local.tsx
@@ -5,6 +5,7 @@
  */
 import { doLocalLogin } from '../../../api/auth/local'
 import { ErrorToI18nKeyMapper } from '../../../api/common/error-to-i18n-key-mapper'
+import { useLowercaseOnInputChange } from '../../../hooks/common/use-lowercase-on-input-change'
 import { useOnInputChange } from '../../../hooks/common/use-on-input-change'
 import { useFrontendConfig } from '../../common/frontend-config-context/use-frontend-config'
 import { ShowIf } from '../../common/show-if/show-if'
@@ -44,7 +45,7 @@ export const ViaLocal: React.FC = () => {
     [username, password]
   )
 
-  const onUsernameChange = useOnInputChange(setUsername)
+  const onUsernameChange = useLowercaseOnInputChange(setUsername)
   const onPasswordChange = useOnInputChange(setPassword)
 
   return (
@@ -54,7 +55,7 @@ export const ViaLocal: React.FC = () => {
           <Trans i18nKey='login.signInVia' values={{ service: t('login.auth.username') }} />
         </Card.Title>
         <Form onSubmit={onLoginSubmit} className={'d-flex gap-3 flex-column'}>
-          <UsernameField onChange={onUsernameChange} invalid={!!error} />
+          <UsernameField onChange={onUsernameChange} invalid={!!error} value={username} />
           <PasswordField onChange={onPasswordChange} invalid={!!error} />
           <Alert className='small' show={!!error} variant='danger'>
             <Trans i18nKey={error} />

--- a/frontend/src/hooks/common/use-lowercase-on-input-change.spec.tsx
+++ b/frontend/src/hooks/common/use-lowercase-on-input-change.spec.tsx
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useLowercaseOnInputChange } from './use-lowercase-on-input-change'
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+
+describe('useOnInputChange', () => {
+  it('executes the setter', async () => {
+    const callback = jest.fn()
+    const testValue = 'TEST VALUE'
+
+    const Test: React.FC = () => {
+      const onChange = useLowercaseOnInputChange(callback)
+      return <input data-testid={'input'} type={'text'} onChange={onChange} />
+    }
+
+    render(<Test></Test>)
+
+    const element: HTMLInputElement = await screen.findByTestId('input')
+
+    fireEvent.change(element, { target: { value: testValue } })
+
+    expect(callback).toBeCalledWith('test value')
+  })
+})

--- a/frontend/src/hooks/common/use-lowercase-on-input-change.ts
+++ b/frontend/src/hooks/common/use-lowercase-on-input-change.ts
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useOnInputChange } from './use-on-input-change'
+import type { ChangeEvent } from 'react'
+import { useCallback } from 'react'
+
+/**
+ * Takes an input change event and sends the lower case event value to a state setter.
+ *
+ * @param setter The setter method for the state.
+ * @return Hook that can be used as callback for onChange.
+ */
+export const useLowercaseOnInputChange = (
+  setter: (value: string) => void
+): ((event: ChangeEvent<HTMLInputElement>) => void) => {
+  return useOnInputChange(useCallback((value) => setter(value.toLowerCase()), [setter]))
+}

--- a/frontend/src/hooks/common/use-on-input-change.spec.tsx
+++ b/frontend/src/hooks/common/use-on-input-change.spec.tsx
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useOnInputChange } from './use-on-input-change'
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+
+describe('useOnInputChange', () => {
+  it('executes the setter', async () => {
+    const callback = jest.fn()
+    const testValue = 'testValue'
+
+    const Test: React.FC = () => {
+      const onChange = useOnInputChange(callback)
+      return <input data-testid={'input'} type={'text'} onChange={onChange} />
+    }
+
+    render(<Test></Test>)
+
+    const element: HTMLInputElement = await screen.findByTestId('input')
+    fireEvent.change(element, { target: { value: testValue } })
+
+    expect(callback).toBeCalledWith(testValue)
+  })
+})

--- a/frontend/src/hooks/common/use-on-input-change.ts
+++ b/frontend/src/hooks/common/use-on-input-change.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -13,10 +13,5 @@ import { useCallback } from 'react'
  * @return Hook that can be used as callback for onChange.
  */
 export const useOnInputChange = (setter: (value: string) => void): ((event: ChangeEvent<HTMLInputElement>) => void) => {
-  return useCallback(
-    (event) => {
-      setter(event.target.value)
-    },
-    [setter]
-  )
+  return useCallback((event) => setter(event.target.value), [setter])
 }

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -17,6 +17,7 @@ import { useUiNotifications } from '../components/notifications/ui-notification-
 import { RegisterError } from '../components/register-page/register-error'
 import { RegisterInfos } from '../components/register-page/register-infos'
 import { useApplicationState } from '../hooks/common/use-application-state'
+import { useLowercaseOnInputChange } from '../hooks/common/use-lowercase-on-input-change'
 import { useOnInputChange } from '../hooks/common/use-on-input-change'
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
@@ -62,7 +63,7 @@ export const RegisterPage: NextPage = () => {
     return error?.backendErrorName === 'PasswordTooWeakError'
   }, [error])
 
-  const onUsernameChange = useOnInputChange(setUsername)
+  const onUsernameChange = useLowercaseOnInputChange(setUsername)
   const onDisplayNameChange = useOnInputChange(setDisplayName)
   const onPasswordChange = useOnInputChange(setPassword)
   const onPasswordAgainChange = useOnInputChange(setPasswordAgain)


### PR DESCRIPTION
### Component/Part
user 

### Description
This should make all usernames of new users into lowercase. Usernames are also searched in the DB as lowercase.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

