### PR TITLE
fix: show new note button only dependent on guest access

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -555,7 +555,8 @@
     "signOut": "Sign Out",
     "logoutFailed": "There was an error logging you out.\nClose your browser window to ensure session data is removed.",
     "guest": {
-      "title": "Continue as guest"
+      "title": "Continue as guest",
+      "noteCreationDisabled": "Guest note creation is disabled on this instance. Please log in to create a note."
     },
     "auth": {
       "email": "Email",

--- a/frontend/src/app/(editor)/login/page.tsx
+++ b/frontend/src/app/(editor)/login/page.tsx
@@ -1,9 +1,3 @@
-/*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
- *
- * SPDX-License-Identifier: AGPL-3.0-only
- */
-
 'use client'
 
 /*

--- a/frontend/src/app/(editor)/login/page.tsx
+++ b/frontend/src/app/(editor)/login/page.tsx
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 'use client'
 
 /*
@@ -14,16 +20,16 @@ import { Trans } from 'react-i18next'
 import { CustomBranding } from '../../../components/common/custom-branding/custom-branding'
 import { IntroCustomContent } from '../../../components/intro-page/intro-custom-content'
 import React from 'react'
-import { useApplicationState } from '../../../hooks/common/use-application-state'
 import { RedirectToParamOrHistory } from '../../../components/login-page/redirect-to-param-or-history'
 import { Col, Container, Row } from 'react-bootstrap'
 import { LocalLoginCard } from '../../../components/login-page/local-login/local-login-card'
 import { LdapLoginCards } from '../../../components/login-page/ldap/ldap-login-cards'
 import { OneClickLoginCard } from '../../../components/login-page/one-click/one-click-login-card'
 import { GuestCard } from '../../../components/login-page/guest/guest-card'
+import { useIsLoggedIn } from '../../../hooks/common/use-is-logged-in'
 
 const LoginPage: NextPage = () => {
-  const userLoggedIn = useApplicationState((state) => !!state.user)
+  const userLoggedIn = useIsLoggedIn()
 
   if (userLoggedIn) {
     return <RedirectToParamOrHistory />

--- a/frontend/src/components/common/new-note-button/new-note-button.tsx
+++ b/frontend/src/components/common/new-note-button/new-note-button.tsx
@@ -11,6 +11,9 @@ import { useRouter } from 'next/navigation'
 import React, { useCallback } from 'react'
 import { FileEarmarkPlus as IconPlus } from 'react-bootstrap-icons'
 import { Trans } from 'react-i18next'
+import { useFrontendConfig } from '../frontend-config-context/use-frontend-config'
+import { GuestAccessLevel } from '../../../api/config/types'
+import { useIsLoggedIn } from '../../../hooks/common/use-is-logged-in'
 
 /**
  * Links to the "new note" endpoint
@@ -18,6 +21,9 @@ import { Trans } from 'react-i18next'
 export const NewNoteButton: React.FC = () => {
   const { showErrorNotification } = useUiNotifications()
   const router = useRouter()
+  const guestAccessLevel = useFrontendConfig().guestAccess
+  const isLoggedIn = useIsLoggedIn()
+
   const createNewNoteAndRedirect = useCallback((): void => {
     createNote('')
       .then((note) => {
@@ -27,6 +33,10 @@ export const NewNoteButton: React.FC = () => {
         showErrorNotification(error.message)
       })
   }, [router, showErrorNotification])
+
+  if (!isLoggedIn && guestAccessLevel !== GuestAccessLevel.CREATE) {
+    return null
+  }
 
   return (
     <IconButton

--- a/frontend/src/components/history-page/entry-menu/entry-menu.tsx
+++ b/frontend/src/components/history-page/entry-menu/entry-menu.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { HistoryEntryOrigin } from '../../../api/history/types'
-import { useApplicationState } from '../../../hooks/common/use-application-state'
 import { cypressId } from '../../../utils/cypress-attribute'
 import { UiIcon } from '../../common/icons/ui-icon'
 import { ShowIf } from '../../common/show-if/show-if'

--- a/frontend/src/components/history-page/entry-menu/entry-menu.tsx
+++ b/frontend/src/components/history-page/entry-menu/entry-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,6 +15,7 @@ import React from 'react'
 import { Dropdown } from 'react-bootstrap'
 import { Cloud as IconCloud, Laptop as IconLaptop, ThreeDots as IconThreeDots } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
+import { useIsLoggedIn } from '../../../hooks/common/use-is-logged-in'
 
 export interface EntryMenuProps {
   id: string
@@ -44,7 +45,7 @@ export const EntryMenu: React.FC<EntryMenuProps> = ({
   className
 }) => {
   useTranslation()
-  const userExists = useApplicationState((state) => !!state.user)
+  const userExists = useIsLoggedIn()
 
   return (
     <Dropdown className={`d-inline-flex ${className || ''}`} {...cypressId('history-entry-menu')}>

--- a/frontend/src/components/history-page/history-toolbar/history-toolbar.tsx
+++ b/frontend/src/components/history-page/history-toolbar/history-toolbar.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -24,6 +24,7 @@ import { useSyncToolbarStateToUrlEffect } from './toolbar-context/use-sync-toolb
 import React, { useCallback } from 'react'
 import { Button, Col } from 'react-bootstrap'
 import { CloudUpload as IconCloudUpload } from 'react-bootstrap-icons'
+import { useIsLoggedIn } from '../../../hooks/common/use-is-logged-in'
 
 export enum ViewStateEnum {
   CARD,
@@ -35,7 +36,7 @@ export enum ViewStateEnum {
  */
 export const HistoryToolbar: React.FC = () => {
   const historyEntries = useApplicationState((state) => state.history)
-  const userExists = useApplicationState((state) => !!state.user)
+  const userExists = useIsLoggedIn()
   const { showErrorNotification } = useUiNotifications()
   const safeRefreshHistoryState = useSafeRefreshHistoryStateCallback()
   useSyncToolbarStateToUrlEffect()

--- a/frontend/src/components/history-page/history-toolbar/import-history-button.tsx
+++ b/frontend/src/components/history-page/history-toolbar/import-history-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -16,12 +16,13 @@ import { useSafeRefreshHistoryStateCallback } from './hooks/use-safe-refresh-his
 import React, { useCallback, useRef, useState } from 'react'
 import { Button } from 'react-bootstrap'
 import { Upload as IconUpload } from 'react-bootstrap-icons'
+import { useIsLoggedIn } from '../../../hooks/common/use-is-logged-in'
 
 /**
  * Button that lets the user select a history JSON file and uploads imports that into the history.
  */
 export const ImportHistoryButton: React.FC = () => {
-  const userExists = useApplicationState((state) => !!state.user)
+  const userExists = useIsLoggedIn()
   const historyState = useApplicationState((state) => state.history)
   const uploadInput = useRef<HTMLInputElement>(null)
   const [fileName, setFilename] = useState('')

--- a/frontend/src/components/layout/app-bar/app-bar-elements/user-element.tsx
+++ b/frontend/src/components/layout/app-bar/app-bar-elements/user-element.tsx
@@ -3,15 +3,15 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { useApplicationState } from '../../../../hooks/common/use-application-state'
 import { SignInButton } from '../../../landing-layout/navigation/sign-in-button'
 import { UserDropdown } from '../../../landing-layout/navigation/user-dropdown'
 import React from 'react'
+import { useIsLoggedIn } from '../../../../hooks/common/use-is-logged-in'
 
 /**
  * Renders either the user dropdown or the sign-in button depending on the user state.
  */
 export const UserElement: React.FC = () => {
-  const userExists = useApplicationState((state) => !!state.user)
+  const userExists = useIsLoggedIn()
   return userExists ? <UserDropdown /> : <SignInButton size={'sm'} className={'h-100'} />
 }

--- a/frontend/src/components/login-page/guest/guest-card.tsx
+++ b/frontend/src/components/login-page/guest/guest-card.tsx
@@ -11,6 +11,7 @@ import { HistoryButton } from '../../layout/app-bar/app-bar-elements/help-dropdo
 import { useFrontendConfig } from '../../common/frontend-config-context/use-frontend-config'
 import { Trans, useTranslation } from 'react-i18next'
 import { GuestAccessLevel } from '../../../api/config/types'
+import { ShowIf } from '../../common/show-if/show-if'
 
 /**
  * Renders the card with the options for not logged-in users.
@@ -19,10 +20,6 @@ export const GuestCard: React.FC = () => {
   const guestAccessLevel = useFrontendConfig().guestAccess
 
   useTranslation()
-
-  if (guestAccessLevel === GuestAccessLevel.DENY) {
-    return null
-  }
 
   return (
     <Card>
@@ -34,6 +31,11 @@ export const GuestCard: React.FC = () => {
           <NewNoteButton />
           <HistoryButton />
         </div>
+        <ShowIf condition={guestAccessLevel !== GuestAccessLevel.CREATE}>
+          <div className={'text-muted mt-2 small'}>
+            <Trans i18nKey={'login.guest.noteCreationDisabled'} />
+          </div>
+        </ShowIf>
       </Card.Body>
     </Card>
   )

--- a/frontend/src/hooks/common/use-is-logged-in.ts
+++ b/frontend/src/hooks/common/use-is-logged-in.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useApplicationState } from './use-application-state'
+
+/**
+ * Hook to check if currently a user is logged in.
+ * @return True, if a user is logged in. False otherwise.
+ */
+export const useIsLoggedIn = () => {
+  return useApplicationState((state) => !!state.user)
+}


### PR DESCRIPTION
### Component/Part
login page, app bar

### Description
This PR shows the new note button only when being logged in or guests have the permission to create notes. Also the continue as guest button is now always available to get to the explore page (guests may also read notes).

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
