### PR TITLE
Add button to re-open motd

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -498,7 +498,8 @@
       },
       "instance": {
         "header": "About this instance",
-        "versionInfo": "Running version"
+        "versionInfo": "Running version",
+        "motdModal": "Instance information message"
       },
       "legal": {
         "header": "Legal",

--- a/frontend/src/components/global-dialogs/motd-modal/fetch-motd.spec.ts
+++ b/frontend/src/components/global-dialogs/motd-modal/fetch-motd.spec.ts
@@ -97,21 +97,27 @@ describe('fetch motd', () => {
     })
   })
 
-  it("can detect that the motd hasn't been updated", async () => {
+  it("can detect that the motd hasn't been updated and returns cached content", async () => {
     mockFetch('mocked motd', 'yesterday')
     window.localStorage.setItem('motd.lastModified', 'yesterday')
+    window.localStorage.setItem('motd.content', 'mocked motd')
     const result = fetchMotd()
-    await expect(result).resolves.toStrictEqual(undefined)
+    await expect(result).resolves.toStrictEqual({
+      motdText: 'mocked motd',
+      lastModified: 'yesterday'
+    })
   })
 
-  it('can detect that the motd has been updated', async () => {
+  it('can detect that the motd has been updated and updates cache', async () => {
     mockFetch('mocked motd', 'yesterday')
+    window.localStorage.setItem('motd.content', 'old motd')
     window.localStorage.setItem('motd.lastModified', 'the day before yesterday')
     const result = fetchMotd()
     await expect(result).resolves.toStrictEqual({
       motdText: 'mocked motd',
       lastModified: 'yesterday'
     })
+    expect(window.localStorage.getItem('motd.content')).toBe('mocked motd')
   })
 
   it("won't fetch a motd if no file was found", async () => {

--- a/frontend/src/components/global-dialogs/motd-modal/use-motd-message.ts
+++ b/frontend/src/components/global-dialogs/motd-modal/use-motd-message.ts
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useAsync } from 'react-use'
+import { fetchMotd, MOTD_LOCAL_STORAGE_KEY_LAST_MODIFIED } from './fetch-motd'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Logger } from '../../../utils/logger'
+
+const logger = new Logger('Motd')
+
+/**
+ * Fetches the motd message.
+ * Provides the message, the dismissal state and an option to dismiss the modal.
+ * The dismissal option will result in the "last modified" identifier being written into the local storage
+ * to indicate that the modal does not need to be shown again unless the motd message changes.
+ */
+export const useMotdMessage = () => {
+  const { error, loading, value } = useAsync(fetchMotd)
+  const messageLines = useMemo(() => value?.motdText.split('\n'), [value])
+  const [dismissTriggered, setDismissTriggered] = useState(false)
+  const isMessageSet = useMemo(() => {
+    return !loading && !error && !!value?.motdText
+  }, [loading, error, value])
+
+  const isDismissed = useMemo(() => {
+    if (dismissTriggered) {
+      return true
+    }
+    const lastModified = window.localStorage.getItem(MOTD_LOCAL_STORAGE_KEY_LAST_MODIFIED)
+    return lastModified === value?.lastModified
+  }, [value, dismissTriggered])
+
+  const dismissMotd = useCallback(() => {
+    logger.debug('Dismissed motd with last modified value:', value?.lastModified)
+    if (value?.lastModified) {
+      window.localStorage.setItem(MOTD_LOCAL_STORAGE_KEY_LAST_MODIFIED, value.lastModified)
+    }
+    setDismissTriggered(true)
+  }, [value, setDismissTriggered])
+
+  useEffect(() => {
+    if (error) {
+      logger.error('Error while fetching motd', error)
+    }
+  }, [error])
+
+  return {
+    isMessageSet,
+    messageLines,
+    isDismissed,
+    dismissMotd
+  }
+}

--- a/frontend/src/components/layout/app-bar/app-bar-elements/help-dropdown/submenues/instance-submenu.tsx
+++ b/frontend/src/components/layout/app-bar/app-bar-elements/help-dropdown/submenues/instance-submenu.tsx
@@ -6,6 +6,7 @@
 import { DropdownHeader } from '../dropdown-header'
 import { VersionInfoHelpMenuEntry } from './instance/version-info-help-menu-entry'
 import React, { Fragment } from 'react'
+import { MotdModalHelpMenuEntry } from './instance/motd-modal-help-menu-entry'
 
 /**
  * Renders the instance submenu for the help dropdown.
@@ -15,6 +16,7 @@ export const InstanceSubmenu: React.FC = () => {
     <Fragment>
       <DropdownHeader i18nKey={'appbar.help.instance.header'} />
       <VersionInfoHelpMenuEntry />
+      <MotdModalHelpMenuEntry />
     </Fragment>
   )
 }

--- a/frontend/src/components/layout/app-bar/app-bar-elements/help-dropdown/submenues/instance/motd-modal-help-menu-entry.tsx
+++ b/frontend/src/components/layout/app-bar/app-bar-elements/help-dropdown/submenues/instance/motd-modal-help-menu-entry.tsx
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, { Fragment } from 'react'
+import { TranslatedDropdownItem } from '../../translated-dropdown-item'
+import { InfoCircleFill as IconInfoCircleFill } from 'react-bootstrap-icons'
+import { useBooleanState } from '../../../../../../../hooks/common/use-boolean-state'
+import { MotdModal } from '../../../../../../global-dialogs/motd-modal/motd-modal'
+import { useMotdMessage } from '../../../../../../global-dialogs/motd-modal/use-motd-message'
+import { ShowIf } from '../../../../../../common/show-if/show-if'
+
+/**
+ * Help menu entry for the motd modal.
+ * When no modal content is defined, the menu entry will not render.
+ */
+export const MotdModalHelpMenuEntry: React.FC = () => {
+  const [modalVisibility, showModal, closeModal] = useBooleanState(false)
+  const { isMessageSet } = useMotdMessage()
+
+  if (!isMessageSet) {
+    return null
+  }
+
+  return (
+    <Fragment>
+      <TranslatedDropdownItem
+        icon={IconInfoCircleFill}
+        i18nKey={'appbar.help.instance.motdModal'}
+        onClick={showModal}
+      />
+      <ShowIf condition={modalVisibility}>
+        <MotdModal showExplicitly={modalVisibility} onDismiss={closeModal} />
+      </ShowIf>
+    </Fragment>
+  )
+}


### PR DESCRIPTION
### Component/Part
frontend -> app bar -> help menu

### Description
This PR adds a button to the help menu to re-open the motd.
To accomplish this, the MotdModal component has been refactored to allow being force-shown. The modal content is also cached in local storage as on the HEAD request no content will be delivered.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Closes #2933
