### PR TITLE
fix(blockquote): remove extra color tag

### DIFF
--- a/frontend/src/extensions/essential-app-extensions/blockquote/__snapshots__/blockquote-extra-tag-markdown-extension.spec.tsx.snap
+++ b/frontend/src/extensions/essential-app-extensions/blockquote/__snapshots__/blockquote-extra-tag-markdown-extension.spec.tsx.snap
@@ -46,11 +46,10 @@ exports[`blockquote extra tag renders the tag "[color=#abcdef]" correctly 1`] = 
   
 
   <p>
-    <span
-      class="blockquote-extra"
-      style="color: rgb(171, 205, 239);"
-    >
-      BootstrapIconMock_Tag
+    <span>
+      [color=
+      #abcdef
+      ]
     </span>
   </p>
   
@@ -66,11 +65,10 @@ exports[`blockquote extra tag renders the tag "[color=#dfe]" correctly 1`] = `
   
 
   <p>
-    <span
-      class="blockquote-extra"
-      style="color: rgb(221, 255, 238);"
-    >
-      BootstrapIconMock_Tag
+    <span>
+      [color=
+      #dfe
+      ]
     </span>
   </p>
   
@@ -101,10 +99,10 @@ exports[`blockquote extra tag renders the tag "[color=notarealcolor]" correctly 
   
 
   <p>
-    <span
-      class="blockquote-extra"
-    >
+    <span>
+      [color=
       notarealcolor
+      ]
     </span>
   </p>
   
@@ -120,11 +118,10 @@ exports[`blockquote extra tag renders the tag "[color=white]" correctly 1`] = `
   
 
   <p>
-    <span
-      class="blockquote-extra"
-      style="color: white;"
-    >
-      BootstrapIconMock_Tag
+    <span>
+      [color=
+      white
+      ]
     </span>
   </p>
   

--- a/frontend/src/extensions/essential-app-extensions/blockquote/blockquote-color-extra-tag-replacer.tsx
+++ b/frontend/src/extensions/essential-app-extensions/blockquote/blockquote-color-extra-tag-replacer.tsx
@@ -1,21 +1,18 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { UiIcon } from '../../../components/common/icons/ui-icon'
 import type { NodeReplacement } from '../../../components/markdown-renderer/replace-components/component-replacer'
 import {
   ComponentReplacer,
   DO_NOT_REPLACE
 } from '../../../components/markdown-renderer/replace-components/component-replacer'
-import { cssColor } from './blockquote-border-color-node-preprocessor'
 import { BlockquoteExtraTagMarkdownExtension } from './blockquote-extra-tag-markdown-extension'
 import { Optional } from '@mrdrogdrog/optional'
 import type { Element } from 'domhandler'
 import { isText } from 'domhandler'
 import type { Text } from 'domhandler/lib/node'
-import { Tag as IconTag } from 'react-bootstrap-icons'
 
 /**
  * Replaces <blockquote-tag> elements with "color" as label and a valid color as content
@@ -32,13 +29,7 @@ export class BlockquoteColorExtraTagReplacer extends ComponentReplacer {
       )
       .map((element) => element.children[0])
       .filter(isText)
-      .map((child) => (child as Text).data)
-      .filter((content) => cssColor.test(content))
-      .map((color) => (
-        <span className={'blockquote-extra'} key={1} style={{ color: color }}>
-          <UiIcon icon={IconTag} key='icon' className={'mx-1'} />
-        </span>
-      ))
+      .map((child) => <span key={1}>[color={(child as Text).data}]</span>)
       .orElse(DO_NOT_REPLACE)
   }
 }


### PR DESCRIPTION
### Component/Part
extra color tags

### Description
This PR removes the extra color tag in a way that still makes us able to use the color tag in the blockquote

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#3734
