### PR TITLE
fix(backend): immediately use our custom logger

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { LogLevel } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
@@ -12,14 +11,16 @@ import { setupApp } from './app-init';
 import { AppModule } from './app.module';
 import { AppConfig } from './config/app.config';
 import { AuthConfig } from './config/auth.config';
+import { Loglevel } from './config/loglevel.enum';
 import { MediaConfig } from './config/media.config';
 import { ConsoleLoggerService } from './logger/console-logger.service';
 
 async function bootstrap(): Promise<void> {
   // Initialize AppModule
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    logger: ['error', 'warn', 'log'] as LogLevel[],
-    bufferLogs: true,
+    // ConsoleLoggerService only uses the loglevel, so we can give it an incomplete AppConfig to log everything
+    // This Logger instance will be replaced by a proper one with config from DI below
+    logger: new ConsoleLoggerService({ loglevel: Loglevel.TRACE } as AppConfig),
   });
 
   // Set up our custom logger


### PR DESCRIPTION
### Component/Part
app init

### Description

While the DI and database initialization is running, NestJSs default logger is normally used. Our custom logger was only being initialized after DI setup is complete.
 Errors encountered during DI setup were buffered and only printed after DI init was complete, or the app exited on error.
 This led to the app not printing anything for a minute in certain cases.

 This commit replaces the initial logger with our ConsoleLoggerService that logs everything.
 After DI init is complete, that logger is replaced with a normal instance of ConsoleLoggerService that uses the real config from DI.



### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes https://github.com/hedgedoc/hedgedoc/issues/4306
