### PR TITLE
chore(deps): use the same ts-node version in frontend/backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -116,7 +116,7 @@
     "supertest": "6.3.3",
     "ts-jest": "29.1.1",
     "ts-mockery": "1.2.0",
-    "ts-node": "https://github.com/TypeStrong/ts-node.git#main",
+    "ts-node": "https://github.com/TypeStrong/ts-node.git#0eb980f2b7e86801eca76782a323f7ad696784ab",
     "tsconfig-paths": "4.2.0",
     "typescript": "5.2.2"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -171,7 +171,7 @@
     "react-test-renderer": "18.2.0",
     "ts-loader": "9.5.0",
     "ts-mockery": "1.2.0",
-    "ts-node": "10.9.1",
+    "ts-node": "https://github.com/TypeStrong/ts-node.git#0eb980f2b7e86801eca76782a323f7ad696784ab",
     "typescript": "5.2.2",
     "user-agent-data-types": "0.4.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2409,7 +2409,7 @@ __metadata:
     supertest: 6.3.3
     ts-jest: 29.1.1
     ts-mockery: 1.2.0
-    ts-node: "https://github.com/TypeStrong/ts-node.git#main"
+    ts-node: "https://github.com/TypeStrong/ts-node.git#0eb980f2b7e86801eca76782a323f7ad696784ab"
     tsconfig-paths: 4.2.0
     typeorm: 0.3.17
     typescript: 5.2.2
@@ -2588,7 +2588,7 @@ __metadata:
     tlds: 1.242.0
     ts-loader: 9.5.0
     ts-mockery: 1.2.0
-    ts-node: 10.9.1
+    ts-node: "https://github.com/TypeStrong/ts-node.git#0eb980f2b7e86801eca76782a323f7ad696784ab"
     twemoji-colr-font: 14.1.3
     typescript: 5.2.2
     user-agent-data-types: 0.4.2
@@ -4210,20 +4210,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node10@npm:^1.0.7":
-  version: 1.0.9
-  resolution: "@tsconfig/node10@npm:1.0.9"
-  checksum: a33ae4dc2a621c0678ac8ac4bceb8e512ae75dac65417a2ad9b022d9b5411e863c4c198b6ba9ef659e14b9fb609bbec680841a2e84c1172df7a5ffcf076539df
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node12@npm:^1.0.7":
-  version: 1.0.11
-  resolution: "@tsconfig/node12@npm:1.0.11"
-  checksum: 5ce29a41b13e7897a58b8e2df11269c5395999e588b9a467386f99d1d26f6c77d1af2719e407621412520ea30517d718d5192a32403b8dfcc163bf33e40a338a
-  languageName: node
-  linkType: hard
-
 "@tsconfig/node14@npm:*":
   version: 14.1.0
   resolution: "@tsconfig/node14@npm:14.1.0"
@@ -4231,24 +4217,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node14@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "@tsconfig/node14@npm:1.0.3"
-  checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
-  languageName: node
-  linkType: hard
-
 "@tsconfig/node16@npm:*":
   version: 16.1.1
   resolution: "@tsconfig/node16@npm:16.1.1"
   checksum: 26d83db06866083b543e73eda33585464362fd0835229b9a5b1185f0353b9b5db9ca4f66a4be53d4ec5d4c219be42b0a7582f8bcc7268f2f77b1c643375e490f
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node16@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "@tsconfig/node16@npm:1.0.4"
-  checksum: 202319785901f942a6e1e476b872d421baec20cf09f4b266a1854060efbf78cde16a4d256e8bc949d31e6cd9a90f1e8ef8fb06af96a65e98338a2b6b0de0a0ff
   languageName: node
   linkType: hard
 
@@ -7597,13 +7569,6 @@ __metadata:
   bin:
     create-jest: bin/create-jest.js
   checksum: 1427d49458adcd88547ef6fa39041e1fe9033a661293aa8d2c3aa1b4967cb5bf4f0c00436c7a61816558f28ba2ba81a94d5c962e8022ea9a883978fc8e1f2945
-  languageName: node
-  linkType: hard
-
-"create-require@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "create-require@npm:1.1.1"
-  checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
   languageName: node
   linkType: hard
 
@@ -17495,7 +17460,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node@https://github.com/TypeStrong/ts-node.git#main":
+"ts-node@https://github.com/TypeStrong/ts-node.git#0eb980f2b7e86801eca76782a323f7ad696784ab":
   version: 10.9.1
   resolution: "ts-node@https://github.com/TypeStrong/ts-node.git#commit=0eb980f2b7e86801eca76782a323f7ad696784ab"
   dependencies:
@@ -17527,44 +17492,6 @@ __metadata:
     ts-node-script: dist/bin-script.js
     ts-node-transpile-only: dist/bin-transpile.js
   checksum: cc3d83097a18c8a4188e2f92b444220dac6b0a26f267eb6e66b66219d45691488296d7aba18caadaaf057bd6d59828bd90566c21ef5ba08274b9fb034cd27efa
-  languageName: node
-  linkType: hard
-
-"ts-node@npm:10.9.1":
-  version: 10.9.1
-  resolution: "ts-node@npm:10.9.1"
-  dependencies:
-    "@cspotcode/source-map-support": ^0.8.0
-    "@tsconfig/node10": ^1.0.7
-    "@tsconfig/node12": ^1.0.7
-    "@tsconfig/node14": ^1.0.0
-    "@tsconfig/node16": ^1.0.2
-    acorn: ^8.4.1
-    acorn-walk: ^8.1.1
-    arg: ^4.1.0
-    create-require: ^1.1.0
-    diff: ^4.0.1
-    make-error: ^1.1.1
-    v8-compile-cache-lib: ^3.0.1
-    yn: 3.1.1
-  peerDependencies:
-    "@swc/core": ">=1.2.50"
-    "@swc/wasm": ">=1.2.50"
-    "@types/node": "*"
-    typescript: ">=2.7"
-  peerDependenciesMeta:
-    "@swc/core":
-      optional: true
-    "@swc/wasm":
-      optional: true
-  bin:
-    ts-node: dist/bin.js
-    ts-node-cwd: dist/bin-cwd.js
-    ts-node-esm: dist/bin-esm.js
-    ts-node-script: dist/bin-script.js
-    ts-node-transpile-only: dist/bin-transpile.js
-    ts-script: dist/bin-script-deprecated.js
-  checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
   languageName: node
   linkType: hard
 
@@ -19282,13 +19209,6 @@ __metadata:
   dependencies:
     lib0: ^0.2.74
   checksum: a8bc68a8ce83d9e2c497d8d849a8557c2ab8a87950e4057762c81f28e78266c2f632a493d22a775eeab315643f18ea02498cb978dc58ce38dd7e9d32a45f9f97
-  languageName: node
-  linkType: hard
-
-"yn@npm:3.1.1":
-  version: 3.1.1
-  resolution: "yn@npm:3.1.1"
-  checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
dependencies

### Description
This PR changes the specified version from main branch to a specific commit. Hopefully this changes will result in (better) caching of the ts-node package, especially in the GitHub CI. By setting a specific commit, the package is also pinned like all other dependencies and therefore ensures a more predictionable behaviour.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
