### PR TITLE
fix(frontend): build script error

### DIFF
--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -29,7 +29,7 @@ if [ ! -z "${NEXT_PUBLIC_USE_MOCK_API}" ]; then
 else
     echo "🦔 > Moving Mock API because NEXT_PUBLIC_USE_MOCK_API is unset"
     mkdir -p ../tmp/src/pages
-    mv src/pages/api ../tmp/src/pages/api
+    mv src/pages/api ../tmp/src/pages/
 fi
 
 echo "🦔 > Building"


### PR DESCRIPTION
### Component/Part
frontend build script

### Description
This PR fixes a small error in the frontend build script.

The extra `api` at the end did lead mv to try to copy the api directory in directory named api. This is not intended behaviour and fails if there is no api directory already.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x