### PR TITLE
fix(frontend): remove light text class from error page

### DIFF
--- a/frontend/src/components/error-pages/common-error-page.tsx
+++ b/frontend/src/components/error-pages/common-error-page.tsx
@@ -31,7 +31,7 @@ export const CommonErrorPage: React.FC<PropsWithChildren<CommonErrorPageProps>> 
 
   return (
     <LandingLayout>
-      <div className='text-light d-flex flex-column align-items-center justify-content-center my-5'>
+      <div className='d-flex flex-column align-items-center justify-content-center my-5'>
         <h1>
           <Trans i18nKey={titleI18nKey} />
         </h1>


### PR DESCRIPTION
### Component/Part
Frontend

### Description
This PR removes the enforced light text color on the error page.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fix #5189 