### PR TITLE
refactor(realtime): solve circle dependencies in realtime-user-status-adapter.ts

### DIFF
--- a/backend/src/realtime/realtime-note/realtime-connection.ts
+++ b/backend/src/realtime/realtime-note/realtime-connection.ts
@@ -50,7 +50,11 @@ export class RealtimeConnection {
     this.realtimeUserStateAdapter = new RealtimeUserStatusAdapter(
       this.user?.username ?? null,
       this.getDisplayName(),
-      this,
+      () =>
+        this.realtimeNote
+          .getConnections()
+          .map((connection) => connection.getRealtimeUserStateAdapter()),
+      this.getTransporter(),
       () => acceptEdits,
     );
   }


### PR DESCRIPTION
### Component/Part
Realtime

### Description
This PR refactors the realtime user status adapter to not have a circle dependency with the realtime connection anymore. This always annoyed me, because circle dependencies are bad code design, so i've solved it.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
