### PR TITLE
fix(frontend): use correct translations for privacy and term of use links

### DIFF
--- a/frontend/src/components/register-page/register-infos.tsx
+++ b/frontend/src/components/register-page/register-infos.tsx
@@ -22,12 +22,12 @@ export const RegisterInfos: React.FC = () => {
       <ul>
         <ShowIf condition={!!specialUrls.termsOfUse}>
           <li>
-            <TranslatedExternalLink i18nKey='appBar.legal.termsOfUse' href={specialUrls.termsOfUse ?? ''} />
+            <TranslatedExternalLink i18nKey='appbar.help.legal.termsOfUse' href={specialUrls.termsOfUse ?? ''} />
           </li>
         </ShowIf>
         <ShowIf condition={!!specialUrls.privacy}>
           <li>
-            <TranslatedExternalLink i18nKey='appBar.legal.privacy' href={specialUrls.privacy ?? ''} />
+            <TranslatedExternalLink i18nKey='appbar.help.legal.privacy' href={specialUrls.privacy ?? ''} />
           </li>
         </ShowIf>
       </ul>


### PR DESCRIPTION
### Component/Part
Register Infos

### Description
This PR fixes the translations keys

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
