### PR TITLE
fix(frontend): show reconnect alert only if note has been loaded

### DIFF
--- a/frontend/src/app/(editor)/@appBar/n/[noteId]/editor-app-bar.tsx
+++ b/frontend/src/app/(editor)/@appBar/n/[noteId]/editor-app-bar.tsx
@@ -16,6 +16,21 @@ import React from 'react'
  */
 export const EditorAppBar: React.FC = () => {
   const isSynced = useApplicationState((state) => state.realtimeStatus.isSynced)
+  const noteDetailsExist = useApplicationState((state) => !!state.noteDetails)
 
-  return <BaseAppBar>{isSynced ? <NoteTitleElement /> : <RealtimeConnectionAlert />}</BaseAppBar>
+  if (!noteDetailsExist) {
+    return <BaseAppBar />
+  } else if (isSynced) {
+    return (
+      <BaseAppBar>
+        <NoteTitleElement />
+      </BaseAppBar>
+    )
+  } else {
+    return (
+      <BaseAppBar>
+        <RealtimeConnectionAlert />
+      </BaseAppBar>
+    )
+  }
 }


### PR DESCRIPTION
### Component/Part
Frontend app bar

### Description
This PR fixes the reconnect alert.
The alert is only shown if a note has been loaded.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
