### PR TITLE
chore(github): make description in bug report use a textarea

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         - If you're requesting an improvement for an existing feature, then please consider filling out an "enhancement request" instead!
         - If you're requesting a new feature, that isn't part of this project yet, then please consider filling out a "feature request" instead!
-  - type: input
+  - type: textarea
     id: description
     attributes:
       label: Description


### PR DESCRIPTION
### Component/Part
Github Issue Template

### Description
This PR makes the description in the bug report template into a textarea

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x