### PR TITLE
refactor: rename HD_AUTH_LDAPS to HD_AUTH_LDAP_SERVERS

### DIFF
--- a/backend/src/config/auth.config.spec.ts
+++ b/backend/src/config/auth.config.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -169,7 +169,7 @@ describe('authConfig', () => {
     const tlsCaContent = ['test-cert\n'];
     const completeLdapConfig = {
       /* eslint-disable @typescript-eslint/naming-convention */
-      HD_AUTH_LDAPS: ldapNames.join(','),
+      HD_AUTH_LDAP_SERVERS: ldapNames.join(','),
       HD_AUTH_LDAP_FUTURAMA_PROVIDER_NAME: providerName,
       HD_AUTH_LDAP_FUTURAMA_URL: url,
       HD_AUTH_LDAP_FUTURAMA_SEARCH_BASE: searchBase,

--- a/backend/src/config/auth.config.ts
+++ b/backend/src/config/auth.config.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -253,9 +253,9 @@ export default registerAs('authConfig', () => {
   const gitlabNames = (
     toArrayConfig(process.env.HD_AUTH_GITLABS, ',') ?? []
   ).map((name) => name.toUpperCase());
-  const ldapNames = (toArrayConfig(process.env.HD_AUTH_LDAPS, ',') ?? []).map(
-    (name) => name.toUpperCase(),
-  );
+  const ldapNames = (
+    toArrayConfig(process.env.HD_AUTH_LDAP_SERVERS, ',') ?? []
+  ).map((name) => name.toUpperCase());
   const samlNames = (toArrayConfig(process.env.HD_AUTH_SAMLS, ',') ?? []).map(
     (name) => name.toUpperCase(),
   );

--- a/docs/content/config/index.md
+++ b/docs/content/config/index.md
@@ -93,7 +93,7 @@ The password score is calculated with [zxcvbn-ts][zxcvbn-ts-score].
 ### LDAP
 
 HedgeDoc can use one or multiple LDAP servers to authenticate users. To do this,
-you first need to tell HedgeDoc the names of servers you want to use (`HD_AUTH_LDAPS`),
+you first need to tell HedgeDoc the names of servers you want to use (`HD_AUTH_LDAP_SERVERS`),
 and then you need to provide the configuration for those LDAP servers
 depending on how you want to use them.
 Each of those variables will contain the given name for this LDAP server.
@@ -102,7 +102,7 @@ will start with `HD_AUTH_LDAP_MY_LDAP`.
 
 | environment variable                       | default              | example                                            | description                                                                                                   |
 | ------------------------------------------ | -------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `HD_AUTH_LDAPS`                            | -                    | `MY_LDAP`                                          | A comma-seperated list of names of LDAP servers HedgeDoc should use.                                          |
+| `HD_AUTH_LDAP_SERVERS`                     | -                    | `MY_LDAP`                                          | A comma-seperated list of names of LDAP servers HedgeDoc should use.                                          |
 | `HD_AUTH_LDAP_$NAME_PROVIDER_NAME`         | `LDAP`               | `My LDAP`                                          | The display name for the LDAP server, that is shown in the UI of HegdeDoc.                                    |
 | `HD_AUTH_LDAP_$NAME_URL`                   | -                    | `ldaps://ldap.example.com`                         | The url with which the LDAP server can be accessed.                                                           |
 | `HD_AUTH_LDAP_$NAME_SEARCH_BASE`           | -                    | `ou=users,dc=LDAP,dc=example,dc=com`               | The LDAP search base which contains the user accounts on the LDAP server.                                     |

--- a/docs/content/dev/auth/ldap.md
+++ b/docs/content/dev/auth/ldap.md
@@ -12,7 +12,7 @@ docker run --rm -p 10389:10389 -p 10636:10636 rroemhild/test-openldap
 and add the following to the `.env` file before starting the backend.
 
 ```dotenv
-HD_AUTH_LDAPS="FUTURAMA"
+HD_AUTH_LDAP_SERVERS="FUTURAMA"
 HD_AUTH_LDAP_FUTURAMA_PROVIDER_NAME="Futurama LDAP"
 HD_AUTH_LDAP_FUTURAMA_URL="ldap://localhost:10389"
 HD_AUTH_LDAP_FUTURAMA_SEARCH_BASE="ou=people,dc=planetexpress,dc=com"


### PR DESCRIPTION
### Component/Part
backend

### Description
This PR renames `HD_AUTH_LDAPS` to `HD_AUTH_LDAP_SERVERS`

This was done as LDAPS us both the plural of LDAP and the common abbreviation for secure LDAP connections.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

Fixes #4460
