### PR TITLE
ci: build docker images for tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,7 @@ name: Docker
 on:
   push:
     branches: [ develop ]
+    tags: [ v2* ]
 
 permissions:
   contents: read


### PR DESCRIPTION
### Component/Part
CI

### Description
The Docker workflow should now run when tags starting with `v2` are created and push a corresponding image.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
