### PR TITLE
fix the link of Code of Conduct file inside contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Thanks for your help in improving the HedgeDoc project!
 
-Please note we have a [code of conduct][code-of-conduct], please follow it in all your interactions with the project.
+Please note we have a [code of conduct][code_of_conduct], please follow it in all your interactions with the project.
 
 ## Ways of contributing
 
@@ -143,7 +143,7 @@ You are welcome to add a `(by [@your_username](https://github.com/your_username)
 - When refactoring something, take care to not include any functional changes into the same commit. Mixing refactoring
   and functional changes makes it hard to find the cause of regressions.
 
-[code-of-conduct]: ./CODE-OF-CONDUCT.md
+[code-of-conduct]: ./CODE_OF_CONDUCT.md
 
 [community-forum]: https://community.hedgedoc.org
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Thanks for your help in improving the HedgeDoc project!
 
-<<<<<<< HEAD
-Please note we have a [code of conduct][code_of_conduct], please follow it in all your interactions with the project.
-=======
 Please note we have a [code of conduct][code-of-conduct], please follow it in all your interactions with the project.
->>>>>>> 7ba6232cbd8abf114c7b3a425d9a1df15d7c6041
 
 ## Ways of contributing
 


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->
#5129 
### Description
This PR fixes/adds/improves/...

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ ] Added implementation
- [ ] Added / updated tests
- [ ] Added / updated documentation
- [ ] Added changelog snippet
- [ ] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
