### PR TITLE
fix(codemirror): remove defect language highlighting

### DIFF
--- a/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
+++ b/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
@@ -9,7 +9,6 @@ import { useMayEdit } from '../../../hooks/common/use-may-edit'
 import { useTranslatedText } from '../../../hooks/common/use-translated-text'
 import { useDarkModeState } from '../../../hooks/dark-mode/use-dark-mode-state'
 import { cypressAttribute, cypressId } from '../../../utils/cypress-attribute'
-import { findLanguageByCodeBlockName } from '../../markdown-renderer/extensions/_base-classes/code-block-markdown-extension/find-language-by-code-block-name'
 import type { ScrollProps } from '../synced-scroll/scroll-props'
 import styles from './extended-codemirror/codemirror.module.scss'
 import { useCodeMirrorAutocompletionsExtension } from './hooks/codemirror-extensions/use-code-mirror-autocompletions-extension'
@@ -37,8 +36,6 @@ import { useLinter } from './linter/linter'
 import { MaxLengthWarning } from './max-length-warning/max-length-warning'
 import { StatusBar } from './status-bar/status-bar'
 import { ToolBar } from './tool-bar/tool-bar'
-import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
-import { languages } from '@codemirror/language-data'
 import { lintGutter } from '@codemirror/lint'
 import { oneDark } from '@codemirror/theme-one-dark'
 import ReactCodeMirror from '@uiw/react-codemirror'
@@ -94,10 +91,6 @@ export const EditorPane: React.FC<EditorPaneProps> = ({ scrollState, onScroll, o
     () => [
       linterExtension,
       lintGutter(),
-      markdown({
-        base: markdownLanguage,
-        codeLanguages: (input) => findLanguageByCodeBlockName(languages, input)
-      }),
       remoteCursorsExtension,
       lineWrappingExtension,
       editorScrollExtension,


### PR DESCRIPTION
### Component/Part
codemirror

### Description
This PR removes the language highlighting from the editor as it is defect and makes problems with Firefox.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
(follows)
