### PR TITLE
fix(auth): Fix session data loss by redirect

### DIFF
--- a/lib/web/auth/email/index.js
+++ b/lib/web/auth/email/index.js
@@ -73,6 +73,7 @@ emailAuth.post('/login', urlencodedParser, function (req, res, next) {
   passport.authenticate('local', {
     successReturnToOrRedirect: config.serverURL + '/',
     failureRedirect: config.serverURL + '/',
-    failureFlash: 'Invalid email or password.'
+    failureFlash: 'Invalid email or password.',
+    keepSessionInfo: true
   })(req, res, next)
 })

--- a/lib/web/auth/facebook/index.js
+++ b/lib/web/auth/facebook/index.js
@@ -23,6 +23,7 @@ facebookAuth.get('/auth/facebook', function (req, res, next) {
 facebookAuth.get('/auth/facebook/callback',
   passport.authenticate('facebook', {
     successReturnToOrRedirect: config.serverURL + '/',
-    failureRedirect: config.serverURL + '/'
+    failureRedirect: config.serverURL + '/',
+    keepSessionInfo: true
   })
 )

--- a/lib/web/auth/github/index.js
+++ b/lib/web/auth/github/index.js
@@ -23,7 +23,8 @@ githubAuth.get('/auth/github', function (req, res, next) {
 githubAuth.get('/auth/github/callback',
   passport.authenticate('github', {
     successReturnToOrRedirect: config.serverURL + '/',
-    failureRedirect: config.serverURL + '/'
+    failureRedirect: config.serverURL + '/',
+    keepSessionInfo: true
   })
 )
 

--- a/lib/web/auth/gitlab/index.js
+++ b/lib/web/auth/gitlab/index.js
@@ -25,7 +25,8 @@ gitlabAuth.get('/auth/gitlab', function (req, res, next) {
 gitlabAuth.get('/auth/gitlab/callback',
   passport.authenticate('gitlab', {
     successReturnToOrRedirect: config.serverURL + '/',
-    failureRedirect: config.serverURL + '/'
+    failureRedirect: config.serverURL + '/',
+    keepSessionInfo: true
   })
 )
 

--- a/lib/web/auth/google/index.js
+++ b/lib/web/auth/google/index.js
@@ -22,6 +22,7 @@ googleAuth.get('/auth/google', function (req, res, next) {
 googleAuth.get('/auth/google/callback',
   passport.authenticate('google', {
     successReturnToOrRedirect: config.serverURL + '/',
-    failureRedirect: config.serverURL + '/'
+    failureRedirect: config.serverURL + '/',
+    keepSessionInfo: true
   })
 )

--- a/lib/web/auth/ldap/index.js
+++ b/lib/web/auth/ldap/index.js
@@ -88,6 +88,7 @@ ldapAuth.post('/auth/ldap', urlencodedParser, function (req, res, next) {
   passport.authenticate('ldapauth', {
     successReturnToOrRedirect: config.serverURL + '/',
     failureRedirect: config.serverURL + '/',
-    failureFlash: true
+    failureFlash: true,
+    keepSessionInfo: true
   })(req, res, next)
 })

--- a/lib/web/auth/mattermost/index.js
+++ b/lib/web/auth/mattermost/index.js
@@ -43,6 +43,7 @@ mattermostAuth.get('/auth/mattermost', function (req, res, next) {
 mattermostAuth.get('/auth/mattermost/callback',
   passport.authenticate('oauth2', {
     successReturnToOrRedirect: config.serverURL + '/',
-    failureRedirect: config.serverURL + '/'
+    failureRedirect: config.serverURL + '/',
+    keepSessionInfo: true
   })
 )

--- a/lib/web/auth/oauth2/index.js
+++ b/lib/web/auth/oauth2/index.js
@@ -130,6 +130,7 @@ oauth2Auth.get('/auth/oauth2', function (req, res, next) {
 oauth2Auth.get('/auth/oauth2/callback',
   passport.authenticate('oauth2', {
     successReturnToOrRedirect: config.serverURL + '/',
-    failureRedirect: config.serverURL + '/'
+    failureRedirect: config.serverURL + '/',
+    keepSessionInfo: true
   })
 )

--- a/lib/web/auth/openid/index.js
+++ b/lib/web/auth/openid/index.js
@@ -54,6 +54,7 @@ openIDAuth.post('/auth/openid', urlencodedParser, function (req, res, next) {
 openIDAuth.get('/auth/openid/callback',
   passport.authenticate('openid', {
     successReturnToOrRedirect: config.serverURL + '/',
-    failureRedirect: config.serverURL + '/'
+    failureRedirect: config.serverURL + '/',
+    keepSessionInfo: true
   })
 )

--- a/lib/web/auth/saml/index.js
+++ b/lib/web/auth/saml/index.js
@@ -102,7 +102,8 @@ samlAuth.get('/auth/saml',
 samlAuth.post('/auth/saml/callback', urlencodedParser,
   passport.authenticate('saml', {
     successReturnToOrRedirect: config.serverURL + '/',
-    failureRedirect: config.serverURL + '/'
+    failureRedirect: config.serverURL + '/',
+    keepSessionInfo: true
   })
 )
 

--- a/lib/web/auth/twitter/index.js
+++ b/lib/web/auth/twitter/index.js
@@ -23,6 +23,7 @@ twitterAuth.get('/auth/twitter', function (req, res, next) {
 twitterAuth.get('/auth/twitter/callback',
   passport.authenticate('twitter', {
     successReturnToOrRedirect: config.serverURL + '/',
-    failureRedirect: config.serverURL + '/'
+    failureRedirect: config.serverURL + '/',
+    keepSessionInfo: true
   })
 )


### PR DESCRIPTION


### Component/Part
authentication

### Description
This patch should fix the broken redirect behaviour of the authentication provider where users aren't redirected back to the note they were send off, due to passport forgetting its session.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [ ] Added / updated tests
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
https://github.com/jaredhanson/passport/issues/919
