### PR TITLE
chore: release alpha 2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hedgedoc/backend",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Realtime collaborative markdown notes on all platforms.",
   "author": "",
   "private": true,

--- a/docs/content/files/setup-docker/docker-compose.yml
+++ b/docs/content/files/setup-docker/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   backend:
-    image: ghcr.io/hedgedoc/hedgedoc/backend:2.0.0-alpha.1
+    image: ghcr.io/hedgedoc/hedgedoc/backend:2.0.0-alpha.2
     volumes:
       - $PWD/.env:/usr/src/app/backend/.env
       - hedgedoc_uploads:/usr/src/app/backend/uploads
 
   frontend:
-    image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0.0-alpha.1
+    image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0.0-alpha.2
     environment:
       HD_BASE_URL: "${HD_BASE_URL}"
       HD_INTERNAL_API_URL: http://backend:3000

--- a/docs/content/how-to/reverse-proxy.md
+++ b/docs/content/how-to/reverse-proxy.md
@@ -25,7 +25,7 @@ in your `docker-compose.yml`:
 ??? abstract "docker-compose.yml"
     ```yaml
     backend:
-      image: ghcr.io/hedgedoc/hedgedoc/backend:2.0.0-alpha.1
+      image: ghcr.io/hedgedoc/hedgedoc/backend:2.0.0-alpha.2
       volumes:
         - $PWD/.env:/usr/src/app/backend/.env
         - hedgedoc_uploads:/usr/src/app/backend/uploads
@@ -37,7 +37,7 @@ in your `docker-compose.yml`:
         traefik.http.services.hedgedoc_2_backend.loadbalancer.server.port: "3000"
         traefik.http.services.hedgedoc_2_backend.loadbalancer.server.scheme: "http"
     frontend:
-      image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0.0-alpha.1
+      image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0.0-alpha.2
       environment:
         HD_BASE_URL: "${HD_BASE_URL}"
       labels:
@@ -79,14 +79,14 @@ you need to add the `ports` entry for both `backend` and `frontend` as following
 ??? abstract "docker-compose.yml"
     ```yaml
     backend:
-      image: ghcr.io/hedgedoc/hedgedoc/backend:2.0.0-alpha.1
+      image: ghcr.io/hedgedoc/hedgedoc/backend:2.0.0-alpha.2
       volumes:
         - $PWD/.env:/usr/src/app/backend/.env
         - hedgedoc_uploads:/usr/src/app/backend/uploads
       ports:
         - "3000:3000"
     frontend:
-      image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0.0-alpha.1
+      image: ghcr.io/hedgedoc/hedgedoc/frontend:2.0.0-alpha.2
       environment:
         HD_BASE_URL: "${HD_BASE_URL}"
       ports:

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hedgedoc/docs",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "license": "AGPL-3.0",
   "scripts": {
     "lint": "markdownlint-cli2 content/**/*.md",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hedgedoc/frontend",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgedoc",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
### Component/Part
package.json & docs

### Description
This PR increments the version number to `2.0.0-alpha.2`

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x