### PR TITLE
refactor: remove name tooltip from user avatar

### DIFF
--- a/frontend/src/components/common/user-avatar/user-avatar.tsx
+++ b/frontend/src/components/common/user-avatar/user-avatar.tsx
@@ -6,9 +6,7 @@
 import { useTranslatedText } from '../../../hooks/common/use-translated-text'
 import { ShowIf } from '../show-if/show-if'
 import styles from './user-avatar.module.scss'
-import React, { useCallback, useMemo } from 'react'
-import { OverlayTrigger, Tooltip } from 'react-bootstrap'
-import type { OverlayInjectedProps } from 'react-bootstrap/Overlay'
+import React, { useMemo } from 'react'
 import { useAvatarUrl } from './hooks/use-avatar-url'
 
 export interface UserAvatarProps {
@@ -55,15 +53,6 @@ export const UserAvatar: React.FC<UserAvatarProps> = ({
   )
   const imgDescription = useTranslatedText('common.avatarOf', imageTranslateOptions)
 
-  const tooltip = useCallback(
-    (overlayInjectedProps: OverlayInjectedProps) => (
-      <Tooltip id={displayName} {...overlayInjectedProps}>
-        {displayName}
-      </Tooltip>
-    ),
-    [displayName]
-  )
-
   return (
     <span className={'d-inline-flex align-items-center ' + additionalClasses}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -76,9 +65,7 @@ export const UserAvatar: React.FC<UserAvatarProps> = ({
         width={imageSize}
       />
       <ShowIf condition={showName}>
-        <OverlayTrigger overlay={tooltip}>
-          <span className={`ms-2 me-1 ${styles['user-line-name']}`}>{displayName}</span>
-        </OverlayTrigger>
+        <span className={`ms-2 me-1 ${styles['user-line-name']}`}>{displayName}</span>
       </ShowIf>
     </span>
   )

--- a/frontend/src/components/landing-layout/navigation/user-dropdown.tsx
+++ b/frontend/src/components/landing-layout/navigation/user-dropdown.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */


### PR DESCRIPTION
### Component/Part
app bar user menu

### Description
This PR removes the tooltip from the user menu in the app bar

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x