### PR TITLE
Make our Webpack config compatible with Node 18+

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['16']
+        node: ['16', '18', '20']
     name: Node ${{ matrix.node }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: ./.github/actions/setup-node
         with:
-          NODEJS_VERSION: '16'
+          NODEJS_VERSION: '20'
 
       - name: Run ESLint
         run: yarn run eslint

--- a/bin/setup
+++ b/bin/setup
@@ -31,11 +31,11 @@ EOF
   exit 1
 fi
 
-if version_lt "$(node --version)" 'v14.13.1'; then
+if version_lt "$(node --version)" 'v16.0.0'; then
   cat << EOF
 FATAL: Your Node.js version is not supported.
 
-Please upgrade to version 14.13.1 or higher and try again.
+Please upgrade to version 16 or higher and try again.
 We recommend running the latest LTS release, see https://nodejs.org/en/about/releases/ for details.
 EOF
   exit 1

--- a/docs/content/setup/manual-setup.md
+++ b/docs/content/setup/manual-setup.md
@@ -1,8 +1,8 @@
 # Manual Installation
 
 !!! info "Requirements on your server"
-    - Node.js 16
-      Newer versions are NOT supported. We recommend to run HedgeDoc with the latest release of Node 16.
+    - Node.js 16 or later
+      We recommend to run HedgeDoc with the latest LTS release of Node.js.
     - Database (PostgreSQL, MySQL, MariaDB, SQLite)  
       The database must use charset `utf8`. This is typically the default in PostgreSQL and SQLite.  
       In MySQL and MariaDB UTF-8 might need to be set with `alter database <DBNAME> character set utf8 collate utf8_bin;`  

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "xss": "^1.0.3"
   },
   "engines": {
-    "node": "16.x"
+    "node": ">=16"
   },
   "bugs": "https://github.com/hedgedoc/hedgedoc/issues",
   "keywords": [

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -3,12 +3,13 @@
 ## UNRELEASED
 
 **Please note:** This release dropped support for Node 14, which is end-of-life since May 2023.
-You now need Node 16 to run HedgeDoc. We don't support more recent versions of Node.
+You now need at least Node 16 to run HedgeDoc. We recommend to use the latest LTS release of Node.js.
 
 ### Enhancements
 - Extend boolean environment variable parsing with other positive answers and case insensitivity.
 - Allow setting of `documentMaxLength` via `CMD_DOCUMENT_MAX_LENGTH` environment variable.
 - Add dedicated healthcheck endpoint at /_health that is less resource intensive than /status.
+- Compatibility with Node.js 18 and later
 
 ### Bugfixes
 - Fix that permission errors can break existing connections to a note, causing inconsistent note content and changes not being saved

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,6 +5,13 @@ const CopyWebpackPlugin = require('copy-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 
+// This monkey-patches node to use sha256 instead of md4 for crypto.createHash
+// md4 is not available in node 18+ anymore, as that uses modern OpenSSL versions
+// Inspired by https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported/69691525#69691525
+const crypto = require('crypto')
+const cryptoOrigCreateHash = crypto.createHash
+crypto.createHash = algorithm => cryptoOrigCreateHash(algorithm === 'md4' ? 'sha256' : algorithm)
+
 // Fix possible nofile-issues
 const fs = require('fs')
 const gracefulFs = require('graceful-fs')


### PR DESCRIPTION
### Component/Part
Webpack config

### Description
Node 18 and newer switched to OpenSSL 3, which does not support the MD4 hash algorithm.

Unfortunately, Webpack 4 hardcodes the use of MD4 at various places. This leaves us no other option than to monkey-patch node to transform calls to the MD4 hash to use SHA256.

References:
https://github.com/webpack/webpack/issues/14532
https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported/69691525#69691525

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated documentation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
