### PR TITLE
fix: save created revision on realtime note destroy

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -13,7 +13,10 @@ on:
 jobs:
   reuse:
     runs-on: ubuntu-latest
+    container:
+      image: fsfe/reuse:1.1.2
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@e7a435374d26d54b324fa6699d8eafb076340dfd # v1.2.0
+
+      - name: Run linter
+        run: reuse lint

--- a/backend/src/realtime/realtime-note/realtime-note.service.spec.ts
+++ b/backend/src/realtime/realtime-note/realtime-note.service.spec.ts
@@ -78,7 +78,7 @@ describe('RealtimeNoteService', () => {
 
     revisionsService = Mock.of<RevisionsService>({
       getLatestRevision: jest.fn(),
-      createRevision: jest.fn(),
+      createAndSaveRevision: jest.fn(),
     });
 
     consoleLoggerService = Mock.of<ConsoleLoggerService>({
@@ -294,8 +294,8 @@ describe('RealtimeNoteService', () => {
     await realtimeNoteService.getOrCreateRealtimeNote(note);
 
     const createRevisionSpy = jest
-      .spyOn(revisionsService, 'createRevision')
-      .mockImplementation(() => Promise.resolve(Mock.of<Revision>()));
+      .spyOn(revisionsService, 'createAndSaveRevision')
+      .mockResolvedValue();
 
     realtimeNote.emit('beforeDestroy');
     expect(createRevisionSpy).toHaveBeenCalledWith(

--- a/backend/src/realtime/realtime-note/realtime-note.service.ts
+++ b/backend/src/realtime/realtime-note/realtime-note.service.ts
@@ -44,7 +44,7 @@ export class RealtimeNoteService implements BeforeApplicationShutdown {
    */
   public saveRealtimeNote(realtimeNote: RealtimeNote): void {
     this.revisionsService
-      .createRevision(
+      .createAndSaveRevision(
         realtimeNote.getNote(),
         realtimeNote.getRealtimeDoc().getCurrentContent(),
         realtimeNote.getRealtimeDoc().encodeStateAsUpdate(),

--- a/backend/src/revisions/revisions.service.spec.ts
+++ b/backend/src/revisions/revisions.service.spec.ts
@@ -364,4 +364,50 @@ describe('RevisionsService', () => {
       expect(saveSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('createAndSaveRevision', () => {
+    it('creates and saves a new revision', async () => {
+      const newRevision = Mock.of<Revision>();
+      const createRevisionSpy = jest
+        .spyOn(service, 'createRevision')
+        .mockResolvedValue(newRevision);
+      const repoSaveSpy = jest
+        .spyOn(revisionRepo, 'save')
+        .mockResolvedValue(newRevision);
+
+      const note = Mock.of<Note>({});
+      const newContent = 'MockContent';
+
+      const yjsState = [0, 1, 2, 3, 4, 5];
+
+      await service.createAndSaveRevision(note, newContent, yjsState);
+      expect(createRevisionSpy).toHaveBeenCalledWith(
+        note,
+        newContent,
+        yjsState,
+      );
+      expect(repoSaveSpy).toHaveBeenCalledWith(newRevision);
+    });
+
+    it("doesn't save if no revision has been created", async () => {
+      const createRevisionSpy = jest
+        .spyOn(service, 'createRevision')
+        .mockResolvedValue(undefined);
+      const repoSaveSpy = jest
+        .spyOn(revisionRepo, 'save')
+        .mockRejectedValue(new Error("shouldn't have been called"));
+
+      const note = Mock.of<Note>({});
+      const newContent = 'MockContent';
+      const yjsState = [0, 1, 2, 3, 4, 5];
+
+      await service.createAndSaveRevision(note, newContent, yjsState);
+      expect(createRevisionSpy).toHaveBeenCalledWith(
+        note,
+        newContent,
+        yjsState,
+      );
+      expect(repoSaveSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/backend/src/revisions/revisions.service.ts
+++ b/backend/src/revisions/revisions.service.ts
@@ -150,6 +150,17 @@ export class RevisionsService {
     };
   }
 
+  /**
+   * Creates (but does not persist(!)) a new {@link Revision} for the given {@link Note}.
+   * Useful if the revision is saved together with the note in one action.
+   *
+   * @async
+   * @param note The note for which the revision should be created
+   * @param newContent The new note content
+   * @param yjsStateVector The yjs state vector that describes the new content
+   * @return {Revision} the created revision
+   * @return {undefined} if the revision couldn't be created because e.g. the content hasn't changed
+   */
   async createRevision(
     note: Note,
     newContent: string,
@@ -184,5 +195,28 @@ export class RevisionsService {
       description,
       tagEntities,
     ) as Revision;
+  }
+
+  /**
+   * Creates and saves a new {@link Revision} for the given {@link Note}.
+   *
+   * @async
+   * @param note The note for which the revision should be created
+   * @param newContent The new note content
+   * @param yjsStateVector The yjs state vector that describes the new content
+   */
+  async createAndSaveRevision(
+    note: Note,
+    newContent: string,
+    yjsStateVector?: number[],
+  ): Promise<void> {
+    const revision = await this.createRevision(
+      note,
+      newContent,
+      yjsStateVector,
+    );
+    if (revision) {
+      await this.revisionRepository.save(revision);
+    }
   }
 }


### PR DESCRIPTION
### Component/Part
Revision persistence

### Description
This PR fixes the realtime-note save process. After c25c0fac922facd288e661d2b1de343e0d18bad8 we forgot to adjust the realtime service.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
