### PR TITLE
chore: add cypress test result directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ backups/
 .turbo
 .env
 dist/
-
+frontend/cypress/screenshots
 
 # Yarn 2 without zero-installs
 .yarn/*

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ backups/
 .turbo
 .env
 dist/
+frontend/cypress/downloads
 frontend/cypress/screenshots
 
 # Yarn 2 without zero-installs


### PR DESCRIPTION
### Component/Part

.gitignore

### Description

This PR add .gitignore rule.
I add cypress test result directory for running local E2E test.

```sh
$ yarn test:e2e

$ git status
On branch develop
Your branch is up to date with 'origin/develop'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        cypress/screenshots/
```

### Steps

- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)


