### PR TITLE
fix(editor): fix positions of tag migration lint

### DIFF
--- a/frontend/src/components/editor-page/editor-pane/linter/frontmatter-linter.spec.ts
+++ b/frontend/src/components/editor-page/editor-pane/linter/frontmatter-linter.spec.ts
@@ -45,8 +45,8 @@ describe('FrontmatterLinter', () => {
       testFrontmatterLinter(
         '---\ntags: a\n---',
         {
-          from: 5,
-          to: 12,
+          from: 4,
+          to: 11,
           severity: 'warning'
         },
         'tags:\n- a'
@@ -56,8 +56,8 @@ describe('FrontmatterLinter', () => {
       testFrontmatterLinter(
         '---\ntags: 1\n---',
         {
-          from: 5,
-          to: 12,
+          from: 4,
+          to: 11,
           severity: 'warning'
         },
         'tags:\n- 1'
@@ -67,8 +67,8 @@ describe('FrontmatterLinter', () => {
       testFrontmatterLinter(
         '---\ntags: 123, a\n---',
         {
-          from: 5,
-          to: 17,
+          from: 4,
+          to: 16,
           severity: 'warning'
         },
         'tags:\n- 123\n- a'

--- a/frontend/src/components/editor-page/editor-pane/linter/frontmatter-linter.ts
+++ b/frontend/src/components/editor-page/editor-pane/linter/frontmatter-linter.ts
@@ -60,7 +60,7 @@ export class FrontmatterLinter implements Linter {
     const replacedText = 'tags:\n- ' + tags.join('\n- ')
     const tagsLineIndex = frontmatterLines.findIndex((value) => value.startsWith('tags: '))
     const linesBeforeTagsLine = frontmatterLines.slice(0, tagsLineIndex)
-    const from = startOfYaml + linesBeforeTagsLine.join('\n').length + 1
+    const from = startOfYaml + linesBeforeTagsLine.join('\n').length + linesBeforeTagsLine.length
     const to = from + frontmatterLines[tagsLineIndex].length
     return [
       {


### PR DESCRIPTION
### Component/Part
Editor

### Description
This PR fixes the broken tag migration in the editor

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
