### PR TITLE
fix: don't create notes if not found in presentation route

### DIFF
--- a/lib/web/note/controller.js
+++ b/lib/web/note/controller.js
@@ -78,7 +78,7 @@ exports.showNote = function (req, res, next) {
       title,
       opengraph
     })
-  })
+  }, null, true)
 }
 
 exports.createFromPOST = function (req, res, next) {
@@ -119,7 +119,7 @@ exports.doAction = function (req, res, next) {
       default:
         return res.redirect(config.serverURL + '/' + noteId)
     }
-  }, null, false)
+  })
 }
 
 exports.downloadMarkdown = function (req, res, note) {

--- a/lib/web/note/util.js
+++ b/lib/web/note/util.js
@@ -5,7 +5,7 @@ const errors = require('../../errors')
 const fs = require('fs')
 const path = require('path')
 
-exports.findNote = function (req, res, callback, include, createIfNotFound = true) {
+exports.findNote = function (req, res, callback, include = null, createIfNotFound = false) {
   const id = req.params.noteId || req.params.shortid
   models.Note.parseNoteId(id, function (err, _id) {
     if (err) {


### PR DESCRIPTION
### Component/Part
Router

### Description
This PR fixes a bug that creates notes in the presentation router if they dont exist instead of returning a 404.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
