### PR TITLE
feat(motd): read motd in RSC and provide via context

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Run server
         working-directory: frontend/
-        run: (screen -dmS server -L yarn start) && sleep 3 && (tail -f screenlog.0 &)
+        run: screen -dmS server -L yarn start
         env:
           NODE_ENV: test
           HOSTNAME: "127.0.0.1"
@@ -194,7 +194,7 @@ jobs:
           PORT: 3001
 
       - name: Wait for server
-        run: "curl -L --max-time 120 http://127.0.0.1:3001/"
+        run: "sleep 3 && curl -L --max-time 120 http://127.0.0.1:3001/"
 
       - name: Run cypress
         run: yarn test:e2e:ci --filter=frontend
@@ -208,6 +208,13 @@ jobs:
           CYPRESS_CONTAINER_ID: ${{ matrix.containers }}
 
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # master
+        if: always()
+        with:
+          name: screenlog
+          path: frontend/screenlog.0
+
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # master
+        if: always()
         with:
           name: screenshots
           path: cypress/screenshots

--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -42,7 +42,12 @@ cp -R .next/static dist/frontend/.next/static
 cp next.config.js dist/frontend/next.config.js
 cp -R public dist/frontend/public
 rm -f dist/frontend/.env
-rm -rf dist/frontend/public/public
+
+if [ "${NODE_ENV}" = "production" ]; then
+    echo "🦔 > Remove public directory because this is a production build"
+    rm -rf dist/frontend/public/public
+fi
+
 rm -rf dist/frontend/src
 
 echo "🦔 > Done! You can run the build by going into the dist directory and executing \`node frontend/server.js\`"

--- a/frontend/cypress/e2e/motd.spec.ts
+++ b/frontend/cypress/e2e/motd.spec.ts
@@ -5,29 +5,18 @@
  */
 
 const MOTD_LOCAL_STORAGE_KEY = 'motd.lastModified'
-const MOCK_LAST_MODIFIED = 'mockETag'
-const motdMockContent = 'This is the **mock** Motd call'
-const motdMockHtml = 'This is the <strong>mock</strong> Motd call'
+const motdMockHtml = 'This is the test motd text'
 
 describe('Motd', () => {
   it("shows, dismisses and won't show again a motd modal", () => {
     localStorage.removeItem(MOTD_LOCAL_STORAGE_KEY)
-    cy.intercept('GET', '/public/motd.md', {
-      statusCode: 200,
-      headers: { 'Last-Modified': MOCK_LAST_MODIFIED },
-      body: motdMockContent
-    })
 
-    cy.intercept('HEAD', '/public/motd.md', {
-      statusCode: 200,
-      headers: { 'Last-Modified': MOCK_LAST_MODIFIED }
-    })
     cy.visitHistory()
-    cy.getSimpleRendererBody().should('contain.html', motdMockHtml)
+    cy.getSimpleRendererBody().should('contain.text', motdMockHtml)
     cy.getByCypressId('motd-dismiss')
       .click()
       .then(() => {
-        expect(localStorage.getItem(MOTD_LOCAL_STORAGE_KEY)).to.equal(MOCK_LAST_MODIFIED)
+        expect(localStorage.getItem(MOTD_LOCAL_STORAGE_KEY)).not.to.be.eq(null)
       })
     cy.getByCypressId('motd-modal').should('not.exist')
     cy.reload()

--- a/frontend/cypress/e2e/motd.spec.ts
+++ b/frontend/cypress/e2e/motd.spec.ts
@@ -4,19 +4,20 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-const MOTD_LOCAL_STORAGE_KEY = 'motd.lastModified'
+import { MOTD_LOCAL_STORAGE_KEY } from '../../src/components/global-dialogs/motd-modal/local-storage-keys'
+
 const motdMockHtml = 'This is the test motd text'
 
 describe('Motd', () => {
   it("shows, dismisses and won't show again a motd modal", () => {
-    localStorage.removeItem(MOTD_LOCAL_STORAGE_KEY)
+    window.localStorage.removeItem(MOTD_LOCAL_STORAGE_KEY)
 
     cy.visitHistory()
     cy.getSimpleRendererBody().should('contain.text', motdMockHtml)
     cy.getByCypressId('motd-dismiss')
       .click()
       .then(() => {
-        expect(localStorage.getItem(MOTD_LOCAL_STORAGE_KEY)).not.to.be.eq(null)
+        expect(window.localStorage.getItem(MOTD_LOCAL_STORAGE_KEY)).not.to.be.eq(null)
       })
     cy.getByCypressId('motd-modal').should('not.exist')
     cy.reload()

--- a/frontend/cypress/support/config.ts
+++ b/frontend/cypress/support/config.ts
@@ -5,6 +5,7 @@
  */
 import { AuthProviderType } from '../../src/api/config/types'
 import { HttpMethod } from '../../src/handler-utils/respond-to-matching-request'
+import { IGNORE_MOTD, MOTD_LOCAL_STORAGE_KEY } from '../../src/components/global-dialogs/motd-modal/local-storage-keys'
 
 declare namespace Cypress {
   interface Chainable {
@@ -87,6 +88,7 @@ Cypress.Commands.add('logOut', () => {
 
 beforeEach(() => {
   cy.loadConfig()
+  window.localStorage.setItem(MOTD_LOCAL_STORAGE_KEY, IGNORE_MOTD)
   cy.logIn()
 
   cy.intercept('GET', '/public/motd.md', {

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -506,7 +506,8 @@
       },
       "instance": {
         "header": "About this instance",
-        "versionInfo": "Running version"
+        "versionInfo": "Running version",
+        "motdModal": "Show instance announcement"
       },
       "legal": {
         "header": "Legal",
@@ -596,7 +597,7 @@
     }
   },
   "motd": {
-    "title": "Information"
+    "title": "Announcement"
   },
   "errors": {
     "notFound": {

--- a/frontend/src/components/global-dialogs/motd-modal/cached-motd-modal.tsx
+++ b/frontend/src/components/global-dialogs/motd-modal/cached-motd-modal.tsx
@@ -1,0 +1,44 @@
+'use client'
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import React, { useCallback, useMemo, useState } from 'react'
+import { useMotdContextValue } from '../../motd/motd-context'
+import { useLocalStorage } from 'react-use'
+import { MOTD_LOCAL_STORAGE_KEY } from './fetch-motd'
+import { MotdModal } from './motd-modal'
+import { testId } from '../../../utils/test-id'
+
+/**
+ * Reads the motd from the context and shows it in a modal.
+ * If the modal gets dismissed by the user then the "last modified" identifier will be written into the local storage
+ * to prevent that the motd will be shown again until it gets changed.
+ */
+export const CachedMotdModal: React.FC = () => {
+  const contextValue = useMotdContextValue()
+  const [cachedLastModified, saveLocalStorage] = useLocalStorage<string>(MOTD_LOCAL_STORAGE_KEY, undefined)
+
+  const [dismissed, setDismissed] = useState(false)
+
+  const show = useMemo(() => {
+    const lastModified = contextValue?.lastModified
+    return cachedLastModified !== lastModified && lastModified !== undefined && !dismissed
+  }, [cachedLastModified, contextValue?.lastModified, dismissed])
+
+  const doDismiss = useCallback(() => {
+    const lastModified = contextValue?.lastModified
+    if (lastModified) {
+      saveLocalStorage(lastModified)
+    }
+    setDismissed(true)
+  }, [contextValue, saveLocalStorage])
+
+  if (contextValue?.lastModified === undefined && process.env.NODE_ENV === 'test') {
+    return <span {...testId('loaded not visible')} />
+  }
+
+  return <MotdModal show={show} onDismiss={doDismiss}></MotdModal>
+}

--- a/frontend/src/components/global-dialogs/motd-modal/fetch-motd.ts
+++ b/frontend/src/components/global-dialogs/motd-modal/fetch-motd.ts
@@ -5,8 +5,6 @@
  */
 import { defaultConfig } from '../../../api/common/default-config'
 
-export const MOTD_LOCAL_STORAGE_KEY = 'motd.lastModified'
-
 export interface MotdApiResponse {
   motdText: string
   lastModified: string

--- a/frontend/src/components/global-dialogs/motd-modal/fetch-motd.ts
+++ b/frontend/src/components/global-dialogs/motd-modal/fetch-motd.ts
@@ -4,14 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { defaultConfig } from '../../../api/common/default-config'
-import { Logger } from '../../../utils/logger'
 
 export const MOTD_LOCAL_STORAGE_KEY = 'motd.lastModified'
-const log = new Logger('Motd')
 
 export interface MotdApiResponse {
   motdText: string
-  lastModified: string | null
+  lastModified: string
 }
 
 /**
@@ -21,36 +19,23 @@ export interface MotdApiResponse {
  * will be compared to the saved value from the browser's local storage.
  * @return A promise that gets resolved if the motd was fetched successfully.
  */
-export const fetchMotd = async (): Promise<MotdApiResponse | undefined> => {
-  const cachedLastModified = window.localStorage.getItem(MOTD_LOCAL_STORAGE_KEY)
-  const motdUrl = `/public/motd.md`
-
-  if (cachedLastModified) {
-    const response = await fetch(motdUrl, {
-      ...defaultConfig,
-      method: 'HEAD'
-    })
-    if (response.status !== 200) {
-      return undefined
-    }
-    const lastModified = response.headers.get('Last-Modified') || response.headers.get('etag')
-    if (lastModified === cachedLastModified) {
-      return undefined
-    }
-  }
-
+export const fetchMotd = async (baseUrl: string): Promise<MotdApiResponse | undefined> => {
+  const motdUrl = `${baseUrl}public/motd.md`
   const response = await fetch(motdUrl, {
     ...defaultConfig
   })
 
   if (response.status !== 200) {
-    return undefined
+    return
   }
 
   const lastModified = response.headers.get('Last-Modified') || response.headers.get('etag')
-  if (!lastModified) {
-    log.warn("'Last-Modified' or 'Etag' not found for motd.md!")
+  if (lastModified === null) {
+    return
   }
 
-  return { motdText: await response.text(), lastModified }
+  return {
+    lastModified,
+    motdText: await response.text()
+  }
 }

--- a/frontend/src/components/global-dialogs/motd-modal/local-storage-keys.ts
+++ b/frontend/src/components/global-dialogs/motd-modal/local-storage-keys.ts
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export const MOTD_LOCAL_STORAGE_KEY: string = 'motd.lastModified'
+export const IGNORE_MOTD: string = 'IGNORE_MOTD'

--- a/frontend/src/components/global-dialogs/motd-modal/motd-modal.spec.tsx
+++ b/frontend/src/components/global-dialogs/motd-modal/motd-modal.spec.tsx
@@ -9,13 +9,12 @@ import { testId } from '../../../utils/test-id'
 import type { CommonModalProps } from '../../common/modals/common-modal'
 import * as CommonModalModule from '../../common/modals/common-modal'
 import * as RendererIframeModule from '../../common/renderer-iframe/renderer-iframe'
-import * as fetchMotdModule from './fetch-motd'
-import { MotdModal } from './motd-modal'
 import { act, render, screen } from '@testing-library/react'
 import type { PropsWithChildren } from 'react'
 import React from 'react'
+import { CachedMotdModal } from './cached-motd-modal'
+import { MotdProvider } from '../../motd/motd-context'
 
-jest.mock('./fetch-motd')
 jest.mock('../../common/modals/common-modal')
 jest.mock('../../common/renderer-iframe/renderer-iframe')
 jest.mock('../../../hooks/common/use-base-url')
@@ -49,13 +48,15 @@ describe('motd modal', () => {
   })
 
   it('renders a modal if a motd was fetched and can dismiss it', async () => {
-    jest.spyOn(fetchMotdModule, 'fetchMotd').mockImplementation(() => {
-      return Promise.resolve({
-        motdText: 'very important mock text!',
-        lastModified: 'yesterday'
-      })
-    })
-    const view = render(<MotdModal></MotdModal>)
+    const motd = {
+      motdText: 'very important mock text!',
+      lastModified: 'yesterday'
+    }
+    const view = render(
+      <MotdProvider motd={motd}>
+        <CachedMotdModal></CachedMotdModal>
+      </MotdProvider>
+    )
     await screen.findByTestId('motd-renderer')
     expect(view.container).toMatchSnapshot()
 
@@ -67,10 +68,11 @@ describe('motd modal', () => {
   })
 
   it("doesn't render a modal if no motd has been fetched", async () => {
-    jest.spyOn(fetchMotdModule, 'fetchMotd').mockImplementation(() => {
-      return Promise.resolve(undefined)
-    })
-    const view = render(<MotdModal></MotdModal>)
+    const view = render(
+      <MotdProvider motd={undefined}>
+        <CachedMotdModal></CachedMotdModal>
+      </MotdProvider>
+    )
     await screen.findByTestId('loaded not visible')
     expect(view.container).toMatchSnapshot()
   })

--- a/frontend/src/components/layout/app-bar/app-bar-elements/help-dropdown/submenues/instance-submenu.tsx
+++ b/frontend/src/components/layout/app-bar/app-bar-elements/help-dropdown/submenues/instance-submenu.tsx
@@ -6,6 +6,7 @@
 import { DropdownHeader } from '../dropdown-header'
 import { VersionInfoHelpMenuEntry } from './instance/version-info-help-menu-entry'
 import React, { Fragment } from 'react'
+import { MotdModalHelpMenuEntry } from './instance/motd-modal-help-menu-entry'
 
 /**
  * Renders the instance submenu for the help dropdown.
@@ -15,6 +16,7 @@ export const InstanceSubmenu: React.FC = () => {
     <Fragment>
       <DropdownHeader i18nKey={'appbar.help.instance.header'} />
       <VersionInfoHelpMenuEntry />
+      <MotdModalHelpMenuEntry />
     </Fragment>
   )
 }

--- a/frontend/src/components/layout/app-bar/app-bar-elements/help-dropdown/submenues/instance/motd-modal-help-menu-entry.tsx
+++ b/frontend/src/components/layout/app-bar/app-bar-elements/help-dropdown/submenues/instance/motd-modal-help-menu-entry.tsx
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, { Fragment } from 'react'
+import { TranslatedDropdownItem } from '../../translated-dropdown-item'
+import { InfoCircleFill as IconInfoCircleFill } from 'react-bootstrap-icons'
+import { useBooleanState } from '../../../../../../../hooks/common/use-boolean-state'
+import { MotdModal } from '../../../../../../global-dialogs/motd-modal/motd-modal'
+import { useMotdContextValue } from '../../../../../../motd/motd-context'
+
+/**
+ * Help menu entry for the motd modal.
+ * When no modal content is defined, the menu entry will not render.
+ */
+export const MotdModalHelpMenuEntry: React.FC = () => {
+  const [modalVisibility, showModal, closeModal] = useBooleanState(false)
+  const contextValue = useMotdContextValue()
+
+  if (!contextValue) {
+    return null
+  }
+
+  return (
+    <Fragment>
+      <TranslatedDropdownItem
+        icon={IconInfoCircleFill}
+        i18nKey={'appbar.help.instance.motdModal'}
+        onClick={showModal}
+      />
+      <MotdModal show={modalVisibility} onDismiss={closeModal} />
+    </Fragment>
+  )
+}

--- a/frontend/src/components/layout/expected-origin-boundary.tsx
+++ b/frontend/src/components/layout/expected-origin-boundary.tsx
@@ -38,7 +38,9 @@ export const ExpectedOriginBoundary: React.FC<ExpectedOriginBoundaryProps> = ({ 
   const currentOrigin = buildOriginFromHeaders()
 
   if (new URL(expectedOrigin).origin !== currentOrigin) {
-    return <span>{`You can't open this page using this URL. For this endpoint "${expectedOrigin}" is expected.`}</span>
+    return (
+      <span>{`You can't open this page using this URL. For this endpoint "${expectedOrigin}" is expected but got "${currentOrigin}".`}</span>
+    )
   }
   return children
 }

--- a/frontend/src/components/motd/motd-context.tsx
+++ b/frontend/src/components/motd/motd-context.tsx
@@ -1,0 +1,25 @@
+'use client'
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { PropsWithChildren } from 'react'
+import { createContext, useContext } from 'react'
+import React from 'react'
+import type { MotdApiResponse } from '../global-dialogs/motd-modal/fetch-motd'
+
+const motdContext = createContext<MotdApiResponse | undefined>(undefined)
+
+export const useMotdContextValue = () => {
+  return useContext(motdContext)
+}
+
+interface MotdProviderProps extends PropsWithChildren {
+  motd: MotdApiResponse | undefined
+}
+
+export const MotdProvider: React.FC<MotdProviderProps> = ({ children, motd }) => {
+  return <motdContext.Provider value={motd}>{children}</motdContext.Provider>
+}

--- a/frontend/src/handler-utils/respond-to-matching-request.ts
+++ b/frontend/src/handler-utils/respond-to-matching-request.ts
@@ -62,7 +62,10 @@ export const respondToTestRequest = <T>(req: NextApiRequest, res: NextApiRespons
     res.status(405).send('Method not allowed')
   } else if (!isTestMode) {
     res.status(404).send('Route only available in test mode')
-  } else if (!['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.socket.remoteAddress)) {
+  } else if (
+    req.socket.remoteAddress === undefined ||
+    !['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.socket.remoteAddress)
+  ) {
     res.status(403).send(`Request must come from localhost but was ${req.socket.remoteAddress}`)
   } else {
     res.status(200).json(response())

--- a/frontend/src/handler-utils/respond-to-matching-request.ts
+++ b/frontend/src/handler-utils/respond-to-matching-request.ts
@@ -62,8 +62,8 @@ export const respondToTestRequest = <T>(req: NextApiRequest, res: NextApiRespons
     res.status(405).send('Method not allowed')
   } else if (!isTestMode) {
     res.status(404).send('Route only available in test mode')
-  } else if (req.socket.remoteAddress !== '127.0.0.1' && req.socket.remoteAddress !== '::1') {
-    res.status(403).send('Request must come from localhost')
+  } else if (!['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.socket.remoteAddress)) {
+    res.status(403).send(`Request must come from localhost but was ${req.socket.remoteAddress}`)
   } else {
     res.status(200).json(response())
   }


### PR DESCRIPTION
### Component/Part
Motd

### Description
This PR changes the loading mechanism of the motd.
It is loaded by a RSC and provided via context to the modals.
This reduces the number of fetches and makes it easier to re-show the motd

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
