### PR TITLE
Renderer improvements

### DIFF
--- a/frontend/src/components/common/motd-modal/__snapshots__/motd-modal.spec.tsx.snap
+++ b/frontend/src/components/common/motd-modal/__snapshots__/motd-modal.spec.tsx.snap
@@ -20,7 +20,7 @@ exports[`motd modal renders a modal if a motd was fetched and can dismiss it 1`]
           data-testid="motd-renderer"
         >
           This is a mock implementation of a iframe renderer. Props: 
-          {"frameClasses":"w-100","rendererType":"simple","markdownContentLines":["very important mock text!"],"adaptFrameHeightToContent":true}
+          {"frameClasses":"w-100","rendererType":"simple","markdownContentLines":["very important mock text!"],"adaptFrameHeightToContent":true,"showWaitSpinner":true}
         </span>
       </div>
       <div

--- a/frontend/src/components/common/motd-modal/motd-modal.tsx
+++ b/frontend/src/components/common/motd-modal/motd-modal.tsx
@@ -60,6 +60,7 @@ export const MotdModal: React.FC = () => {
             rendererType={RendererType.SIMPLE}
             markdownContentLines={lines as string[]}
             adaptFrameHeightToContent={true}
+            showWaitSpinner={true}
           />
         </EditorToRendererCommunicatorContextProvider>
       </Modal.Body>

--- a/frontend/src/components/common/renderer-iframe/renderer-iframe.tsx
+++ b/frontend/src/components/common/renderer-iframe/renderer-iframe.tsx
@@ -34,6 +34,7 @@ export interface RendererIframeProps extends Omit<CommonMarkdownRendererProps & 
   frameClasses?: string
   onRendererStatusChange?: undefined | ((rendererReady: boolean) => void)
   adaptFrameHeightToContent?: boolean
+  showWaitSpinner?: boolean
 }
 
 const log = new Logger('RendererIframe')
@@ -52,6 +53,7 @@ const log = new Logger('RendererIframe')
  * @param rendererType The {@link RendererType type} of the renderer to use.
  * @param adaptFrameHeightToContent If set, the iframe height will be adjusted to the content height
  * @param onRendererStatusChange Callback that is fired when the renderer in the iframe is ready
+ * @param showWaitSpinner Defines if the page loading should be indicated by a wait spinner instead of the page loading animation.
  */
 export const RendererIframe: React.FC<RendererIframeProps> = ({
   markdownContentLines,
@@ -61,7 +63,8 @@ export const RendererIframe: React.FC<RendererIframeProps> = ({
   frameClasses,
   rendererType,
   adaptFrameHeightToContent,
-  onRendererStatusChange
+  onRendererStatusChange,
+  showWaitSpinner = false
 }) => {
   const [rendererReady, setRendererReady] = useState<boolean>(false)
   const frameReference = useRef<HTMLIFrameElement>(null)
@@ -152,9 +155,14 @@ export const RendererIframe: React.FC<RendererIframeProps> = ({
     useCallback(() => onMakeScrollSource?.(), [onMakeScrollSource])
   )
 
+  const frameClassNames = useMemo(
+    () => concatCssClasses({ 'd-none': !rendererReady && showWaitSpinner }, 'border-0', styles.frame, frameClasses),
+    [frameClasses, rendererReady, showWaitSpinner]
+  )
+
   return (
     <Fragment>
-      <ShowIf condition={!rendererReady}>
+      <ShowIf condition={!rendererReady && showWaitSpinner}>
         <WaitSpinner />
       </ShowIf>
       <iframe
@@ -166,7 +174,7 @@ export const RendererIframe: React.FC<RendererIframeProps> = ({
         allowFullScreen={true}
         ref={frameReference}
         referrerPolicy={'no-referrer'}
-        className={concatCssClasses('border-0', styles.frame, frameClasses)}
+        className={frameClassNames}
         allow={'clipboard-write'}
         {...cypressAttribute('renderer-ready', rendererReady ? 'true' : 'false')}
         {...cypressAttribute('renderer-type', rendererType)}

--- a/frontend/src/components/editor-page/app-bar/cheatsheet/cheatsheet-entry-pane.tsx
+++ b/frontend/src/components/editor-page/app-bar/cheatsheet/cheatsheet-entry-pane.tsx
@@ -78,6 +78,7 @@ export const CheatsheetEntryPane: React.FC<CheatsheetRendererProps> = ({ extensi
             adaptFrameHeightToContent={true}
             rendererType={RendererType.SIMPLE}
             markdownContentLines={lines}
+            showWaitSpinner={true}
           />
         </ListGroupItem>
       </ExtensionEventEmitterProvider>

--- a/frontend/src/components/editor-page/app-bar/slide-mode-button.tsx
+++ b/frontend/src/components/editor-page/app-bar/slide-mode-button.tsx
@@ -22,11 +22,7 @@ export const SlideModeButton: React.FC = () => {
 
   return (
     <Link href={`/p/${noteIdentifier}`} target='_blank'>
-      <Button
-        title={t('editor.documentBar.slideMode') ?? undefined}
-        className='ms-2 text-secondary'
-        size='sm'
-        variant={buttonVariant}>
+      <Button title={t('editor.documentBar.slideMode') ?? undefined} className='ms-2' size='sm' variant={buttonVariant}>
         <UiIcon icon={IconTv} />
       </Button>
     </Link>

--- a/frontend/src/components/intro-page/intro-custom-content.tsx
+++ b/frontend/src/components/intro-page/intro-custom-content.tsx
@@ -32,6 +32,7 @@ export const IntroCustomContent: React.FC = () => {
         markdownContentLines={value as string[]}
         rendererType={RendererType.SIMPLE}
         adaptFrameHeightToContent={true}
+        showWaitSpinner={true}
       />
     </AsyncLoadingBoundary>
   )

--- a/frontend/src/components/render-page/hooks/use-transparent-body-background.ts
+++ b/frontend/src/components/render-page/hooks/use-transparent-body-background.ts
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useEffect } from 'react'
+
+/**
+ * Makes the HTML body transparent.
+ */
+export const useTransparentBodyBackground = () => {
+  useEffect(() => {
+    document.body.classList.add('bg-transparent')
+    return () => document.body.classList.remove('bg-transparent')
+  }, [])
+}

--- a/frontend/src/components/render-page/renderers/document/document-markdown-renderer.tsx
+++ b/frontend/src/components/render-page/renderers/document/document-markdown-renderer.tsx
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { useApplyDarkModeStyle } from '../../../../hooks/dark-mode/use-apply-dark-mode-style'
 import { cypressId } from '../../../../utils/cypress-attribute'
 import type { ScrollProps } from '../../../editor-page/synced-scroll/scroll-props'
 import type { LineMarkers } from '../../../markdown-renderer/extensions/linemarker/add-line-marker-markdown-it-plugin'
@@ -12,6 +13,7 @@ import { useMarkdownExtensions } from '../../../markdown-renderer/hooks/use-mark
 import { MarkdownToReact } from '../../../markdown-renderer/markdown-to-react/markdown-to-react'
 import { useDocumentSyncScrolling } from '../../hooks/sync-scroll/use-document-sync-scrolling'
 import { useOnHeightChange } from '../../hooks/use-on-height-change'
+import { useTransparentBodyBackground } from '../../hooks/use-transparent-body-background'
 import { RendererType } from '../../window-post-message-communicator/rendering-message'
 import type { CommonMarkdownRendererProps, HeightChangeRendererProps } from '../common-markdown-renderer-props'
 import { DocumentTocSidebar } from './document-toc-sidebar'
@@ -68,6 +70,9 @@ export const DocumentMarkdownRenderer: React.FC<DocumentMarkdownRendererProps> =
     useMemo(() => [new LinemarkerMarkdownExtension((values) => (currentLineMarkers.current = values))], [])
   )
   useCalculateLineMarkerPosition(markdownBodyRef, currentLineMarkers.current, recalculateLineMarkers)
+
+  useTransparentBodyBackground()
+  useApplyDarkModeStyle()
 
   return (
     <div

--- a/frontend/src/components/render-page/renderers/simple/simple-markdown-renderer.tsx
+++ b/frontend/src/components/render-page/renderers/simple/simple-markdown-renderer.tsx
@@ -3,10 +3,12 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { useApplyDarkModeStyle } from '../../../../hooks/dark-mode/use-apply-dark-mode-style'
 import { cypressId } from '../../../../utils/cypress-attribute'
 import { useMarkdownExtensions } from '../../../markdown-renderer/hooks/use-markdown-extensions'
 import { MarkdownToReact } from '../../../markdown-renderer/markdown-to-react/markdown-to-react'
 import { useOnHeightChange } from '../../hooks/use-on-height-change'
+import { useTransparentBodyBackground } from '../../hooks/use-transparent-body-background'
 import { RendererType } from '../../window-post-message-communicator/rendering-message'
 import type { CommonMarkdownRendererProps, HeightChangeRendererProps } from '../common-markdown-renderer-props'
 import React, { useRef } from 'react'
@@ -30,6 +32,9 @@ export const SimpleMarkdownRenderer: React.FC<SimpleMarkdownRendererProps> = ({
   const rendererRef = useRef<HTMLDivElement | null>(null)
   useOnHeightChange(rendererRef, onHeightChange)
   const extensions = useMarkdownExtensions(baseUrl, RendererType.SIMPLE, [])
+
+  useTransparentBodyBackground()
+  useApplyDarkModeStyle()
 
   return (
     <div className={`vh-100 bg-transparent overflow-y-hidden`}>

--- a/frontend/src/components/slide-show-page/slide-show-page-content.tsx
+++ b/frontend/src/components/slide-show-page/slide-show-page-content.tsx
@@ -36,7 +36,7 @@ export const SlideShowPageContent: React.FC = () => {
   )
 
   return (
-    <div className={'vh-100 vw-100'}>
+    <div className={'vh-100 vw-100 overflow-hidden'}>
       <RendererIframe
         frameClasses={'h-100 w-100'}
         markdownContentLines={markdownContentLines}

--- a/frontend/src/pages/render.tsx
+++ b/frontend/src/pages/render.tsx
@@ -5,21 +5,13 @@
  */
 import { RendererToEditorCommunicatorContextProvider } from '../components/editor-page/render-context/renderer-to-editor-communicator-context-provider'
 import { RenderPageContent } from '../components/render-page/render-page-content'
-import { useApplyDarkModeStyle } from '../hooks/dark-mode/use-apply-dark-mode-style'
 import type { NextPage } from 'next'
-import React, { useEffect } from 'react'
+import React from 'react'
 
 /**
  * Renders the actual markdown renderer that receives the content and metadata via iframe communication.
  */
 export const RenderPage: NextPage = () => {
-  useEffect(() => {
-    document.body.classList.add('bg-transparent')
-    return () => document.body.classList.remove('bg-transparent')
-  }, [])
-
-  useApplyDarkModeStyle()
-
   return (
     <RendererToEditorCommunicatorContextProvider>
       <RenderPageContent />


### PR DESCRIPTION
### Component/Part
Mostly just the renderer iframe component

### Description
This PR:
 - fixes the theme support for slideshows
 - fixes the text color for the slideshow button
 - adds a prop that indicates if the page load animation OR the wait spinner should be shown in the render iframe.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
