### PR TITLE
docs: add faq entry about fork awesome deprecation

### DIFF
--- a/docs/content/faq/index.md
+++ b/docs/content/faq/index.md
@@ -97,3 +97,12 @@ However, you can run HedgeDoc without this extra security, but we recommend usin
     needs to be adjusted to direct requests for this domain to the frontend.
 
 [xss]: https://en.wikipedia.org/wiki/Cross-site_scripting
+
+## Why are forkawesome icons deprecated?
+
+As forkawesome icons are not really well maintained, we decided to replace them with
+[bootstrap icons][bootstrap-icons]. To keep the compatibility with HedgeDoc 1 notes
+we still import them, but will likely remove those icons at some point. So your
+best take of action is replacing these icons with [bootstrap icons][bootstrap-icons].
+
+[bootstrap-icons]: https://icons.getbootstrap.com/

--- a/frontend/src/extensions/essential-app-extensions/fork-awesome-html-tag/fork-awesome-html-tag-app-extension.ts
+++ b/frontend/src/extensions/essential-app-extensions/fork-awesome-html-tag/fork-awesome-html-tag-app-extension.ts
@@ -18,8 +18,7 @@ export class ForkAwesomeHtmlTagAppExtension extends AppExtension {
     return [
       new SingleLineRegexLinter(
         forkAwesomeRegex,
-        // ToDo: Add correct link here (https://github.com/hedgedoc/hedgedoc/issues/5021)
-        t('editor.linter.fork-awesome', { link: 'https://docs.hedgedoc.org' })
+        t('editor.linter.fork-awesome', { link: 'https://docs.hedgedoc.dev/faq/#why-are-forkawesome-icons-deprecated' })
       )
     ]
   }


### PR DESCRIPTION
### Component/Part
docs and ForkAwesomeHtmlTagAppExtension

### Description
This PR adds the FAQ entry for fork awesome depcreation and adds the correct link to the ForkAwesomeHtmlTagAppExtension component

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #5021
