### PR TITLE
chore: adjust patched yjs version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -128,6 +128,16 @@
       ],
       "datasourceTemplate": "node",
       "depNameTemplate": "node version in workflows"
+    },
+    {
+      "fileMatch": [
+        "package.json"
+      ],
+      "matchStrings": [
+        "yjs@(?:npm%3A)?(?<currentValue>[\\d\\.]+)"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "yjs"
     }
   ]
 }


### PR DESCRIPTION
### Component/Part
Packages

### Description
This PR instructs renovate to also adjust the patched version of yjs.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
