### PR TITLE
feat(editor): show notification if user is not allowed to edit note

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -234,6 +234,10 @@
       "you": "(You)"
     },
     "error": {
+      "noPermission": {
+        "title": "No edit permission",
+        "description": "You don't have permission to edit this note. Please login and try again"
+      },
       "locked": {
         "title": "This note is locked",
         "description": "Sorry, only the owner can edit this note."


### PR DESCRIPTION
### Component/Part
editor

### Description
This PR shows a notification if user is not allowed to edit note.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x