### PR TITLE
Limit test concurrency

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
           NODEJS_VERSION: ${{ env.NODEJS_VERSION }}
 
       - name: Run e2e tests
-        run: yarn turbo run test:e2e:ci --filter=backend
+        run: yarn test:e2e:ci --filter=backend
         shell: bash
         env:
           HEDGEDOC_TEST_DB_TYPE: sqlite
@@ -78,7 +78,7 @@ jobs:
           NODEJS_VERSION: ${{ env.NODEJS_VERSION }}
 
       - name: Run e2e tests
-        run: yarn turbo run test:e2e:ci --filter=backend
+        run: yarn test:e2e:ci --filter=backend
         shell: bash
         env:
           HEDGEDOC_TEST_DB_TYPE: mariadb
@@ -109,7 +109,7 @@ jobs:
           NODEJS_VERSION: ${{ env.NODEJS_VERSION }}
 
       - name: Run e2e tests
-        run: yarn turbo run test:e2e:ci --filter=backend
+        run: yarn test:e2e:ci --filter=backend
         shell: bash
         env:
           HEDGEDOC_TEST_DB_TYPE: postgres
@@ -133,7 +133,7 @@ jobs:
           NODEJS_VERSION: ${{ env.NODEJS_VERSION }}
 
       - name: Build test production build
-        run: yarn turbo run build:test --filter=frontend
+        run: yarn build:test --filter=frontend
         shell: bash
         env:
           NODEJS_VERSION: ${{ env.NODEJS_VERSION }}
@@ -197,7 +197,7 @@ jobs:
         run: "curl -L --max-time 120 http://127.0.0.1:3001/"
 
       - name: Run cypress
-        run: yarn turbo run test:e2e:ci --filter=frontend
+        run: yarn test:e2e:ci --filter=frontend
         shell: bash
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/frontend-netlify-deploy-main.yml
+++ b/.github/workflows/frontend-netlify-deploy-main.yml
@@ -44,7 +44,7 @@ jobs:
         run: echo "HD_BASE_URL=\"https://hedgedoc.dev/\"" >> .env.production
 
       - name: Build app
-        run: yarn turbo run build --filter=frontend
+        run: yarn build --filter=frontend
         shell: bash
         working-directory: .
         env:

--- a/.github/workflows/frontend-netlify-deploy-pr.yml
+++ b/.github/workflows/frontend-netlify-deploy-pr.yml
@@ -67,7 +67,7 @@ jobs:
         run: echo "HD_BASE_URL=\"${{ env.DEPLOY_URL }}\"" >> .env.production
 
       - name: Build app
-        run: yarn turbo run build --filter=frontend
+        run: yarn build --filter=frontend
         shell: bash
         working-directory: .
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
           NODEJS_VERSION: ${{ env.NODEJS_VERSION }}
 
       - name: Run ESLint
-        run: yarn turbo run lint
+        run: yarn lint
         shell: bash
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -34,7 +34,7 @@ jobs:
           NODEJS_VERSION: ${{ matrix.node }}
 
       - name: Build project
-        run: yarn turbo run build
+        run: yarn build
         shell: bash
         env:
           NODEJS_VERSION: ${{ matrix.node }}
@@ -43,7 +43,7 @@ jobs:
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
       - name: Test Project
-        run: yarn turbo run test:ci
+        run: yarn test:ci
         shell: bash
         env:
           NODEJS_VERSION: ${{ matrix.node }}

--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -40,7 +40,7 @@ ARG TURBO_TEAM
 ARG TURBO_API
 ARG TURBO_TOKEN
 
-RUN yarn turbo run build --filter=backend --no-cache --no-daemon
+RUN yarn build --filter=backend --no-cache --no-daemon
 
 ## Stage 2b: Install only prod dependencies
 FROM code-with-deps as prod-dependencies

--- a/frontend/docker/Dockerfile
+++ b/frontend/docker/Dockerfile
@@ -26,7 +26,7 @@ ARG TURBO_TEAM
 ARG TURBO_API
 ARG TURBO_TOKEN
 
-RUN yarn turbo run build --filter=frontend --no-cache --no-daemon
+RUN yarn build --filter=frontend --no-cache --no-daemon
 
 # RUNNER
 FROM base

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "format": "dotenv -c development -- turbo run format",
     "start:dev": "dotenv -c development -- turbo run start:dev",
     "start": "dotenv -c production -- turbo run start",
-    "test:ci": "dotenv -c test -- turbo run test:ci",
-    "test": "dotenv -c test -- turbo run test",
+    "test:ci": "dotenv -c test -- turbo run test:ci --concurrency 1",
+    "test": "dotenv -c test -- turbo run test --concurrency 1",
     "test:e2e:ci": "dotenv -c test -- turbo run test:e2e:ci"
   },
   "packageManager": "yarn@3.6.3",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
   ],
   "scripts": {
     "build": "dotenv -c production -- turbo run build",
+    "build:test": "dotenv -c production -- turbo run build:test",
     "lint": "dotenv -c development -- turbo run lint",
     "lint:fix": "dotenv -c development -- turbo run lint:fix",
     "format": "dotenv -c development -- turbo run format",
     "start:dev": "dotenv -c development -- turbo run start:dev",
     "start": "dotenv -c production -- turbo run start",
     "test:ci": "dotenv -c test -- turbo run test:ci",
-    "test": "dotenv -c test -- turbo run test"
+    "test": "dotenv -c test -- turbo run test",
+    "test:e2e:ci": "dotenv -c test -- turbo run test:e2e:ci"
   },
   "packageManager": "yarn@3.6.3",
   "resolutions": {


### PR DESCRIPTION
### Component/Part
Turbo

### Description
This PR limits the parallel execution of the turbo test tasks. This is necessary to prevent the frontend and backend tests to run in parallel and take a lot of RAM at once.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
