### PR TITLE
fix(webpack): give reveal.js's marked.js a 'exports' variable

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -12,6 +12,7 @@ You now need Node 16 to run HedgeDoc. We don't support more recent versions of N
 
 ### Bugfixes
 - Fix that permission errors can break existing connections to a note, causing inconsistent note content and changes not being saved
+- Fix speaker notes not showing up in the presentation view
 
 ## <i class="fa fa-tag"></i> 1.9.7 <i class="fa fa-calendar-o"></i> 2023-02-19
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -129,7 +129,12 @@ module.exports = {
         {
           context: path.join(__dirname, 'node_modules/reveal.js'),
           from: 'plugin',
-          to: 'reveal.js/plugin'
+          to: 'reveal.js/plugin',
+          transform (content, path) {
+            // The marked.js script wants a 'exports' variable and is referenced from plugin/notes/notes.html
+            // we copy, so just patch that to give it one.
+            return content.toString().replace('<script src="../../plugin/markdown/marked.js"></script>', '<script>var exports = {};</script><script src="../../plugin/markdown/marked.js"></script>')
+          }
         }
       ]
     }),


### PR DESCRIPTION
### Component/Part
Webpack config

### Description
I really don't know why this breaks only in a production build, but this
 evil hack makes the script work again.
Closes https://github.com/hedgedoc/hedgedoc/issues/3862

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
