### PR TITLE
chore: Update E2E test script name in docs

### DIFF
--- a/docs/content/how-to/develop/frontend.md
+++ b/docs/content/how-to/develop/frontend.md
@@ -36,10 +36,10 @@ We use [cypress][cypress] for e2e tests.
 
 1. Start the frontend with `yarn start:dev:test` (or use a test build using `yarn build:test`
    which you can start using `yarn start`). The usage of `:test` is mandatory!
-2. Run `yarn cy:open` to open the cypress test loader
+2. Run `yarn test:e2e:open` to open the cypress test loader
 3. Choose your browser and start a test suite
 
-To run all tests in a headless browser use `yarn cy:run:chrome` or `yarn cy:run:firefox`
+To run all tests in a headless browser use `yarn test:e2e`
 
 ### Bundle analysis
 


### PR DESCRIPTION
### Component/Part

docs develop-guide

### Description

This PR updates E2E test script name in development guide.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

I found out when implementating below PR.

- #5348
