### PR TITLE
fix CODE_OF_CONDUCT.md file url , inside CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ You are welcome to add a `(by [@your_username](https://github.com/your_username)
 - When refactoring something, take care to not include any functional changes into the same commit. Mixing refactoring
   and functional changes makes it hard to find the cause of regressions.
 
-[code-of-conduct]: ./CODE-OF-CONDUCT.md
+[code-of-conduct]: ./CODE_OF_CONDUCT.md
 
 [community-forum]: https://community.hedgedoc.org
 


### PR DESCRIPTION
fix CODE_OF_CONDUCT.md file url , inside CONTRIBUTING.md

### Component/Part
contributing.md

### Description
This PR fixes the url of CODE_OF_CONDUCT.md file inside  CONTRIBUTING.md


<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
 #5129
