### PR TITLE
fix: show guest access button only with relevant config being set

### DIFF
--- a/frontend/src/components/login-page/guest/guest-card.tsx
+++ b/frontend/src/components/login-page/guest/guest-card.tsx
@@ -21,6 +21,10 @@ export const GuestCard: React.FC = () => {
 
   useTranslation()
 
+  if (guestAccessLevel === GuestAccessLevel.DENY) {
+    return null
+  }
+
   return (
     <Card>
       <Card.Body>


### PR DESCRIPTION
### Component/Part
login page

### Description
This PR fixes the continue as guest button

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
