### PR TITLE
docs: add alpha version warning to setup instructions 

### DIFF
--- a/docs/content/files/setup-docker/docker-compose.yml
+++ b/docs/content/files/setup-docker/docker-compose.yml
@@ -1,17 +1,17 @@
 services:
   backend:
-    image: ghcr.io/hedgedoc/hedgedoc/backend:2.0-alpha
+    image: ghcr.io/hedgedoc/hedgedoc/backend:2.0.0-alpha.1
     volumes:
       - $PWD/.env:/usr/src/app/backend/.env
       - hedgedoc_uploads:/usr/src/app/backend/uploads
 
   frontend:
-    image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0-alpha
+    image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0.0-alpha.1
     environment:
       HD_BASE_URL: "${HD_BASE_URL}"
 
   db:
-    image: postgres:15
+    image: postgres:16
     environment:
       POSTGRES_USER: "${HD_DATABASE_USER}"
       POSTGRES_PASSWORD: "${HD_DATABASE_PASS}"

--- a/docs/content/how-to/reverse-proxy.md
+++ b/docs/content/how-to/reverse-proxy.md
@@ -25,7 +25,7 @@ in your `docker-compose.yml`:
 ??? abstract "docker-compose.yml"
     ```yaml
     backend:
-      image: ghcr.io/hedgedoc/hedgedoc/backend:2.0-alpha
+      image: ghcr.io/hedgedoc/hedgedoc/backend:2.0.0-alpha.1
       volumes:
         - $PWD/.env:/usr/src/app/backend/.env
         - hedgedoc_uploads:/usr/src/app/backend/uploads
@@ -37,7 +37,7 @@ in your `docker-compose.yml`:
         traefik.http.services.hedgedoc_2_backend.loadbalancer.server.port: "3000"
         traefik.http.services.hedgedoc_2_backend.loadbalancer.server.scheme: "http"
     frontend:
-      image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0-alpha
+      image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0.0-alpha.1
       environment:
         HD_BASE_URL: "${HD_BASE_URL}"
       labels:
@@ -79,14 +79,14 @@ you need to add the `ports` entry for both `backend` and `frontend` as following
 ??? abstract "docker-compose.yml"
     ```yaml
     backend:
-      image: ghcr.io/hedgedoc/hedgedoc/backend:2.0-alpha
+      image: ghcr.io/hedgedoc/hedgedoc/backend:2.0.0-alpha.1
       volumes:
         - $PWD/.env:/usr/src/app/backend/.env
         - hedgedoc_uploads:/usr/src/app/backend/uploads
       ports:
         - "3000:3000"
     frontend:
-      image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0-alpha
+      image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0.0-alpha.1
       environment:
         HD_BASE_URL: "${HD_BASE_URL}"
       ports:

--- a/docs/content/tutorials/setup.md
+++ b/docs/content/tutorials/setup.md
@@ -3,6 +3,12 @@
 After completing this tutorial you'll have your own HedgeDoc instance running.
 We will use [Docker][docker-docs] to accomplish this.
 
+!!! warning "HedgeDoc 2 is currently in alpha"
+    Alpha releases come with no guarantees regarding upgradeability.
+    It is very likely that you will need to wipe the database between alpha releases.  
+    Please set up a separate instance to test HedgeDoc 2, there is currently no migration path
+    from HedgeDoc 1.
+
 <!-- markdownlint-disable proper-names -->
 
 1. Open the terminal of the machine you want to install HedgeDoc on.


### PR DESCRIPTION
### Component/Part
docs

### Description
This PR adjusts the docs for the upcoming alpha release

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
