### PR TITLE
ci: remove node 16

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '16', '18', '20' ] # Are you changing this? Don't forget to update the min. and recommended node version in getting-started.md!
+        node: [ '18', '20' ] # Are you changing this? Don't forget to update the min. and recommended node version in getting-started.md!
         include:
           - node: '20'
             coverage: true


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR removes Node 16 from the CI.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes https://github.com/hedgedoc/hedgedoc/issues/4788
