### PR TITLE
Docs: Add a warning about an NGINX pitfall and its symptom in HedgeDoc

### DIFF
--- a/docs/content/guides/reverse-proxy.md
+++ b/docs/content/guides/reverse-proxy.md
@@ -89,6 +89,14 @@ server {
     ssl_dhparam ssl-dhparams.pem;
 }
 ```
+
+!!! warning
+
+    NGINX `proxy_pass` directives must NOT have trailing slashes. If the trailing
+    slashes are present, the browser will not be able to establish a WebSocket
+    connection to the server, and the editor interface will display an endless loading
+    animation.
+
 ### Apache
 You will need these modules enabled: `proxy`, `proxy_http` and `proxy_wstunnel`.  
 Here is an example config snippet:


### PR DESCRIPTION
### Component/Part

Docs

### Description

This PR adds a warning about an NGINX configuration pitfall that I fell in. Hopefully it will help others who make my mistake.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

N/A
