### PR TITLE
Re-Add firefox to CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -162,6 +162,7 @@ jobs:
       fail-fast: false
       matrix:
         containers: [ 1, 2, 3 ]
+        browser: ["chrome", "firefox"]
     steps:
       - name: Install additional packages
         run: apt-get update && apt-get install -y jq zstd screen curl
@@ -197,7 +198,7 @@ jobs:
         run: "curl -L --max-time 120 http://127.0.0.1:3001/"
 
       - name: Run cypress
-        run: yarn test:e2e:ci --filter=frontend
+        run: yarn test:e2e:ci:${{ matrix.browser }} --filter=frontend
         shell: bash
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "start:dev:test": "cross-env PORT=${HD_FRONTEND_PORT:-3001} NODE_ENV=test NEXT_PUBLIC_TEST_MODE=true next dev",
     "test:e2e:open": "cypress open",
     "test:e2e": "cypress run --browser chrome",
-    "test:e2e:ci": "cypress run --browser chrome --record true --parallel --group \"chrome\"",
+    "test:e2e:ci:chrome": "cypress run --browser chrome --record true --parallel --group \"chrome\"",
+    "test:e2e:ci:firefox": "cypress run --browser firefox --record true --parallel --group \"firefox\"",
     "test:watch": "cross-env NODE_ENV=test jest --watch",
     "test:ci": "cross-env NODE_ENV=test jest --coverage",
     "test": "cross-env NODE_ENV=test jest"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "start": "dotenv -c production -- turbo run start",
     "test:ci": "dotenv -c test -- turbo run test:ci --concurrency 1",
     "test": "dotenv -c test -- turbo run test --concurrency 1",
+    "test:e2e:ci:firefox": "dotenv -c test -- turbo run test:e2e:ci:firefox",
+    "test:e2e:ci:chrome": "dotenv -c test -- turbo run test:e2e:ci:chrome",
     "test:e2e:ci": "dotenv -c test -- turbo run test:e2e:ci"
   },
   "packageManager": "yarn@3.6.4",

--- a/turbo.json
+++ b/turbo.json
@@ -96,7 +96,15 @@
     },
 
     "test:e2e:ci": {},
-    "@hedgedoc/frontend#test:e2e:ci": {
+    "@hedgedoc/frontend#test:e2e:ci:chrome": {
+      "dependsOn": [
+        "^build"
+      ],
+      "env": [
+        "CYPRESS_CONTAINER_ID"
+      ]
+    },
+    "@hedgedoc/frontend#test:e2e:ci:firefox": {
       "dependsOn": [
         "^build"
       ],


### PR DESCRIPTION
### Component/Part
CI E2E

### Description
This PR re-adds firefox to the CI . We had firefox in before but it caused a lot of trouble like crashing and way longer runs. This PR should test if it got any better in the meantime.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
