### PR TITLE
fix: clicking the logo let's the user get back to the note

### DIFF
--- a/frontend/src/components/login-page/redirect-to-param-or-history.tsx
+++ b/frontend/src/components/login-page/redirect-to-param-or-history.tsx
@@ -20,5 +20,5 @@ export const RedirectToParamOrHistory: React.FC = () => {
   const cleanedUrl =
     redirectBackUrl.startsWith('/') && !redirectBackUrl.startsWith('//') ? redirectBackUrl : defaultFallback
 
-  return <Redirect to={cleanedUrl} />
+  return <Redirect to={cleanedUrl} replace={true} />
 }


### PR DESCRIPTION
### Component/Part
logo redirect

### Description
This PR fixes the UX when clicking the logo in the editor

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x