### PR TITLE
Add a reference to Mermaid 9.1.7 documentation

### DIFF
--- a/public/docs/features.md
+++ b/public/docs/features.md
@@ -334,6 +334,9 @@ gantt
 
 More information about **mermaid** syntax [here](https://mermaid-js.github.io/mermaid/)
 
+This version of HedgeDoc bundles Mermaid 9.1.7. The documentation for this version can
+be found [here](https://github.com/mermaid-js/mermaid/blob/v9.1.7/docs/n00b-gettingStarted.md).
+
 #### Abc Music Notation
 
 ```abc

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## UNRELEASED
+
+### Enhancements
+- Add a pointer to Mermaid 9.1.7 documentation, which is what HedgeDoc 1 supports.
+
 ## <i class="fa fa-tag"></i> 1.9.9 <i class="fa fa-calendar-o"></i> 2023-07-30
 
 HedgeDoc has a new slogan! See [our announcement](https://community.hedgedoc.org/t/and-the-new-slogan-is/) for the details.


### PR DESCRIPTION
HedgeDoc 1.9.x bundles Mermaid version 9.1.7, which is old enough that current Mermaid syntax will fail to render inside HedgeDoc notes.

Add a pointer to Mermaid 9.1.7 docs, so users of the current stable HedgeDoc know what's actually supported.

https://github.com/mermaid-js/mermaid/blob/v9.1.7/docs/n00b-gettingStarted.md

### Component/Part
documentation

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ ] Added implementation
- [ ] Added / updated tests
- [x] Added / updated documentation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#4479, #4894
