### PR TITLE
docs: add readme note about docs.hedgedoc.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Information for setting up a local development environment can be found in the [
 ## HedgeDoc 2 Alpha
 Curious about the new look and feel of HedgeDoc 2? We provide a demo of the alpha on [hedgedoc.dev](https://hedgedoc.dev).
 
+If you want to try it out on your own devices, visit the [HedgeDoc 2 docs](https://docs.hedgedoc.dev).
+But be aware that these may change over time.
+
 ## Contributions
 
 We welcome contributions!  


### PR DESCRIPTION
### Component/Part
readme

### Description
This PR adds a note about docs.hedgedoc.dev on the readme.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
