### PR TITLE
fix: support dots in semver prerelease identifier

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hedgedoc/backend",
-  "version": "2.0.0-dev",
+  "version": "2.0.0-alpha.1",
   "description": "Realtime collaborative markdown notes on all platforms.",
   "author": "",
   "private": true,

--- a/backend/src/utils/serverVersion.ts
+++ b/backend/src/utils/serverVersion.ts
@@ -32,7 +32,7 @@ async function parseVersionFromPackageJson(): Promise<ServerVersion> {
   const packageInfo = JSON.parse(rawFileContent) as { version: string };
   const versionParts = Optional.ofNullable(packageInfo.version)
     .orThrow(() => new Error('No version found in root package.json'))
-    .map((version) => /^(\d+).(\d+).(\d+)(?:-(\w+))?$/g.exec(version))
+    .map((version) => /^(\d+).(\d+).(\d+)(?:-([\w.]+))?$/g.exec(version))
     .orElseThrow(
       () =>
         new Error(

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hedgedoc/docs",
-  "version": "2.0.0-dev",
+  "version": "2.0.0-alpha.1",
   "license": "AGPL-3.0",
   "scripts": {
     "lint": "markdownlint-cli2 content/**/*.md",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hedgedoc/frontend",
-  "version": "2.0.0-dev",
+  "version": "2.0.0-alpha.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
### Component/Part
version parsing

### Description
This PR fixes/adds/improves/...

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
