### PR TITLE
doc: add note about arm64 to the release notes

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -14,6 +14,7 @@ special actions.
 - Allow setting of `documentMaxLength` via `CMD_DOCUMENT_MAX_LENGTH` environment variable.
 - Add dedicated healthcheck endpoint at /_health that is less resource intensive than /status.
 - Compatibility with Node.js 18 and later
+- Add support for the arm64 architecture in the docker image
 
 ### Bugfixes
 - Fix that permission errors can break existing connections to a note, causing inconsistent note content and changes not being saved


### PR DESCRIPTION
### Component/Part
Release notes

### Description
Mention the arm64 image in the release notes

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
