### PR TITLE
fix: improve deep partial type used in tests

### DIFF
--- a/commons/src/utils/deep-partial.ts
+++ b/commons/src/utils/deep-partial.ts
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export type DeepPartial<T> = T extends null | undefined
+  ? T
+  : T extends Array<infer ArrayType>
+  ? Array<DeepPartial<ArrayType>>
+  : T extends Record<string | number | symbol, unknown>
+  ? { [P in keyof T]?: DeepPartial<T[P]> }
+  : T

--- a/commons/src/utils/index.ts
+++ b/commons/src/utils/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from './wait-for-other-promises-to-finish.js'
+export type { DeepPartial } from './deep-partial.js'

--- a/frontend/src/test-utils/mock-app-state.ts
+++ b/frontend/src/test-utils/mock-app-state.ts
@@ -5,7 +5,6 @@
  */
 import * as useApplicationStateModule from '../hooks/common/use-application-state'
 import type { ApplicationState } from '../redux/application-state'
-import type { DeepPartial } from 'redux'
 import { initialState as initialStateDarkMode } from '../redux/dark-mode/reducers'
 import { initialState as initialStateEditorConfig } from '../redux/editor/reducers'
 import { initialState as initialStateNoteDetails } from '../redux/note-details/initial-state'
@@ -13,7 +12,7 @@ import { initialState as initialStateRealtimeStatus } from '../redux/realtime/re
 import { initialState as initialStateRendererStatus } from '../redux/renderer-status/reducers'
 import type { NoteDetails } from '../redux/note-details/types/note-details'
 import type { RealtimeStatus } from '../redux/realtime/types'
-import type { HistoryEntryWithOrigin } from '../api/history/types'
+import type { DeepPartial } from '@hedgedoc/commons'
 
 jest.mock('../redux/editor/methods', () => ({
   loadFromLocalStorage: jest.fn().mockReturnValue(undefined)
@@ -37,7 +36,7 @@ export const mockAppState = (state?: DeepPartial<ApplicationState>) => {
         ...initialStateEditorConfig,
         ...state?.editorConfig
       },
-      history: (state?.history ?? []) as HistoryEntryWithOrigin[],
+      history: state?.history ?? [],
       noteDetails: {
         ...initialStateNoteDetails,
         ...state?.noteDetails

--- a/frontend/src/test-utils/mock-note-permissions.ts
+++ b/frontend/src/test-utils/mock-note-permissions.ts
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import type { ApplicationState } from '../redux/application-state'
-import type { DeepPartial } from 'redux'
 import { mockAppState } from './mock-app-state'
-import type { LoginUserInfo } from '../api/me/types'
-import type { NotePermissions } from '@hedgedoc/commons'
+import type { DeepPartial, NotePermissions } from '@hedgedoc/commons'
 
 /**
  * Mocks the {@link NotePermissions} field of a note in the {@link ApplicationState }for a test.
@@ -38,6 +36,6 @@ export const mockNotePermissions = (
     user: {
       ...additionalState?.user,
       username: ownUsername
-    } as LoginUserInfo
-  })
+    }
+  } as DeepPartial<ApplicationState>)
 }


### PR DESCRIPTION
### Component/Part
Deep Partial type in commons

### Description
The deep partial type from redux had the problem that it could only be applied to records. This caused problems with primitive types and arrays.
This PR fixes the type.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
