### PR TITLE
Configure Renovate to pin versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:js-app",
     "group:definitelyTyped",
     "group:socketio",
     "group:linters",


### PR DESCRIPTION
### Component/Part
Renovate config

### Description
The `config:base` preset does not pin versions in package.json. This switches to the `config:js-app` preset, which enables this feature.

See https://docs.renovatebot.com/presets-config

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
