### PR TITLE
ci: pin database docker image versions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -89,7 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        # renovate: datasource=docker depName=postgres
+        image: postgres:15.3
         env:
           POSTGRES_PASSWORD: hedgedoc
           POSTGRES_USER: hedgedoc

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -56,7 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mariadb:
-        image: mariadb
+        # renovate: datasource=docker depName=mariadb
+        image: mariadb:10.11.4
         env:
           MYSQL_USER: hedgedoc
           MYSQL_PASSWORD: hedgedoc

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
           MYSQL_PASSWORD: hedgedoc
           MYSQL_DATABASE: hedgedoc
           MYSQL_ROOT_PASSWORD: hedgedoc
-        options: --health-cmd "mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 5
+        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 10
         ports:
           - 3306:3306
     steps:

--- a/renovate.json
+++ b/renovate.json
@@ -87,6 +87,17 @@
   "regexManagers": [
     {
       "fileMatch": [
+        "\\.yml$",
+        "\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s+\\S+:\\s+\"?(?<currentValue>[^\"]*?)\"?\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "fileMatch": [
         ".github/workflows/frontend-netlify-deploy-main.yml$",
         ".github/workflows/frontend-netlify-deploy-pr.yml$"
       ],


### PR DESCRIPTION
### Component/Part
CI

### Description
The mariadb for e2e tests seems to time out pretty easily which causes multiple CI jobs to just fail. Probably because of the flakiness of github actions.
This PR increases the timeout values.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
