### PR TITLE
fix(opengraph): treat user frontmatter values as String

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -5,6 +5,9 @@
 ### Enhancements
 - Add a pointer to Mermaid 9.1.7 documentation, which is what HedgeDoc 1 supports.
 
+### Bugfixes
+- Fix a crash when having numeric-only values in opengraph frontmatter
+
 ## <i class="fa fa-tag"></i> 1.9.9 <i class="fa fa-calendar-o"></i> 2023-07-30
 
 HedgeDoc has a new slogan! See [our announcement](https://community.hedgedoc.org/t/and-the-new-slogan-is/) for the details.

--- a/public/views/hedgedoc/head.ejs
+++ b/public/views/hedgedoc/head.ejs
@@ -6,8 +6,8 @@
 <meta name="mobile-web-app-capable" content="yes">
 <%- include('../includes/favicon') %>
 <% for (var og in opengraph) { %>
-<% if (opengraph.hasOwnProperty(og) && opengraph[og].trim() !== '') { %>
-<meta property="og:<%= og %>" content="<%= opengraph[og] %>">
+<% if (opengraph.hasOwnProperty(og) && String(opengraph[og]).trim() !== '') { %>
+<meta property="og:<%= og %>" content="<%= String(opengraph[og]) %>">
 <% }} if (!opengraph.hasOwnProperty('image')) { %>
 <meta property="og:image" content="<%- serverURL %>/icons/android-chrome-512x512.png">
 <meta property="og:image:alt" content="HedgeDoc logo">


### PR DESCRIPTION
### Component/Part
ejs templates -> note head

### Description
A bug was reported that having frontmatter fields being only numeric results in an error. This seems to be caused as the frontmatter is processed by the yaml-parser but returned with the types as given. So a numeric value is returned as a number, a "true" or "false" is returned as boolean etc.
As we expect strings in the template, that resulted in an exception.

This PR fixes this by treating every value as string in the template. Since we've got no other usages of opengraph data, this should not have been a security problem.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5351
