### PR TITLE
fix: use better already-exist check in note creation

### DIFF
--- a/lib/web/note/controller.js
+++ b/lib/web/note/controller.js
@@ -85,7 +85,7 @@ exports.createFromPOST = function (req, res, next) {
   let body = ''
   if (req.body && req.body.length > config.documentMaxLength) {
     return errors.errorTooLong(res)
-  } else if (req.body) {
+  } else if (typeof req.body === 'string') {
     body = req.body
   }
   body = body.replace(/[\r]/g, '')

--- a/lib/web/note/util.js
+++ b/lib/web/note/util.js
@@ -60,17 +60,23 @@ exports.newNote = async function (req, res, body) {
     } else {
       return req.method === 'POST' ? errors.errorForbidden(res) : errors.errorNotFound(res)
     }
+
     try {
-      const count = await models.Note.count({
-        where: {
-          alias: req.alias
-        }
+      const id = await new Promise((resolve, reject) => {
+        models.Note.parseNoteId(noteId, (err, id) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(id)
+          }
+        })
       })
-      if (count > 0) {
+
+      if (id) {
         return errors.errorConflict(res)
       }
-    } catch (err) {
-      logger.error('Error while checking for possible duplicate: ' + err)
+    } catch (error) {
+      logger.error(error)
       return errors.errorInternalError(res)
     }
   }


### PR DESCRIPTION
### Component/Part
Note creation

### Description
This PR fixes a bug in the note creation that causes the overwrite of existing notes by using a proper duplication check.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
