### PR TITLE
fix(oauth2): Fix crash in rolesClaim extraction

### DIFF
--- a/lib/web/auth/oauth2/index.js
+++ b/lib/web/auth/oauth2/index.js
@@ -75,7 +75,13 @@ function checkAuthorization (data, done) {
       logger.error('oauth2: "accessRole" is configured, but "rolesClaim" is missing from the config. Can\'t check group membership!')
     } else {
       // parse and check role data
-      const roles = extractProfileAttribute(data, config.oauth2.rolesClaim)
+      let roles = []
+      try {
+        roles = extractProfileAttribute(data, config.oauth2.rolesClaim)
+      } catch (err) {
+        logger.warn(`oauth2: failed to extract rolesClaim '${config.oauth2.rolesClaim}' from user profile.`)
+        return done('Permission denied', null)
+      }
       if (!roles) {
         logger.error('oauth2: "accessRole" is configured, but user profile doesn\'t contain roles attribute. Permission denied')
         return done('Permission denied', null)


### PR DESCRIPTION
### Component/Part
auth/oauth2

### Description
This patch adds a try-catch around the rolesClaim extraction to prevent full crashes of HedgeDoc when a user profile is read, that doesn't contain any such claim, which can happen with some IdPs, like Keycloak, that omit the attribute when it's empty.

As a result an authorized user would crash the entire server, which is definitely unintended behaviour. The simply try-catch should resolve the issue and make sure that roles is always defined even if the `extractProfileAttribute` call fails.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
