### PR TITLE
Increase Frontend Performance

### DIFF
--- a/dev-reverse-proxy/package.json
+++ b/dev-reverse-proxy/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {
-    "start:dev": "caddy run || ./caddy run"
+    "start:dev": "caddy run || ./caddy run",
+    "start": "caddy run || ./caddy run"
   }
 }

--- a/frontend/src/components/common/html-to-react/html-to-react.tsx
+++ b/frontend/src/components/common/html-to-react/html-to-react.tsx
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { measurePerformance } from '../../../utils/measure-performance'
 import type { ParserOptions } from '@hedgedoc/html-to-react'
 import { convertHtmlToReact } from '@hedgedoc/html-to-react'
 import type DOMPurify from 'dompurify'
@@ -24,8 +25,12 @@ export interface HtmlToReactProps {
  */
 export const HtmlToReact: React.FC<HtmlToReactProps> = ({ htmlCode, domPurifyConfig, parserOptions }) => {
   const elements = useMemo(() => {
-    const sanitizedHtmlCode = sanitize(htmlCode, { ...domPurifyConfig, RETURN_DOM_FRAGMENT: false, RETURN_DOM: false })
-    return convertHtmlToReact(sanitizedHtmlCode, parserOptions)
+    const sanitizedHtmlCode = measurePerformance('html-to-react: sanitize', () => {
+      return sanitize(htmlCode, { ...domPurifyConfig, RETURN_DOM_FRAGMENT: false, RETURN_DOM: false })
+    })
+    return measurePerformance('html-to-react: convertHtmlToReact', () => {
+      return convertHtmlToReact(sanitizedHtmlCode, parserOptions)
+    })
   }, [domPurifyConfig, htmlCode, parserOptions])
 
   return <Fragment>{elements}</Fragment>

--- a/frontend/src/components/markdown-renderer/markdown-to-react/markdown-to-react.tsx
+++ b/frontend/src/components/markdown-renderer/markdown-to-react/markdown-to-react.tsx
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { measurePerformance } from '../../../utils/measure-performance'
 import { HtmlToReact } from '../../common/html-to-react/html-to-react'
 import type { MarkdownRendererExtension } from '../extensions/_base-classes/markdown-renderer-extension'
 import { useCombinedNodePreprocessor } from './hooks/use-combined-node-preprocessor'
@@ -43,7 +44,9 @@ export const MarkdownToReact: React.FC<MarkdownToReactProps> = ({
   }, [nodeToReactTransformer, markdownRenderExtensions])
 
   useMemo(() => {
-    nodeToReactTransformer.setLineIds(lineNumberMapper.updateLineMapping(markdownContentLines))
+    measurePerformance('markdown-to-react: update-line-mapping', () => {
+      nodeToReactTransformer.setLineIds(lineNumberMapper.updateLineMapping(markdownContentLines))
+    })
   }, [nodeToReactTransformer, lineNumberMapper, markdownContentLines])
 
   const nodePreProcessor = useCombinedNodePreprocessor(markdownRenderExtensions)
@@ -60,7 +63,11 @@ export const MarkdownToReact: React.FC<MarkdownToReactProps> = ({
     [nodeToReactTransformer, nodePreProcessor]
   )
 
-  const html = useMemo(() => markdownIt.render(markdownContentLines.join('\n')), [markdownContentLines, markdownIt])
+  const html = useMemo(() => {
+    return measurePerformance('markdown-to-react: markdown-it', () =>
+      markdownIt.render(markdownContentLines.join('\n'))
+    )
+  }, [markdownContentLines, markdownIt])
   const domPurifyConfig: DOMPurify.Config = useMemo(
     () => ({
       ADD_TAGS: markdownRenderExtensions.flatMap((extension) => extension.buildTagNameAllowList())

--- a/frontend/src/utils/measure-performance.spec.ts
+++ b/frontend/src/utils/measure-performance.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { measurePerformance } from './measure-performance'
+import { Mock } from 'ts-mockery'
+
+describe('measure performance', () => {
+  it('uses the global performance functions', () => {
+    const measurementName = 'marker-name'
+    const markMock = jest.fn()
+    const measureMock = jest.fn()
+    const startMaker = `${measurementName} - start`
+    const endMarker = `${measurementName} - end`
+
+    Object.defineProperty(window, 'performance', {
+      get: () =>
+        Mock.of<Performance>({
+          mark: markMock,
+          measure: measureMock
+        })
+    })
+    const result = measurePerformance(measurementName, () => {
+      return 'value'
+    })
+    expect(result).toBe('value')
+    expect(markMock).toHaveBeenNthCalledWith(1, startMaker)
+    expect(markMock).toHaveBeenNthCalledWith(2, endMarker)
+    expect(measureMock).toBeCalledWith(measurementName, startMaker, endMarker)
+  })
+
+  it('runs the task without global performance functions', () => {
+    Object.defineProperty(window, 'performance', {
+      get: () => undefined
+    })
+    const result = measurePerformance('measurementName', () => {
+      return 'value'
+    })
+    expect(result).toBe('value')
+  })
+})

--- a/frontend/src/utils/measure-performance.ts
+++ b/frontend/src/utils/measure-performance.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * Uses the browser's performance API to measure how long a given task is running.
+ *
+ * @param measurementName The name of the measurement. Is also used to derive the name of the markers
+ * @param task The task to run
+ * @return the result of the task
+ */
+export const measurePerformance = <T = void>(measurementName: string, task: () => T): T => {
+  if (!window.performance || !window.performance.mark || !window.performance.measure) {
+    return task()
+  }
+  const startMarkName = `${measurementName} - start`
+  const endMarkName = `${measurementName} - end`
+  window.performance.mark(startMarkName)
+  const result = task()
+  window.performance.mark(endMarkName)
+  window.performance.measure(measurementName, startMarkName, endMarkName)
+  return result
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "dotenv -- turbo run lint",
     "format": "dotenv -- turbo run format",
     "start:dev": "dotenv -- turbo run start:dev",
+    "start": "dotenv -- turbo run start",
     "test:ci": "dotenv -- turbo run test:ci",
     "test": "dotenv -- turbo run test"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -106,6 +106,11 @@
       ],
       "cache": false,
       "persistent": true
+    },
+
+    "start": {
+      "cache": false,
+      "persistent": true
     }
   }
 }


### PR DESCRIPTION
### Component/Part
Renderer

### Description
This PR increases the performance of the frontend by using `useDeferredValue`. It's a new hook in React 18 and renders a state change in the background and only renders the result if the browser can handle it right now. If the value changes quickly and often then the result is that not every change is visible.

It also adds performance markers to measure how long the frontend needs to render a markdown text.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
