### PR TITLE
enhancement(autocomplete): add generic code suggestion entry

### DIFF
--- a/frontend/src/extensions/essential-app-extensions/highlighted-code-fence/highlighted-code-fence-app-extension.ts
+++ b/frontend/src/extensions/essential-app-extensions/highlighted-code-fence/highlighted-code-fence-app-extension.ts
@@ -10,6 +10,7 @@ import { AppExtension } from '../../_base-classes/app-extension'
 import { HighlightedCodeMarkdownExtension } from './highlighted-code-markdown-extension'
 import type { CompletionContext, CompletionResult, CompletionSource } from '@codemirror/autocomplete'
 import { languages } from '@codemirror/language-data'
+import { t } from 'i18next'
 
 /**
  * Adds code highlighting to the markdown rendering.
@@ -29,6 +30,16 @@ export class HighlightedCodeFenceAppExtension extends AppExtension {
   }
 
   buildAutocompletion(): CompletionSource[] {
+    const completions = [
+      {
+        detail: t('editor.editorToolbar.code'),
+        label: '```\n\n```'
+      },
+      ...languages.map((lang) => ({
+        detail: lang.name,
+        label: '```' + lang.alias[0] + '\n\n```'
+      }))
+    ]
     return [
       (context: CompletionContext): CompletionResult | null => {
         const match = context.matchBefore(codeFenceRegex)
@@ -37,10 +48,7 @@ export class HighlightedCodeFenceAppExtension extends AppExtension {
         }
         return {
           from: match.from,
-          options: languages.map((lang) => ({
-            detail: lang.name,
-            label: '```' + lang.alias[0] + '\n\n```'
-          }))
+          options: completions
         }
       }
     ]


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
This PR adds a generic code block autocomplete suggestion before the language-specific entries.
By this the accidental usage of abc music notation as language is prevented.

![image](https://github.com/hedgedoc/hedgedoc/assets/52606896/58d87330-a6cf-4c56-8b13-9d09b5bd8180)


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [X] Added implementation
- [X] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5093 
