### PR TITLE
chore: update ts-node to 11.0.0-beta.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -116,7 +116,7 @@
     "supertest": "6.3.3",
     "ts-jest": "29.1.1",
     "ts-mockery": "1.2.0",
-    "ts-node": "https://github.com/TypeStrong/ts-node.git#c06cbe7d83b5585bb24f9963c42ce13eadd2202f",
+    "ts-node": "11.0.0-beta.1",
     "tsconfig-paths": "4.2.0",
     "typescript": "5.2.2"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -171,7 +171,7 @@
     "react-test-renderer": "18.2.0",
     "ts-loader": "9.5.0",
     "ts-mockery": "1.2.0",
-    "ts-node": "https://github.com/TypeStrong/ts-node.git#c06cbe7d83b5585bb24f9963c42ce13eadd2202f",
+    "ts-node": "11.0.0-beta.1",
     "typescript": "5.2.2",
     "user-agent-data-types": "0.4.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,7 +2391,7 @@ __metadata:
     supertest: "npm:6.3.3"
     ts-jest: "npm:29.1.1"
     ts-mockery: "npm:1.2.0"
-    ts-node: "https://github.com/TypeStrong/ts-node.git#c06cbe7d83b5585bb24f9963c42ce13eadd2202f"
+    ts-node: "npm:11.0.0-beta.1"
     tsconfig-paths: "npm:4.2.0"
     typeorm: "npm:0.3.17"
     typescript: "npm:5.2.2"
@@ -2570,7 +2570,7 @@ __metadata:
     tlds: "npm:1.244.0"
     ts-loader: "npm:9.5.0"
     ts-mockery: "npm:1.2.0"
-    ts-node: "https://github.com/TypeStrong/ts-node.git#c06cbe7d83b5585bb24f9963c42ce13eadd2202f"
+    ts-node: "npm:11.0.0-beta.1"
     twemoji-colr-font: "npm:14.1.3"
     typescript: "npm:5.2.2"
     user-agent-data-types: "npm:0.4.2"
@@ -17252,9 +17252,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node@https://github.com/TypeStrong/ts-node.git#c06cbe7d83b5585bb24f9963c42ce13eadd2202f":
+"ts-node@npm:11.0.0-beta.1":
   version: 11.0.0-beta.1
-  resolution: "ts-node@https://github.com/TypeStrong/ts-node.git#commit=c06cbe7d83b5585bb24f9963c42ce13eadd2202f"
+  resolution: "ts-node@npm:11.0.0-beta.1"
   dependencies:
     "@cspotcode/source-map-support": "npm:^0.8.0"
     "@tsconfig/node14": "npm:*"


### PR DESCRIPTION
### Component/Part
update ts-node

### Description
This PR updates ts-node to  11.0.0-beta.1

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x