### PR TITLE
fix(frontend): color mode setting of user menu button 

### DIFF
--- a/frontend/src/components/landing-layout/navigation/user-dropdown.tsx
+++ b/frontend/src/components/landing-layout/navigation/user-dropdown.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { useApplicationState } from '../../../hooks/common/use-application-state'
+import { useOutlineButtonVariant } from '../../../hooks/dark-mode/use-outline-button-variant'
 import { cypressId } from '../../../utils/cypress-attribute'
 import { UiIcon } from '../../common/icons/ui-icon'
 import { UserAvatarForUser } from '../../common/user-avatar/user-avatar-for-user'
@@ -20,6 +21,7 @@ import { Trans, useTranslation } from 'react-i18next'
 export const UserDropdown: React.FC = () => {
   useTranslation()
   const user = useApplicationState((state) => state.user)
+  const buttonVariant = useOutlineButtonVariant()
 
   if (!user) {
     return null
@@ -27,7 +29,11 @@ export const UserDropdown: React.FC = () => {
 
   return (
     <Dropdown align={'end'}>
-      <Dropdown.Toggle size='sm' variant='dark' {...cypressId('user-dropdown')} className={'d-flex align-items-center'}>
+      <Dropdown.Toggle
+        {...cypressId('user-dropdown')}
+        size='sm'
+        variant={buttonVariant}
+        className={'d-flex align-items-center'}>
         <UserAvatarForUser user={user} />
       </Dropdown.Toggle>
 


### PR DESCRIPTION
### Component/Part

landing-layout navigation

### Description

This PR fixes color mode setting of user menu button.

![image](https://github.com/hedgedoc/hedgedoc/assets/38120991/2aada924-0d47-4c62-b43f-9b298173f508)

![image](https://github.com/hedgedoc/hedgedoc/assets/38120991/d7ea4224-bdd5-488e-94d7-eed77d543455)

DropdownToggle's default element type is button, so I use `use-outline-button-variant` component.

ref: https://react-bootstrap.netlify.app/docs/components/dropdowns/#dropdowntoggle

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

- #5086
