### PR TITLE
fix(ci): artifact-upload in e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -210,11 +210,11 @@ jobs:
       - uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # master
         if: always()
         with:
-          name: screenlog
+          name: screenlog-${{ matrix.containers }}
           path: frontend/screenlog.0
 
       - uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # master
         if: always()
         with:
-          name: screenshots
+          name: screenshots-${{ matrix.containers }}
           path: cypress/screenshots


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR fixes the artifact upload of the frontend e2e screenlog.
It's basically https://github.com/hedgedoc/hedgedoc/pull/5381 but because external contributors can't change our CI configuration I've created this PR.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
