### PR TITLE
docs: fix reverse-proxy how-to using wrong host header

### DIFF
--- a/docs/content/how-to/reverse-proxy.md
+++ b/docs/content/how-to/reverse-proxy.md
@@ -115,7 +115,7 @@ Here is an example configuration for [nginx][nginx].
 
             location ~ ^/(api|public|uploads|apidoc)/ {
                     proxy_pass http://127.0.0.1:3000;
-                    proxy_set_header Host $host;
+                    proxy_set_header X-Forwarded-Host $host;
                     proxy_set_header X-Real-IP $remote_addr;
                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                     proxy_set_header X-Forwarded-Proto $scheme;
@@ -123,7 +123,7 @@ Here is an example configuration for [nginx][nginx].
 
             location /realtime {
                     proxy_pass http://127.0.0.1:3000;
-                    proxy_set_header Host $host;
+                    proxy_set_header X-Forwarded-Host $host;
                     proxy_set_header X-Real-IP $remote_addr;
                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                     proxy_set_header X-Forwarded-Proto $scheme;
@@ -133,7 +133,7 @@ Here is an example configuration for [nginx][nginx].
     
             location / {
                     proxy_pass http://127.0.0.1:3001;
-                    proxy_set_header Host $host; 
+                    proxy_set_header X-Forwarded-Host $host; 
                     proxy_set_header X-Real-IP $remote_addr; 
                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; 
                     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
### Component/Part
2.0 docs

### Description
This PR fixes the reverse proxy docs for nginx that say one should set the `Host` header when instead `X-Forwarded-Host` is required.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#5332 
