### PR TITLE
doc: correct name of permission env vars

### DIFF
--- a/docs/content/config/index.md
+++ b/docs/content/config/index.md
@@ -48,13 +48,13 @@ However, you can run HedgeDoc without this extra security, but we recommend usin
 
 ## Notes
 
-| environment variable                     | default | example                           | description                                                                                                                                                                          |
-|------------------------------------------|---------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `HD_FORBIDDEN_NOTE_IDS`                  | -       | `notAllowed, alsoNotAllowed`      | A list of note ids (separated by `,`), that are not allowed to be created or requested by anyone.                                                                                    |
-| `HD_MAX_DOCUMENT_LENGTH`                 | 100000  |                                   | The maximum length of any one document. Changes to this will impact performance for your users.                                                                                      |
-| `HD_GUEST_ACCESS`                        | `write` | `deny`, `read`, `write`, `create` | Defines the maximum access level for guest users to the instance. If guest access is set lower than the "everyone" permission of a note then the note permission will be overridden. |
-| `HD_PERMISSION_LOGGED_IN_DEFAULT_ACCESS` | `write` | `none`, `read`, `write`           | The default permission for the "logged-in" group that is set on new notes.                                                                                                           |
-| `HD_PERMISSION_EVERYONE_DEFAULT_ACCESS`  | `read`  | `none`, `read`, `write`           | The default permission for the "everyone" group (logged-in & guest users), that is set on new notes created by logged-in users. Notes created by guests always set this to "write".  |
+| environment variable              | default | example                           | description                                                                                                                                                                          |
+|-----------------------------------|---------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `HD_FORBIDDEN_NOTE_IDS`           | -       | `notAllowed, alsoNotAllowed`      | A list of note ids (separated by `,`), that are not allowed to be created or requested by anyone.                                                                                    |
+| `HD_MAX_DOCUMENT_LENGTH`          | 100000  |                                   | The maximum length of any one document. Changes to this will impact performance for your users.                                                                                      |
+| `HD_GUEST_ACCESS`                 | `write` | `deny`, `read`, `write`, `create` | Defines the maximum access level for guest users to the instance. If guest access is set lower than the "everyone" permission of a note then the note permission will be overridden. |
+| `HD_PERMISSION_DEFAULT_LOGGED_IN` | `write` | `none`, `read`, `write`           | The default permission for the "logged-in" group that is set on new notes.                                                                                                           |
+| `HD_PERMISSION_DEFAULT_EVERYONE`  | `read`  | `none`, `read`, `write`           | The default permission for the "everyone" group (logged-in & guest users), that is set on new notes created by logged-in users. Notes created by guests always set this to "write".  |
 
 ## Authentication
 


### PR DESCRIPTION
### Component/Part
Docs

### Description
This PR fixes the name of the permission env vars in the docs.

### Steps

- {x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
