### PR TITLE
fix: rename "last updated at" sidebar entry

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -356,7 +356,7 @@
     "noteInfo": {
       "title": "Note info",
       "created": "Note created",
-      "lastUpdated": "Last updated",
+      "lastUpdated": "Last saved at",
       "lastUpdatedBy": "Last updated by",
       "contributors": "Count of contributors",
       "wordCount": "Count of words"

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/note-info-sidebar-menu/note-info-line/note-info-line-updated-at.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/note-info-sidebar-menu/note-info-line/note-info-line-updated-at.tsx
@@ -8,7 +8,7 @@ import { TimeFromNow } from '../../../../../common/time-from-now'
 import { SidebarMenuInfoEntry } from '../../../sidebar-menu-info-entry/sidebar-menu-info-entry'
 import { DateTime } from 'luxon'
 import React, { useMemo } from 'react'
-import { Pencil as IconPencil } from 'react-bootstrap-icons'
+import { Save as IconSave } from 'react-bootstrap-icons'
 import { useTranslation } from 'react-i18next'
 
 /**
@@ -23,7 +23,7 @@ export const NoteInfoLineUpdatedAt: React.FC = () => {
   )
 
   return !noteUpdateDateTime ? null : (
-    <SidebarMenuInfoEntry titleI18nKey={'editor.noteInfo.lastUpdated'} icon={IconPencil}>
+    <SidebarMenuInfoEntry titleI18nKey={'editor.noteInfo.lastUpdated'} icon={IconSave}>
       <TimeFromNow time={noteUpdateDateTime} />
     </SidebarMenuInfoEntry>
   )


### PR DESCRIPTION
### Component/Part
API and Frontend

### Description
This PR:
- renames "last updated at" to "last saved at" because it actually represents the time when the last revision has been saved

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
