### PR TITLE
feat(config): warn user about not yet supported config

### DIFF
--- a/backend/src/config/auth.config.ts
+++ b/backend/src/config/auth.config.ts
@@ -221,15 +221,30 @@ export default registerAs('authConfig', () => {
   const gitlabNames = (
     toArrayConfig(process.env.HD_AUTH_GITLABS, ',') ?? []
   ).map((name) => name.toUpperCase());
+  if (gitlabNames.length !== 0) {
+    throw new Error(
+      "GitLab auth is currently not yet supported. Please don't configure it",
+    );
+  }
   const ldapNames = (
     toArrayConfig(process.env.HD_AUTH_LDAP_SERVERS, ',') ?? []
   ).map((name) => name.toUpperCase());
   const samlNames = (toArrayConfig(process.env.HD_AUTH_SAMLS, ',') ?? []).map(
     (name) => name.toUpperCase(),
   );
+  if (samlNames.length !== 0) {
+    throw new Error(
+      "SAML auth is currently not yet supported. Please don't configure it",
+    );
+  }
   const oauth2Names = (
     toArrayConfig(process.env.HD_AUTH_OAUTH2S, ',') ?? []
   ).map((name) => name.toUpperCase());
+  if (oauth2Names.length !== 0) {
+    throw new Error(
+      "OAuth2 auth is currently not yet supported. Please don't configure it",
+    );
+  }
 
   const gitlabs = gitlabNames.map((gitlabName) => {
     return {
@@ -333,6 +348,25 @@ export default registerAs('authConfig', () => {
       accessRole: process.env[`HD_AUTH_OAUTH2_${oauth2Name}_ACCESS_ROLE`],
     };
   });
+
+  if (
+    process.env.HD_AUTH_GITHUB_CLIENT_ID !== undefined ||
+    process.env.HD_AUTH_GITHUB_CLIENT_SECRET !== undefined
+  ) {
+    throw new Error(
+      "GitHub config is currently not yet supported. Please don't configure it",
+    );
+  }
+
+  if (
+    process.env.HD_AUTH_GOOGLE_CLIENT_ID !== undefined ||
+    process.env.HD_AUTH_GOOGLE_CLIENT_SECRET !== undefined ||
+    process.env.HD_AUTH_GOOGLE_APP_KEY !== undefined
+  ) {
+    throw new Error(
+      "Google config is currently not yet supported. Please don't configure it",
+    );
+  }
 
   const authConfig = authSchema.validate(
     {

--- a/backend/src/config/csp.config.ts
+++ b/backend/src/config/csp.config.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -19,6 +19,15 @@ const cspSchema = Joi.object({
 });
 
 export default registerAs('cspConfig', () => {
+  if (
+    process.env.HD_CSP_ENABLE !== undefined ||
+    process.env.HD_CSP_REPORT_URI !== undefined
+  ) {
+    throw new Error(
+      "CSP config is currently not yet supported. Please don't configure it",
+    );
+  }
+
   const cspConfig = cspSchema.validate(
     {
       enable: process.env.HD_CSP_ENABLE || true,

--- a/backend/src/config/external-services.config.ts
+++ b/backend/src/config/external-services.config.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -29,6 +29,11 @@ const schema = Joi.object({
 });
 
 export default registerAs('externalServicesConfig', () => {
+  if (process.env.HD_IMAGE_PROXY !== undefined) {
+    throw new Error(
+      "HD_IMAGE_PROXY is currently not yet supported. Please don't configure it",
+    );
+  }
   const externalConfig = schema.validate(
     {
       plantUmlServer: process.env.HD_PLANTUML_SERVER,

--- a/docs/content/references/config/integrations.md
+++ b/docs/content/references/config/integrations.md
@@ -3,4 +3,6 @@
 | environment variable   | default | example                             | description                                                                                                                          |
 |------------------------|---------|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | `HD_PLANTUML_SERVER`   | -       | `https://www.plantuml.com/plantuml` | The PlantUML server that HedgeDoc uses to render PlantUML diagrams. If this is not configured, PlantUML diagrams won't be rendered.  |
-| `HD_IMAGE_PROXY`       | -       | `https://image-proxy.example.com`   | **ToDo:** Add description                                                                                                            |
+<!--
+| `HD_IMAGE_PROXY` | -       | `https://image-proxy.example.com`   | **ToDo:** Add description  |
+-->


### PR DESCRIPTION
### Component/Part
config

### Description
This PR adds error messages for not yet supported config options

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x