### PR TITLE
Show alert when permission is overridden by another permission

### DIFF
--- a/frontend/cypress/e2e/permissions.spec.ts
+++ b/frontend/cypress/e2e/permissions.spec.ts
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import type { NotePermissions } from '@hedgedoc/commons'
+
+const mockPermissionChangeApiRoutes = (permission: NotePermissions) => {
+  cy.intercept('PUT', 'api/private/notes/mock-note/metadata/permissions/groups/_EVERYONE', {
+    statusCode: 200,
+    body: permission
+  })
+  cy.intercept('DELETE', 'api/private/notes/mock-note/metadata/permissions/groups/_EVERYONE', {
+    statusCode: 200,
+    body: permission
+  })
+  cy.intercept('PUT', 'api/private/notes/mock-note/metadata/permissions/groups/_LOGGED_IN', {
+    statusCode: 200,
+    body: permission
+  })
+  cy.intercept('DELETE', 'api/private/notes/mock-note/metadata/permissions/groups/_LOGGED_IN', {
+    statusCode: 200,
+    body: permission
+  })
+}
+
+describe('The permission settings modal', () => {
+  beforeEach(() => {
+    cy.visitTestNote()
+    cy.getByCypressId('sidebar-permission-btn').click()
+  })
+
+  it('can be displayed', () => {
+    cy.getByCypressId('permission-modal').should('be.visible')
+    cy.getByCypressId('permission-owner-name').contains('Mock User')
+    cy.getByCypressId('permission-setting-deny_LOGGED_IN').should('have.class', 'btn-secondary')
+    cy.getByCypressId('permission-setting-deny_EVERYONE').should('have.class', 'btn-secondary')
+  })
+
+  it('shows alert icon on invalid settings in special groups', () => {
+    cy.getByCypressId('permission-setting-deny_LOGGED_IN').should('have.class', 'btn-secondary')
+    mockPermissionChangeApiRoutes({
+      owner: 'mock',
+      sharedToUsers: [],
+      sharedToGroups: [
+        {
+          groupName: '_EVERYONE',
+          canEdit: false
+        }
+      ]
+    })
+    cy.getByCypressId('permission-setting-read_EVERYONE').click()
+    cy.get('svg.text-warning.me-2').should('be.visible')
+    mockPermissionChangeApiRoutes({
+      owner: 'mock',
+      sharedToUsers: [],
+      sharedToGroups: [
+        {
+          groupName: '_EVERYONE',
+          canEdit: true
+        }
+      ]
+    })
+    cy.getByCypressId('permission-setting-write_EVERYONE').click()
+    cy.get('svg.text-warning.me-2').should('be.visible')
+    mockPermissionChangeApiRoutes({
+      owner: 'mock',
+      sharedToUsers: [],
+      sharedToGroups: [
+        {
+          groupName: '_EVERYONE',
+          canEdit: false
+        },
+        {
+          groupName: '_LOGGED_IN',
+          canEdit: false
+        }
+      ]
+    })
+    cy.getByCypressId('permission-setting-read_LOGGED_IN').click()
+    cy.get('svg.text-warning.me-2').should('not.exist')
+    mockPermissionChangeApiRoutes({
+      owner: 'mock',
+      sharedToUsers: [],
+      sharedToGroups: [
+        {
+          groupName: '_EVERYONE',
+          canEdit: true
+        },
+        {
+          groupName: '_LOGGED_IN',
+          canEdit: false
+        }
+      ]
+    })
+    cy.getByCypressId('permission-setting-write_EVERYONE').click()
+    cy.get('svg.text-warning.me-2').should('be.visible')
+    mockPermissionChangeApiRoutes({
+      owner: 'mock',
+      sharedToUsers: [],
+      sharedToGroups: [
+        {
+          groupName: '_EVERYONE',
+          canEdit: true
+        },
+        {
+          groupName: '_LOGGED_IN',
+          canEdit: true
+        }
+      ]
+    })
+    cy.getByCypressId('permission-setting-write_LOGGED_IN').click()
+    cy.get('svg.text-warning.me-2').should('not.exist')
+  })
+})

--- a/frontend/cypress/support/visit-test-editor.ts
+++ b/frontend/cypress/support/visit-test-editor.ts
@@ -6,35 +6,37 @@
 import type { Note } from '../../src/api/notes/types'
 
 export const testNoteId = 'test'
+const mockMetadata = {
+  id: testNoteId,
+  aliases: [
+    {
+      name: 'mock-note',
+      primaryAlias: true,
+      noteId: testNoteId
+    }
+  ],
+  primaryAddress: 'mock-note',
+  title: 'Mock Note',
+  description: 'Mocked note for testing',
+  tags: ['test', 'mock', 'cypress'],
+  updatedAt: '2021-04-24T09:27:51.000Z',
+  updateUsername: null,
+  viewCount: 0,
+  version: 2,
+  createdAt: '2021-04-24T09:27:51.000Z',
+  editedBy: [],
+  permissions: {
+    owner: 'mock',
+    sharedToUsers: [],
+    sharedToGroups: []
+  }
+}
 
 beforeEach(() => {
   cy.intercept(`api/private/notes/${testNoteId}`, {
     content: '',
-    metadata: {
-      id: testNoteId,
-      aliases: [
-        {
-          name: 'mock-note',
-          primaryAlias: true,
-          noteId: testNoteId
-        }
-      ],
-      primaryAddress: 'mock-note',
-      title: 'Mock Note',
-      description: 'Mocked note for testing',
-      tags: ['test', 'mock', 'cypress'],
-      updatedAt: '2021-04-24T09:27:51.000Z',
-      updateUsername: null,
-      viewCount: 0,
-      version: 2,
-      createdAt: '2021-04-24T09:27:51.000Z',
-      editedBy: [],
-      permissions: {
-        owner: 'mock',
-        sharedToUsers: [],
-        sharedToGroups: []
-      }
-    },
+    metadata: mockMetadata,
     editedByAtPosition: []
   } as Note)
+  cy.intercept(`api/private/notes/${testNoteId}/metadata`, mockMetadata)
 })

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -423,7 +423,8 @@
           "error": "There was an error changing the owner of this note.",
           "placeholder": "Enter username of new note owner",
           "button": "Change the owner of this note"
-        }
+        },
+        "inconsistent": "This permission is overridden by another permission"
       },
       "shareLink": {
         "title": "Share link",

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/hooks/use-get-special-permissions.ts
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/hooks/use-get-special-permissions.ts
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useApplicationState } from '../../../../../../../hooks/common/use-application-state'
+import { useMemo } from 'react'
+import { SpecialGroup } from '@hedgedoc/commons'
+
+/**
+ * Returns the special permissions for the current note.
+ * @return A memoized object containing the special permissions for the current note.
+ */
+export const useGetSpecialPermissions = () => {
+  const groupPermissions = useApplicationState((state) => state.noteDetails?.permissions.sharedToGroups)
+  return useMemo(() => {
+    const everyone = groupPermissions?.find((group) => group.groupName === (SpecialGroup.EVERYONE as string))
+    const loggedIn = groupPermissions?.find((group) => group.groupName === (SpecialGroup.LOGGED_IN as string))
+    return {
+      [SpecialGroup.EVERYONE]: everyone,
+      [SpecialGroup.LOGGED_IN]: loggedIn
+    }
+  }, [groupPermissions])
+}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-entry-special-group.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-entry-special-group.tsx
@@ -16,6 +16,7 @@ import { ToggleButtonGroup } from 'react-bootstrap'
 import { Eye as IconEye, Pencil as IconPencil, SlashCircle as IconSlashCircle } from 'react-bootstrap-icons'
 import { useTranslation } from 'react-i18next'
 import { PermissionInconsistentAlert } from './permission-inconsistent-alert'
+import { cypressId } from '../../../../../../utils/cypress-attribute'
 
 export interface PermissionEntrySpecialGroupProps {
   level: AccessLevel
@@ -101,6 +102,7 @@ export const PermissionEntrySpecialGroup: React.FC<PermissionEntrySpecialGroupPr
             onClick={onSetEntryDenied}
             disabled={disabled}
             className={'p-1'}
+            {...cypressId(`permission-setting-deny${type}`)}
           />
           <IconButton
             icon={IconEye}
@@ -109,6 +111,7 @@ export const PermissionEntrySpecialGroup: React.FC<PermissionEntrySpecialGroupPr
             onClick={onSetEntryReadOnly}
             disabled={disabled}
             className={'p-1'}
+            {...cypressId(`permission-setting-read${type}`)}
           />
           <IconButton
             icon={IconPencil}
@@ -117,6 +120,7 @@ export const PermissionEntrySpecialGroup: React.FC<PermissionEntrySpecialGroupPr
             onClick={onSetEntryWriteable}
             disabled={disabled}
             className={'p-1'}
+            {...cypressId(`permission-setting-write${type}`)}
           />
         </ToggleButtonGroup>
       </div>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-entry-special-group.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-entry-special-group.tsx
@@ -15,10 +15,12 @@ import React, { useCallback, useMemo } from 'react'
 import { ToggleButtonGroup } from 'react-bootstrap'
 import { Eye as IconEye, Pencil as IconPencil, SlashCircle as IconSlashCircle } from 'react-bootstrap-icons'
 import { useTranslation } from 'react-i18next'
+import { PermissionInconsistentAlert } from './permission-inconsistent-alert'
 
 export interface PermissionEntrySpecialGroupProps {
   level: AccessLevel
   type: SpecialGroup
+  inconsistent?: boolean
 }
 
 /**
@@ -27,11 +29,13 @@ export interface PermissionEntrySpecialGroupProps {
  * @param level The access level that is currently set for the group.
  * @param type The type of the special group. Must be either {@link SpecialGroup.EVERYONE} or {@link SpecialGroup.LOGGED_IN}.
  * @param disabled If the user is not the owner, functionality is disabled.
+ * @param inconsistent Whether to show the inconsistency alert icon or not
  */
 export const PermissionEntrySpecialGroup: React.FC<PermissionEntrySpecialGroupProps & PermissionDisabledProps> = ({
   level,
   type,
-  disabled
+  disabled,
+  inconsistent
 }) => {
   const noteId = useApplicationState((state) => state.noteDetails?.primaryAddress)
   const { t } = useTranslation()
@@ -88,6 +92,7 @@ export const PermissionEntrySpecialGroup: React.FC<PermissionEntrySpecialGroupPr
     <li className={'list-group-item d-flex flex-row justify-content-between align-items-center'}>
       <span>{name}</span>
       <div>
+        <PermissionInconsistentAlert show={inconsistent ?? false} />
         <ToggleButtonGroup type='radio' name='edit-mode'>
           <IconButton
             icon={IconSlashCircle}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-entry-user.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-entry-user.tsx
@@ -17,6 +17,7 @@ import { AccessLevel, SpecialGroup } from '@hedgedoc/commons'
 import React, { useCallback, useMemo } from 'react'
 import { useAsync } from 'react-use'
 import { PermissionInconsistentAlert } from './permission-inconsistent-alert'
+import { useGetSpecialPermissions } from './hooks/use-get-special-permissions'
 
 export interface PermissionEntryUserProps {
   entry: NoteUserPermissionEntry
@@ -34,16 +35,15 @@ export const PermissionEntryUser: React.FC<PermissionEntryUserProps & Permission
 }) => {
   const noteId = useApplicationState((state) => state.noteDetails?.primaryAddress)
   const { showErrorNotification } = useUiNotifications()
-  const groupPermissions = useApplicationState((state) => state.noteDetails.permissions.sharedToGroups)
+  const { [SpecialGroup.EVERYONE]: everyonePermission, [SpecialGroup.LOGGED_IN]: loggedInPermission } =
+    useGetSpecialPermissions()
 
-  const permissionInconsistent = useMemo(() => {
-    const everyonePermission = groupPermissions.find((group) => group.groupName === (SpecialGroup.EVERYONE as string))
-    const loggedInPermission = groupPermissions.find((group) => group.groupName === (SpecialGroup.LOGGED_IN as string))
-    return (
+  const permissionInconsistent = useMemo(
+    () =>
       (everyonePermission && everyonePermission.canEdit && !entry.canEdit) ||
-      (loggedInPermission && loggedInPermission.canEdit && !entry.canEdit)
-    )
-  }, [groupPermissions, entry])
+      (loggedInPermission && loggedInPermission.canEdit && !entry.canEdit),
+    [everyonePermission, loggedInPermission, entry]
+  )
 
   const onRemoveEntry = useCallback(() => {
     if (!noteId) {

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-inconsistent-alert.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-inconsistent-alert.tsx
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react'
+import { UiIcon } from '../../../../../common/icons/ui-icon'
+import { ExclamationTriangleFill as IconExclamationTriangleFill } from 'react-bootstrap-icons'
+import type { SimpleAlertProps } from '../../../../../common/simple-alert/simple-alert-props'
+import { useTranslatedText } from '../../../../../../hooks/common/use-translated-text'
+
+/**
+ * Alert that is shown when the permissions are inconsistent.
+ *
+ * @param show true to show the alert, false otherwise.
+ */
+export const PermissionInconsistentAlert: React.FC<SimpleAlertProps> = ({ show }) => {
+  const message = useTranslatedText('editor.modal.permissions.inconsistent')
+
+  if (!show) {
+    return null
+  }
+  return <UiIcon icon={IconExclamationTriangleFill} className={'text-warning me-2'} title={message} />
+}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-modal.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-modal.tsx
@@ -11,6 +11,7 @@ import { PermissionSectionSpecialGroups } from './permission-section-special-gro
 import { PermissionSectionUsers } from './permission-section-users'
 import React from 'react'
 import { Modal } from 'react-bootstrap'
+import { cypressId } from '../../../../../../utils/cypress-attribute'
 
 /**
  * Modal for viewing and managing the permissions of the note.
@@ -21,7 +22,12 @@ import { Modal } from 'react-bootstrap'
 export const PermissionModal: React.FC<ModalVisibilityProps> = ({ show, onHide }) => {
   const isOwner = useIsOwner()
   return (
-    <CommonModal show={show} onHide={onHide} showCloseButton={true} titleI18nKey={'editor.modal.permissions.title'}>
+    <CommonModal
+      show={show}
+      onHide={onHide}
+      showCloseButton={true}
+      titleI18nKey={'editor.modal.permissions.title'}
+      {...cypressId('permission-modal')}>
       <Modal.Body>
         <PermissionSectionOwner disabled={!isOwner} />
         <PermissionSectionUsers disabled={!isOwner} />

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-section-owner.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-section-owner.tsx
@@ -12,6 +12,7 @@ import { PermissionOwnerChange } from './permission-owner-change'
 import { PermissionOwnerInfo } from './permission-owner-info'
 import React, { Fragment, useCallback, useState } from 'react'
 import { Trans } from 'react-i18next'
+import { cypressId } from '../../../../../../utils/cypress-attribute'
 
 /**
  * Section in the permissions modal for managing the owner of a note.
@@ -50,7 +51,9 @@ export const PermissionSectionOwner: React.FC<PermissionDisabledProps> = ({ disa
         <Trans i18nKey={'editor.modal.permissions.owner'} />
       </h5>
       <ul className={'list-group'}>
-        <li className={'list-group-item d-flex flex-row align-items-center justify-content-between'}>
+        <li
+          className={'list-group-item d-flex flex-row align-items-center justify-content-between'}
+          {...cypressId('permission-owner-name')}>
           {changeOwner ? (
             <PermissionOwnerChange onConfirmOwnerChange={onOwnerChange} />
           ) : (

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-section-special-groups.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-section-special-groups.tsx
@@ -29,16 +29,17 @@ export const PermissionSectionSpecialGroups: React.FC<PermissionDisabledProps> =
     const groupLoggedIn = groupPermissions.find((entry) => entry.groupName === (SpecialGroup.LOGGED_IN as string))
 
     return {
-      everyone: groupEveryone
+      everyoneLevel: groupEveryone
         ? groupEveryone.canEdit
           ? AccessLevel.WRITEABLE
           : AccessLevel.READ_ONLY
         : AccessLevel.NONE,
-      loggedIn: groupLoggedIn
+      loggedInLevel: groupLoggedIn
         ? groupLoggedIn.canEdit
           ? AccessLevel.WRITEABLE
           : AccessLevel.READ_ONLY
-        : AccessLevel.NONE
+        : AccessLevel.NONE,
+      loggedInInconsistentAlert: groupEveryone && (!groupLoggedIn || (groupEveryone.canEdit && !groupLoggedIn.canEdit))
     }
   }, [groupPermissions])
 
@@ -53,12 +54,13 @@ export const PermissionSectionSpecialGroups: React.FC<PermissionDisabledProps> =
       </h5>
       <ul className={'list-group'}>
         <PermissionEntrySpecialGroup
-          level={specialGroupEntries.loggedIn}
+          level={specialGroupEntries.loggedInLevel}
           type={SpecialGroup.LOGGED_IN}
           disabled={!isOwner}
+          inconsistent={specialGroupEntries.loggedInInconsistentAlert}
         />
         <PermissionEntrySpecialGroup
-          level={specialGroupEntries.everyone}
+          level={specialGroupEntries.everyoneLevel}
           type={SpecialGroup.EVERYONE}
           disabled={disabled}
         />

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-section-special-groups.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-section-special-groups.tsx
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { useApplicationState } from '../../../../../../hooks/common/use-application-state'
 import { useIsOwner } from '../../../../../../hooks/common/use-is-owner'
 import type { PermissionDisabledProps } from './permission-disabled.prop'
 import { PermissionEntrySpecialGroup } from './permission-entry-special-group'
 import { AccessLevel, SpecialGroup } from '@hedgedoc/commons'
 import React, { Fragment, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
+import { useGetSpecialPermissions } from './hooks/use-get-special-permissions'
 
 /**
  * Section of the permission modal for managing special group access to the note.
@@ -18,16 +18,10 @@ import { Trans, useTranslation } from 'react-i18next'
  */
 export const PermissionSectionSpecialGroups: React.FC<PermissionDisabledProps> = ({ disabled }) => {
   useTranslation()
-  const groupPermissions = useApplicationState((state) => state.noteDetails?.permissions.sharedToGroups)
   const isOwner = useIsOwner()
+  const { [SpecialGroup.EVERYONE]: groupEveryone, [SpecialGroup.LOGGED_IN]: groupLoggedIn } = useGetSpecialPermissions()
 
   const specialGroupEntries = useMemo(() => {
-    if (!groupPermissions) {
-      return
-    }
-    const groupEveryone = groupPermissions.find((entry) => entry.groupName === (SpecialGroup.EVERYONE as string))
-    const groupLoggedIn = groupPermissions.find((entry) => entry.groupName === (SpecialGroup.LOGGED_IN as string))
-
     return {
       everyoneLevel: groupEveryone
         ? groupEveryone.canEdit
@@ -41,11 +35,7 @@ export const PermissionSectionSpecialGroups: React.FC<PermissionDisabledProps> =
         : AccessLevel.NONE,
       loggedInInconsistentAlert: groupEveryone && (!groupLoggedIn || (groupEveryone.canEdit && !groupLoggedIn.canEdit))
     }
-  }, [groupPermissions])
-
-  if (!specialGroupEntries) {
-    return null
-  }
+  }, [groupEveryone, groupLoggedIn])
 
   return (
     <Fragment>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-sidebar-entry.tsx
@@ -10,6 +10,7 @@ import { PermissionModal } from './permissions-modal/permission-modal'
 import React, { Fragment } from 'react'
 import { Lock as IconLock } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
+import { cypressId } from '../../../../../utils/cypress-attribute'
 
 /**
  * Renders a button to open the permission modal for the sidebar.
@@ -23,7 +24,12 @@ export const PermissionsSidebarEntry: React.FC<SpecificSidebarEntryProps> = ({ c
 
   return (
     <Fragment>
-      <SidebarButton hide={hide} className={className} icon={IconLock} onClick={showModal}>
+      <SidebarButton
+        hide={hide}
+        className={className}
+        icon={IconLock}
+        onClick={showModal}
+        {...cypressId('sidebar-permission-btn')}>
         <Trans i18nKey={'editor.modal.permissions.title'} />
       </SidebarButton>
       <PermissionModal show={modalVisibility} onHide={closeModal} />

--- a/frontend/src/pages/api/private/users/mock.ts
+++ b/frontend/src/pages/api/private/users/mock.ts
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import type { UserInfo } from '../../../../api/users/types'
+import { HttpMethod, respondToMatchingRequest } from '../../../../handler-utils/respond-to-matching-request'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const handler = (req: NextApiRequest, res: NextApiResponse): void => {
+  respondToMatchingRequest<UserInfo>(HttpMethod.GET, req, res, {
+    username: 'mock',
+    displayName: 'Mock User',
+    photoUrl: ''
+  })
+}
+
+export default handler


### PR DESCRIPTION
### Component/Part
Editor page -> permission modal

### Description
This PR adds an alert icon when another permission overrides a permission.


![image](https://github.com/hedgedoc/hedgedoc/assets/52606896/3d0dd4be-2b9d-437b-8d6c-83de4d28e3fb)


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->
- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
