### PR TITLE
chore: Drop twitter from docs

### DIFF
--- a/docs/content/setup/getting-started.md
+++ b/docs/content/setup/getting-started.md
@@ -9,7 +9,7 @@ To set up your instance follow these steps:
 4. If you didn't disable [local accounts](/configuration/#email-local-account), you can use the "Sign In" button to
    create an account, login and start using HedgeDoc.
 
-Follow us on <a href="https://social.hedgedoc.org/" target="_blank" rel="noreferer noopener">:fontawesome-brands-mastodon:{: .mastodon }Mastodon</a> or <a href="https://social.hedgedoc.org/twitter" target="_blank" rel="noreferer noopener">:fontawesome-brands-twitter:{: .twitter }Twitter</a> for updates.
+Follow us on <a href="https://social.hedgedoc.org/" target="_blank" rel="noreferer noopener">:fontawesome-brands-mastodon:{: .mastodon }Mastodon</a> for updates.
 
 ## Upgrading HedgeDoc
 

--- a/docs/content/theme/styles/hedgedoc-custom.css
+++ b/docs/content/theme/styles/hedgedoc-custom.css
@@ -49,10 +49,6 @@
   max-width: 1440px;
 }
 
-.twitter {
-  color: #1DA1F2;
-}
-
 .mastodon {
   color: #2b90d9;
 }


### PR DESCRIPTION
### Component/Part
docs

### Description
This patch drops all references to the disabled HedgeDoc Twitter account.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
