### PR TITLE
fix: action/upload-artifact@v4 breaking change

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -210,11 +210,11 @@ jobs:
       - uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # master
         if: always()
         with:
-          name: screenlog
+          name: screenlog-${{ matrix.containers }}
           path: frontend/screenlog.0
 
       - uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # master
         if: always()
         with:
-          name: screenshots
+          name: screenshots-${{ matrix.containers }}
           path: cypress/screenshots

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -207,14 +207,15 @@ jobs:
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           CYPRESS_CONTAINER_ID: ${{ matrix.containers }}
 
+      - run: echo screenlog-${{ matrix.containers }}-containers # debug
       - uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # master
         if: always()
         with:
-          name: screenlog-${{ matrix.containers }}
+          name: screenlog-${{ matrix.containers }}-container
           path: frontend/screenlog.0
 
       - uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # master
         if: always()
         with:
-          name: screenshots-${{ matrix.containers }}
+          name: screenshots-${{ matrix.containers }}-container
           path: cypress/screenshots


### PR DESCRIPTION
### Component/Part

CI E2E

### Description

This PR fix action/upload-artifact@v4 breaking change.

Currently, the following error occurs during E2E testing.

```
Run actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6

With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```
`actions/upload-artifact` is now v4 in the PR below, but this version includes a breaking change.

- PR #5379
- breaking-change https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

- https://github.com/hedgedoc/hedgedoc/pull/5348#issuecomment-1899419837
