### PR TITLE
fix: add new slogan

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -629,9 +629,9 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    HedgeDoc - The best platform to write and share markdown.
-    Copyright (C) 2022  The HedgeDoc developers
-    
+    HedgeDoc - Ideas grow better together
+    Copyright (C) 2023  The HedgeDoc developers
+
     The individual contributors can be found on
     https://github.com/hedgedoc/hedgedoc/graphs/contributors
     or in the local AUTHORS file.

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "slogan": "The best platform to write and share markdown.",
+    "slogan": "Ideas grow better together",
     "title": "Collaborative markdown notes",
     "icon": "HedgeDoc logo with text"
   },


### PR DESCRIPTION
### Component/Part
Translations

### Description
This PR replaces the old slogan with the new one.

https://community.hedgedoc.org/t/and-the-new-slogan-is/1082

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
