### PR TITLE
fix: height of reveal rendering

### DIFF
--- a/frontend/src/components/render-page/renderers/slideshow/slideshow-markdown-renderer.tsx
+++ b/frontend/src/components/render-page/renderers/slideshow/slideshow-markdown-renderer.tsx
@@ -10,6 +10,7 @@ import { MarkdownToReact } from '../../../markdown-renderer/markdown-to-react/ma
 import { RendererType } from '../../window-post-message-communicator/rendering-message'
 import type { CommonMarkdownRendererProps } from '../common-markdown-renderer-props'
 import { LoadingSlide } from './loading-slide'
+import styles from './slideshow.module.scss'
 import type { SlideOptions } from '@hedgedoc/commons'
 import React, { useMemo, useRef } from 'react'
 
@@ -57,9 +58,11 @@ export const SlideshowMarkdownRenderer: React.FC<SlideshowMarkdownRendererProps>
   )
 
   return (
-    <div className={'reveal'}>
-      <div ref={markdownBodyRef} className={`slides`}>
-        {slideShowDOM}
+    <div className={styles.wrapper}>
+      <div className={'reveal'}>
+        <div ref={markdownBodyRef} className={`slides`}>
+          {slideShowDOM}
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/components/render-page/renderers/slideshow/slideshow.module.scss
+++ b/frontend/src/components/render-page/renderers/slideshow/slideshow.module.scss
@@ -1,0 +1,10 @@
+/*!
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+.wrapper {
+  height: 100vh;
+  min-height: 100vh;
+}


### PR DESCRIPTION
### Component/Part
Slideshow

### Description
This PR fixes the height of the reveal renderer.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
