### PR TITLE
fix: use correct import for identicon

### DIFF
--- a/frontend/src/components/common/user-avatar/hooks/use-avatar-url.ts
+++ b/frontend/src/components/common/user-avatar/hooks/use-avatar-url.ts
@@ -5,7 +5,7 @@
  */
 import { useMemo } from 'react'
 import { createAvatar } from '@dicebear/core'
-import identicon from '@dicebear/identicon'
+import * as identicon from '@dicebear/identicon'
 
 /**
  * Returns the correct avatar url for a user.


### PR DESCRIPTION
### Component/Part
identicon

### Description
This PR fixes the import for the identicon module.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
