### PR TITLE
fix: ensure successful startup is logged

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -45,7 +45,7 @@ async function bootstrap(): Promise<void> {
 
   // Start the server
   await app.listen(appConfig.port);
-  logger.log(`Listening on port ${appConfig.port}`, 'AppBootstrap');
+  logger.warn(`Listening on port ${appConfig.port}`, 'AppBootstrap');
 }
 
 void bootstrap();


### PR DESCRIPTION
### Component/Part
Startup logging

### Description
The default log level is 'warning', so we log the final startup message as warning to ensure it is visible by default.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
