### PR TITLE
Readd languages

### DIFF
--- a/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
+++ b/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
@@ -9,6 +9,7 @@ import { useMayEdit } from '../../../hooks/common/use-may-edit'
 import { useTranslatedText } from '../../../hooks/common/use-translated-text'
 import { useDarkModeState } from '../../../hooks/dark-mode/use-dark-mode-state'
 import { cypressAttribute, cypressId } from '../../../utils/cypress-attribute'
+import { findLanguageByCodeBlockName } from '../../markdown-renderer/extensions/_base-classes/code-block-markdown-extension/find-language-by-code-block-name'
 import type { ScrollProps } from '../synced-scroll/scroll-props'
 import styles from './extended-codemirror/codemirror.module.scss'
 import { useCodeMirrorAutocompletionsExtension } from './hooks/codemirror-extensions/use-code-mirror-autocompletions-extension'
@@ -36,6 +37,8 @@ import { useLinter } from './linter/linter'
 import { MaxLengthWarning } from './max-length-warning/max-length-warning'
 import { StatusBar } from './status-bar/status-bar'
 import { ToolBar } from './tool-bar/tool-bar'
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
+import { languages } from '@codemirror/language-data'
 import { lintGutter } from '@codemirror/lint'
 import { oneDark } from '@codemirror/theme-one-dark'
 import ReactCodeMirror from '@uiw/react-codemirror'
@@ -91,6 +94,10 @@ export const EditorPane: React.FC<EditorPaneProps> = ({ scrollState, onScroll, o
     () => [
       linterExtension,
       lintGutter(),
+      markdown({
+        base: markdownLanguage,
+        codeLanguages: (input) => findLanguageByCodeBlockName(languages, input)
+      }),
       remoteCursorsExtension,
       lineWrappingExtension,
       editorScrollExtension,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@codemirror/language-data": "6.3.1",
     "@codemirror/lint": "6.4.2",
     "@codemirror/theme-one-dark": "6.1.2",
+    "@lezer/common": "1.1.0",
     "@types/react": "18.2.25",
     "eventemitter2@6.4.9": "patch:eventemitter2@npm%3A6.4.9#./.yarn/patches/eventemitter2-npm-6.4.9-ba37798a18.patch",
     "yjs@13.6.8": "patch:yjs@npm%3A13.6.8#./.yarn/patches/yjs-remove-import-warning-in-test.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3032,14 +3032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "@lezer/common@npm:1.0.4"
-  checksum: 0bea82da76e0b89afad4e5159d3add460022916352c47906ec67b26d6fe5ec9cb8e23df0e2bf0adef765ae78bed1706fc573a11506d01a80112a5b6dd317730c
-  languageName: node
-  linkType: hard
-
-"@lezer/common@npm:^1.1.0":
+"@lezer/common@npm:1.1.0":
   version: 1.1.0
   resolution: "@lezer/common@npm:1.1.0"
   checksum: 93c208a44d1c0bdf7407853ba7c4ddcedf1c52d1b82170813d83b9bd6301aa23587405ac54332fe39ce8bc37f706936ab237ceb4d3d535d1dead650153b6474c


### PR DESCRIPTION
### Component/Part
Editor code highlighting

### Description
This PR re-adds the code highlighting in the editor after fixing the codemirror errors.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

Closes https://github.com/hedgedoc/hedgedoc/issues/5049
