### PR TITLE
fix(backend): prevent zombie realtime connections

### DIFF
--- a/backend/src/realtime/websocket/websocket.gateway.ts
+++ b/backend/src/realtime/websocket/websocket.gateway.ts
@@ -87,19 +87,21 @@ export class WebsocketGateway implements OnGatewayConnection {
         await this.realtimeNoteService.getOrCreateRealtimeNote(note);
 
       const websocketTransporter = new MessageTransporter();
+      websocketTransporter.setAdapter(
+        new BackendWebsocketAdapter(clientSocket),
+      );
+
       const permissions = await this.noteService.toNotePermissionsDto(note);
       const acceptEdits: boolean = userCanEdit(
         permissions as NotePermissions,
         user?.username,
       );
+
       const connection = new RealtimeConnection(
         websocketTransporter,
         user,
         realtimeNote,
         acceptEdits,
-      );
-      websocketTransporter.setAdapter(
-        new BackendWebsocketAdapter(clientSocket),
       );
 
       realtimeNote.addClient(connection);


### PR DESCRIPTION
### Component/Part
Backend websocket

### Description

The setAdapter function checks if the websocket is closed. If this is the case then an error is thrown and the whole process will be canceled. If the adapter isn't set before the realtime connection object is prepared then the connection will subscribe to all the events and THEN the process will be canceled. Because the MessageTransporter has no adapter (and won't get one), the connection will never get a disconnect event and clean up.

This causes the flood of "cant send message over closed websocket" messages. 

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
