### PR TITLE
fix internal api url

### DIFF
--- a/frontend/src/api/common/api-request-builder/api-request-builder.ts
+++ b/frontend/src/api/common/api-request-builder/api-request-builder.ts
@@ -39,7 +39,20 @@ export abstract class ApiRequestBuilder<ResponseType> {
    * @return the base url
    */
   private determineBaseUrl(baseUrl?: string) {
-    return typeof window !== 'undefined' ? baseUrl ?? '/' : baseUrlFromEnvExtractor.extractBaseUrls().internalApiUrl
+    if (this.isSSR()) {
+      const internalApiUrl = baseUrlFromEnvExtractor.extractBaseUrls().internalApiUrl
+      const actualBaseUrl = internalApiUrl ?? baseUrl
+      if (actualBaseUrl === undefined) {
+        throw new Error("Can't make request without forced base url and without internal api url")
+      }
+      return actualBaseUrl
+    } else {
+      return baseUrl ?? '/'
+    }
+  }
+
+  private isSSR() {
+    return typeof window === 'undefined'
   }
 
   protected async sendRequestAndVerifyResponse(httpMethod: RequestInit['method']): Promise<ApiResponse<ResponseType>> {

--- a/frontend/src/components/common/base-url/base-url-context-provider.tsx
+++ b/frontend/src/components/common/base-url/base-url-context-provider.tsx
@@ -10,7 +10,7 @@ import React, { createContext } from 'react'
 export interface BaseUrls {
   renderer: string
   editor: string
-  internalApiUrl: string
+  internalApiUrl: string | undefined
 }
 
 interface BaseUrlContextProviderProps {

--- a/frontend/src/utils/base-url-from-env-extractor.spec.ts
+++ b/frontend/src/utils/base-url-from-env-extractor.spec.ts
@@ -83,7 +83,7 @@ describe('BaseUrlFromEnvExtractor', () => {
     expect(() => sut.extractBaseUrls()).toThrow()
   })
 
-  it('should copy editor base url to renderer base/internal api url if url is omitted', () => {
+  it('should copy editor base url to renderer base url if url is omitted', () => {
     process.env.HD_BASE_URL = 'https://editor1.example.org/'
     delete process.env.HD_RENDERER_BASE_URL
     delete process.env.HD_INTERNAL_API_URL
@@ -91,7 +91,7 @@ describe('BaseUrlFromEnvExtractor', () => {
 
     expect(sut.extractBaseUrls()).toStrictEqual({
       renderer: 'https://editor1.example.org/',
-      internalApiUrl: 'https://editor1.example.org/',
+      internalApiUrl: undefined,
       editor: 'https://editor1.example.org/'
     })
   })


### PR DESCRIPTION
### Component/Part
internal api url

### Description
This PR fixes a bug when NOT setting the internal API URL.
If the env var is not set the renderer may use editor URL which can cause problem if they're not the same.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
