### PR TITLE
fix(frontend): Avoiding updates directly to state objects on alias modal

### DIFF
--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/aliases-sidebar-entry/aliases-modal/aliases-list.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/aliases-sidebar-entry/aliases-modal/aliases-list.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { useApplicationState } from '../../../../../../hooks/common/use-application-state'
+import type { Alias } from '../../../../../../api/alias/types'
 import type { ApplicationState } from '../../../../../../redux/application-state'
 import { AliasesListEntry } from './aliases-list-entry'
 import React, { Fragment, useMemo } from 'react'
@@ -13,13 +14,12 @@ import React, { Fragment, useMemo } from 'react'
  */
 export const AliasesList: React.FC = () => {
   const aliases = useApplicationState((state: ApplicationState) => state.noteDetails?.aliases)
-
   const aliasesDom = useMemo(() => {
     return aliases === undefined
       ? null
-      : aliases
-          .sort((a, b) => a.name.localeCompare(b.name))
-          .map((alias) => <AliasesListEntry alias={alias} key={alias.name} />)
+      : Object.assign([], aliases)
+          .sort((a: Alias, b: Alias) => a.name.localeCompare(b.name))
+          .map((alias: Alias) => <AliasesListEntry alias={alias} key={alias.name} />)
   }, [aliases])
 
   return <Fragment>{aliasesDom}</Fragment>


### PR DESCRIPTION
### Component/Part

editor-page sidebar aliases-modal

### Description

This PR fixes the error of updating reducer arguments on alias modal.
`#sort` was updating the state object directly, so I changed it to deep copy the object along with troubleshooting.

- error report
  - [#5348](https://github.com/hedgedoc/hedgedoc/pull/5348#pullrequestreview-1827138216)
- error detail & troubleshooting
  - https://redux.js.org/usage/troubleshooting#never-mutate-reducer-arguments

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

[#5348](https://github.com/hedgedoc/hedgedoc/pull/5348#pullrequestreview-1827138216)
