### PR TITLE
fix: macOS compatibility for bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,7 @@
 
 set -e
 
-version_lt() { test "$(printf '%s\n' "$@" | { [ "$(uname)" = "Linux" ] && (sort -V || sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n;) } | tail -n 1)" != "$1"; }
+version_lt() { test "$(printf '%s\n' "$@" | (sort -V || sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n;) | tail -n 1)" != "$1"; }
 
 # run command at repo root
 CURRENT_PATH=$PWD

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -19,6 +19,7 @@ special actions.
 - Fix that permission errors can break existing connections to a note, causing inconsistent note content and changes not being saved
 - Fix speaker notes not showing up in the presentation view
 - Fix issues with upgrading some dependencies by upgrading to Yarn 3
+- Fix macOS compatibility of `bin/setup` script
 
 ## <i class="fa fa-tag"></i> 1.9.7 <i class="fa fa-calendar-o"></i> 2023-02-19
 


### PR DESCRIPTION
### Component/Part
setup script

### Description
After carefully studying the man pages of GNU sort and BSD sort, we concluded that the `version_lt` function should also work on macOS.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes https://github.com/hedgedoc/hedgedoc/issues/2482