### PR TITLE
refactor: use reduce generic type instead of type cast

### DIFF
--- a/frontend/src/components/editor-page/editor-pane/codemirror-extensions/document-sync/y-text-sync-view-plugin.ts
+++ b/frontend/src/components/editor-page/editor-pane/codemirror-extensions/document-sync/y-text-sync-view-plugin.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -34,7 +34,7 @@ export class YTextSyncViewPlugin implements PluginValue {
   }
 
   private calculateChanges(event: YTextEvent): ChangeSpec[] {
-    const [changes] = event.delta.reduce(
+    const [changes] = event.delta.reduce<[ChangeSpec[], number]>(
       ([changes, position], delta) => {
         if (delta.insert !== undefined && typeof delta.insert === 'string') {
           changes.push({ from: position, to: position, insert: delta.insert })
@@ -48,7 +48,7 @@ export class YTextSyncViewPlugin implements PluginValue {
           return [changes, position]
         }
       },
-      [[], 0] as [ChangeSpec[], number]
+      [[], 0]
     )
     return changes
   }

--- a/frontend/src/components/editor-page/editor-pane/hooks/table-paste/table-extractor.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/table-paste/table-extractor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -43,10 +43,10 @@ export const convertClipboardTableToMarkdown = (pasteData: string): string => {
     return ''
   }
   const tableRows = pasteData.split(/\r?\n/).filter((row) => row.trim() !== '')
-  const tableCells = tableRows.reduce((cellsInRow, row, index) => {
+  const tableCells = tableRows.reduce<string[][]>((cellsInRow, row, index) => {
     cellsInRow[index] = row.split('\t')
     return cellsInRow
-  }, [] as string[][])
+  }, [])
   const arrayMaxRows = createNumberRangeArray(tableCells.length)
   const arrayMaxColumns = createNumberRangeArray(Math.max(...tableCells.map((row) => row.length)))
 

--- a/frontend/src/extensions/essential-app-extensions/emoji/mapping.ts
+++ b/frontend/src/extensions/essential-app-extensions/emoji/mapping.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -12,20 +12,20 @@ interface EmojiEntry {
 
 type ShortCodeMap = { [key: string]: string }
 
-const shortCodeMap = (emojiData as unknown as EmojiEntry[]).reduce((reduceObject, emoji) => {
+const shortCodeMap = (emojiData as unknown as EmojiEntry[]).reduce<ShortCodeMap>((reduceObject, emoji) => {
   emoji.shortcodes.forEach((shortcode) => {
     reduceObject[shortcode] = emoji.emoji
   })
   return reduceObject
-}, {} as ShortCodeMap)
+}, {})
 
-const emojiSkinToneModifierMap = [1, 2, 3, 4, 5].reduce((reduceObject, modifierValue) => {
+const emojiSkinToneModifierMap = [1, 2, 3, 4, 5].reduce<ShortCodeMap>((reduceObject, modifierValue) => {
   const lightSkinCode = 127995
   const codepoint = lightSkinCode + (modifierValue - 1)
   const shortcode = `skin-tone-${modifierValue}`
   reduceObject[shortcode] = `&#${codepoint};`
   return reduceObject
-}, {} as ShortCodeMap)
+}, {})
 
 export const combinedEmojiData = {
   ...shortCodeMap,

--- a/html-to-react/src/utils/convertInlineStyleToMap.ts
+++ b/html-to-react/src/utils/convertInlineStyleToMap.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -17,8 +17,9 @@ export function convertInlineStyleToMap(
     return {}
   }
 
-  return inlineStyle.split(';').reduce(
-    (styleObject, stylePropertyValue) => {
+  return inlineStyle
+    .split(';')
+    .reduce<Record<string, string>>((styleObject, stylePropertyValue) => {
       // extract the style property name and value
       const [property, value] = stylePropertyValue
         .split(/^([^:]+):/)
@@ -44,7 +45,5 @@ export function convertInlineStyleToMap(
       styleObject[replacedProperty] = value
 
       return styleObject
-    },
-    {} as Record<string, string>
-  )
+    }, {})
 }

--- a/html-to-react/src/utils/mapHtmlAttributesToReactElementAttributes.ts
+++ b/html-to-react/src/utils/mapHtmlAttributesToReactElementAttributes.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -48,22 +48,19 @@ export function mapHtmlAttributesToReactElementAttributes(
         !isEventHandlerAttribute(attribute) &&
         isValidTagOrAttributeName(attribute)
     )
-    .reduce(
-      (mappedAttributes, attribute) => {
-        // lowercase the attribute name and find it in the react attribute map
-        const lowerCaseAttribute = attribute.toLowerCase()
+    .reduce<Record<string, string>>((mappedAttributes, attribute) => {
+      // lowercase the attribute name and find it in the react attribute map
+      const lowerCaseAttribute = attribute.toLowerCase()
 
-        // format the attribute name
-        const name = reactAttributes[lowerCaseAttribute] || attribute
+      // format the attribute name
+      const name = reactAttributes[lowerCaseAttribute] || attribute
 
-        // add the parsed attribute value to the mapped attributes
-        mappedAttributes[name] = getParsedAttributeValue(
-          name,
-          attributes[attribute]
-        )
+      // add the parsed attribute value to the mapped attributes
+      mappedAttributes[name] = getParsedAttributeValue(
+        name,
+        attributes[attribute]
+      )
 
-        return mappedAttributes
-      },
-      {} as Record<string, string>
-    )
+      return mappedAttributes
+    }, {})
 }


### PR DESCRIPTION
### Component/Part
multiple parts

### Description
This PR fixes the usage of reduce

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
