### PR TITLE
fix(ci): remove possible command injection in netlify deployment

### DIFF
--- a/.github/workflows/frontend-netlify-deploy-main.yml
+++ b/.github/workflows/frontend-netlify-deploy-main.yml
@@ -62,4 +62,4 @@ jobs:
       - name: Run netlify CLI deployment
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        run: "netlify deploy --build --prod --message \"${{ github.event.head_commit.id }}: ${{ github.event.head_commit.message }}\""
+        run: "netlify deploy --build --prod --message \"${{ github.event.head_commit.id }}\""


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR fixes a possible command injection in the netlify deployment by manipulating commit messages.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
