### PR TITLE
fix(doc): developer document link in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We are currently working on HedgeDoc 2, a complete rewrite of HedgeDoc. Please n
 - HedgeDoc 2 will be split in two components. The backend and the frontend. Both are present in this repository.
 
 ## Development
-Information for setting up a local development environment can be found in the [developer documentation](./docs/content/how-to/develop/setup.md)
+Information for setting up a local development environment can be found in the [developer documentation](https://docs.hedgedoc.dev/how-to/develop/setup/)
 
 ## HedgeDoc 2 Alpha
 Curious about the new look and feel of HedgeDoc 2? We provide a demo of the alpha on [hedgedoc.dev](https://hedgedoc.dev).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We are currently working on HedgeDoc 2, a complete rewrite of HedgeDoc. Please n
 - HedgeDoc 2 will be split in two components. The backend and the frontend. Both are present in this repository.
 
 ## Development
-Information for setting up a local development environment can be found in the [developer documentation](./docs/content/dev/getting-started.md)
+Information for setting up a local development environment can be found in the [developer documentation](./docs/content/how-to/develop/setup.md)
 
 ## HedgeDoc 2 Alpha
 Curious about the new look and feel of HedgeDoc 2? We provide a demo of the alpha on [hedgedoc.dev](https://hedgedoc.dev).


### PR DESCRIPTION
### Component/Part

readme

### Description

This PR fixes developer document link in readme.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

I found out when implementating below PR.

- #5344 
