### PR TITLE
enhancement(notifications): remove from state after dismissal

### DIFF
--- a/frontend/src/components/notifications/ui-notification-toast.tsx
+++ b/frontend/src/components/notifications/ui-notification-toast.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -31,12 +31,17 @@ export interface UiNotificationProps {
 export const UiNotificationToast: React.FC<UiNotificationProps> = ({ notification }) => {
   const { t } = useTranslation()
   const [remainingSteps, setRemainingSteps] = useState<number>(() => notification.durationInSecond * STEPS_PER_SECOND)
-  const { dismissNotification } = useUiNotifications()
+  const { dismissNotification, pruneNotification } = useUiNotifications()
 
   const dismissNow = useCallback(() => {
     log.debug(`Dismiss notification ${notification.uuid} immediately`)
     setRemainingSteps(0)
   }, [notification.uuid])
+
+  const prune = useCallback(() => {
+    log.debug(`Prune notification ${notification.uuid} from state`)
+    pruneNotification(notification.uuid)
+  }, [pruneNotification, notification.uuid])
 
   useEffectOnce(() => {
     log.debug(`Show notification ${notification.uuid}`)
@@ -97,6 +102,7 @@ export const UiNotificationToast: React.FC<UiNotificationProps> = ({ notificatio
       className={styles.toast}
       show={!notification.dismissed}
       onClose={dismissNow}
+      onExited={prune}
       {...cypressId('notification-toast')}>
       <Toast.Header>
         <strong className='me-auto'>

--- a/frontend/src/components/notifications/ui-notifications.tsx
+++ b/frontend/src/components/notifications/ui-notifications.tsx
@@ -9,7 +9,7 @@ import { UiNotificationToast } from './ui-notification-toast'
 import React, { useMemo } from 'react'
 
 export interface UiNotificationsProps {
-  notifications: UiNotification[]
+  notifications: Record<string, UiNotification>
 }
 
 /**
@@ -19,7 +19,7 @@ export interface UiNotificationsProps {
  */
 export const UiNotifications: React.FC<UiNotificationsProps> = ({ notifications }) => {
   const notificationElements = useMemo(() => {
-    return notifications
+    return Object.values(notifications)
       .sort((a, b) => b.createdAtTimestamp - a.createdAtTimestamp)
       .map((notification) => <UiNotificationToast key={notification.uuid} notification={notification} />)
   }, [notifications])

--- a/frontend/src/test-utils/mock-ui-notifications.ts
+++ b/frontend/src/test-utils/mock-ui-notifications.ts
@@ -14,6 +14,7 @@ export const mockUiNotifications = () => {
   jest.spyOn(useUiNotificationsModule, 'useUiNotifications').mockReturnValue({
     showErrorNotification: jest.fn(),
     dismissNotification: jest.fn(),
-    dispatchUiNotification: jest.fn()
+    dispatchUiNotification: jest.fn(),
+    pruneNotification: jest.fn()
   })
 }


### PR DESCRIPTION
### Component/Part
UI Notifications

### Description
Notifications will be removed from the state after dismissal.
This PR changes the implementation from an array to a Map, as that makes accessing a notification for dismissal or removal more performant.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #4948 
