### PR TITLE
enhancement: add profiling flag to analyze run

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-const { isMockMode, isTestMode, isProductionMode} = require('./src/utils/test-modes')
+const { isMockMode, isTestMode, isProductionMode, isProfilingMode } = require('./src/utils/test-modes')
 const path = require('path')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
-  enabled: process.env.ANALYZE === 'true'
+  enabled: isProfilingMode
 })
 
 console.log('Node environment is', process.env.NODE_ENV)
@@ -29,6 +29,10 @@ if (isMockMode) {
  - No persistent data
  - No realtime editing
  `)
+}
+
+if (isProfilingMode) {
+  console.info('This build contains the bundle analyzer and profiling metrics.')
 }
 
 /** @type {import('@svgr/webpack').LoaderOptions} */

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "cross-env NODE_ENV=production next build",
     "build:mock": "cross-env NEXT_PUBLIC_USE_MOCK_API=true next build",
     "build:test": "cross-env NODE_ENV=test NEXT_PUBLIC_TEST_MODE=true next build",
-    "analyze": "cross-env ANALYZE=true yarn build",
+    "analyze": "cross-env ANALYZE=true yarn build --profile",
     "format": "prettier -c \"src/**/*.{ts,tsx,js}\" \"cypress/**/*.{ts,tsx}\"",
     "format:fix": "prettier -w \"src/**/*.{ts,tsx,js}\" \"cypress/**/*.{ts,tsx}\"",
     "lint": "eslint --max-warnings=0 --ext .ts,.tsx src",

--- a/frontend/src/utils/test-modes.js
+++ b/frontend/src/utils/test-modes.js
@@ -43,9 +43,16 @@ const isDevMode = process.env.NODE_ENV === 'development'
  */
 const isProductionMode = process.env.NODE_ENV === 'production'
 
+/**
+ * Defines if the current runtime contains the bundle analyzer and profiling metrics.
+ * @type boolean
+ */
+const isProfilingMode = !!process.env.ANALYZE && isPositiveAnswer(process.env.ANALYZE)
+
 module.exports = {
   isTestMode,
   isMockMode,
   isDevMode,
-  isProductionMode
+  isProductionMode,
+  isProfilingMode
 }


### PR DESCRIPTION
### Component/Part
frontend -> analyze flag

### Description
When running `yarn analyze`, the produced build will now contain the react profiling metrics to be used with the [react-profiler](https://legacy.reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html#profiling-an-application).

It further enhances the `ANALYZE` env variable to be evaluated less strictly (with our `isPositiveAnswer` matcher).

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
