### PR TITLE
fix(i18n): wrong translation key for max length

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -247,7 +247,7 @@
       },
       "limitReached": {
         "title": "Reached the limit",
-        "description": "Sorry, this note reached its maximum length. Notes can be up to {{maxLength}} characters long.",
+        "description": "Sorry, this note reached its maximum length. Notes can be up to {{maxDocumentLength}} characters long.",
         "advice": "Please shorten the note."
       },
       "incompatible": {


### PR DESCRIPTION
### Component/Part
translations

### Description
This PR fixes a wrong i18n key used in the maxLength modal for notes.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5145
