### PR TITLE
fix(session-service): properly handle session store results 

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -115,7 +115,7 @@
     "supertest": "6.3.3",
     "ts-jest": "29.1.1",
     "ts-mockery": "1.2.0",
-    "ts-node": "10.9.1",
+    "ts-node": "https://github.com/TypeStrong/ts-node.git#main",
     "tsconfig-paths": "4.2.0",
     "typescript": "5.2.2"
   },

--- a/backend/src/realtime/websocket/websocket.gateway.ts
+++ b/backend/src/realtime/websocket/websocket.gateway.ts
@@ -128,10 +128,14 @@ export class WebsocketGateway implements OnGatewayConnection {
   ): Promise<User | null> {
     const sessionId = this.sessionService.extractSessionIdFromRequest(request);
 
+    this.logger.debug(
+      'Checking if sessionId is empty',
+      'findUserByRequestSession',
+    );
     if (sessionId.isEmpty()) {
       return null;
     }
-
+    this.logger.debug('sessionId is not empty', 'findUserByRequestSession');
     const username = await this.sessionService.fetchUsernameForSessionId(
       sessionId.get(),
     );

--- a/backend/src/sessions/session.module.ts
+++ b/backend/src/sessions/session.module.ts
@@ -6,11 +6,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { LoggerModule } from '../logger/logger.module';
 import { Session } from './session.entity';
 import { SessionService } from './session.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Session])],
+  imports: [TypeOrmModule.forFeature([Session]), LoggerModule],
   exports: [SessionService],
   providers: [SessionService],
 })

--- a/backend/src/sessions/session.service.spec.ts
+++ b/backend/src/sessions/session.service.spec.ts
@@ -11,9 +11,12 @@ import { IncomingMessage } from 'http';
 import { Mock } from 'ts-mockery';
 import { Repository } from 'typeorm';
 
+import { AppConfig } from '../config/app.config';
 import { AuthConfig } from '../config/auth.config';
 import { DatabaseType } from '../config/database-type.enum';
 import { DatabaseConfig } from '../config/database.config';
+import { Loglevel } from '../config/loglevel.enum';
+import { ConsoleLoggerService } from '../logger/console-logger.service';
 import { HEDGEDOC_SESSION } from '../utils/session';
 import { Session } from './session.entity';
 import { SessionService, SessionState } from './session.service';
@@ -63,6 +66,7 @@ describe('SessionService', () => {
       .mockReturnValue(mockedTypeormStore);
 
     sessionService = new SessionService(
+      new ConsoleLoggerService({ loglevel: Loglevel.DEBUG } as AppConfig),
       mockedSessionRepository,
       databaseConfigMock,
       authConfigMock,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2409,7 +2409,7 @@ __metadata:
     supertest: 6.3.3
     ts-jest: 29.1.1
     ts-mockery: 1.2.0
-    ts-node: 10.9.1
+    ts-node: "https://github.com/TypeStrong/ts-node.git#main"
     tsconfig-paths: 4.2.0
     typeorm: 0.3.17
     typescript: 5.2.2
@@ -4231,10 +4231,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsconfig/node14@npm:*":
+  version: 14.1.0
+  resolution: "@tsconfig/node14@npm:14.1.0"
+  checksum: 8342dc30edbfaed11d1659b1a9819779bb69df210974a9e8a337b0624b1d9f5026f37e2dcc1d555adb3e4246a0ec35896b3ae5fe3fc69f3382d3bc11069cecc1
+  languageName: node
+  linkType: hard
+
 "@tsconfig/node14@npm:^1.0.0":
   version: 1.0.3
   resolution: "@tsconfig/node14@npm:1.0.3"
   checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:*":
+  version: 16.1.1
+  resolution: "@tsconfig/node16@npm:16.1.1"
+  checksum: 26d83db06866083b543e73eda33585464362fd0835229b9a5b1185f0353b9b5db9ca4f66a4be53d4ec5d4c219be42b0a7582f8bcc7268f2f77b1c643375e490f
   languageName: node
   linkType: hard
 
@@ -4245,10 +4259,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node18@npm:18.2.2":
+"@tsconfig/node18@npm:*, @tsconfig/node18@npm:18.2.2":
   version: 18.2.2
   resolution: "@tsconfig/node18@npm:18.2.2"
   checksum: 1c4b04b570e33de14bf518492e077079db2dcfba738c8d40c6ff916d94c9410246f4cb56f0802d9771423862140bf714c35d4a5f6cec2446d851cf61d3f8f9df
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node20@npm:*":
+  version: 20.1.2
+  resolution: "@tsconfig/node20@npm:20.1.2"
+  checksum: fc126e15f0817bd328c15bd6be7972f01ef4d55ceb493c7a83ccb9dd545e39f218711f330e3df4072b116b11180c07943da2b2bfcd7adc58414cb586db52a4c8
   languageName: node
   linkType: hard
 
@@ -17478,6 +17499,41 @@ __metadata:
   peerDependencies:
     typescript: ">= 2.8"
   checksum: 01c5b8cbbc2b716ed96acbcc78679a27cc787b575a76fed7eb1beaa8deed8da274e091a9e7dcc77941e290f46481307b550b6e9799ba631410c5173a7be3f442
+  languageName: node
+  linkType: hard
+
+"ts-node@https://github.com/TypeStrong/ts-node.git#main":
+  version: 10.9.1
+  resolution: "ts-node@https://github.com/TypeStrong/ts-node.git#commit=0eb980f2b7e86801eca76782a323f7ad696784ab"
+  dependencies:
+    "@cspotcode/source-map-support": ^0.8.0
+    "@tsconfig/node14": "*"
+    "@tsconfig/node16": "*"
+    "@tsconfig/node18": "*"
+    "@tsconfig/node20": "*"
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.1
+  peerDependencies:
+    "@swc/core": ">=1.3.85"
+    "@swc/wasm": ">=1.3.85"
+    "@types/node": "*"
+    typescript: ">=4.4"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+  checksum: cc3d83097a18c8a4188e2f92b444220dac6b0a26f267eb6e66b66219d45691488296d7aba18caadaaf057bd6d59828bd90566c21ef5ba08274b9fb034cd27efa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
Previously, an undefined result in `fetchUsernameForSessionId`
was handled the same way as an error, rejecting the promise.

This fixes the behavior, only rejecting the promise if an error
is returned from the session store and properly returning
undefined if the session store returns that.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
