### PR TITLE
fix: redirect to history page after register to avoid problems

### DIFF
--- a/frontend/src/components/login-page/local-login/register/local-register-form.tsx
+++ b/frontend/src/components/login-page/local-login/register/local-register-form.tsx
@@ -49,7 +49,7 @@ export const LocalRegisterForm: NextPage = () => {
       doLocalRegister(username, displayName, password)
         .then(() => fetchAndSetUser())
         .then(() => dispatchUiNotification('login.register.success.title', 'login.register.success.message', {}))
-        .then(() => router.push('/'))
+        .then(() => router.push('/history'))
         .catch((error: ApiError) => setError(error))
       event.preventDefault()
     },


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
With the previous redirect to the root page, there were some problems when having no other routes in the route history.

This PR fixes this by redirecting to the history page instead.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
