### PR TITLE
fix(esbuild): exclude reveal.js marked plugin

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -136,12 +136,7 @@ module.exports = {
         {
           context: path.join(__dirname, 'node_modules/reveal.js'),
           from: 'plugin',
-          to: 'reveal.js/plugin',
-          transform (content, path) {
-            // The marked.js script wants a 'exports' variable and is referenced from plugin/notes/notes.html
-            // we copy, so just patch that to give it one.
-            return content.toString().replace('<script src="../../plugin/markdown/marked.js"></script>', '<script>var exports = {};</script><script src="../../plugin/markdown/marked.js"></script>')
-          }
+          to: 'reveal.js/plugin'
         }
       ]
     }),

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -17,8 +17,8 @@ module.exports = [
       minimizer: [
         new EsbuildPlugin({
           target: 'es2015',
-          format: "cjs",
-          exclude: ['MathJax/extensions/a11y/mathmaps']
+          format: 'cjs',
+          exclude: ['MathJax/extensions/a11y/mathmaps', 'reveal.js/plugin/markdown/marked.js']
         })
       ],
       splitChunks: {
@@ -33,7 +33,7 @@ module.exports = [
       minimizer: [
         new EsbuildPlugin({
           target: 'es2015',
-          format: "cjs"
+          format: 'cjs'
         }),
         new OptimizeCSSAssetsPlugin({})
       ]


### PR DESCRIPTION
### Component/Part
Webpack config

### Description
https://github.com/hedgedoc/hedgedoc/pull/4114
did not properly fix the missing speaker notes.

It turns out that by just excluding `reveal.js/plugin/markdown/marked.js`
from esbuild processing, we can stop invalid JS from being generated.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
