### PR TITLE
refactor: Replace baseUrl with consumer/provider in width-based-table-of-contents

### DIFF
--- a/frontend/src/components/render-page/renderers/document/document-markdown-renderer.tsx
+++ b/frontend/src/components/render-page/renderers/document/document-markdown-renderer.tsx
@@ -99,7 +99,7 @@ export const DocumentMarkdownRenderer: React.FC<DocumentMarkdownRendererProps> =
           </div>
         </div>
       </div>
-      <DocumentTocSidebar width={internalDocumentRenderPaneSize?.width ?? 0} baseUrl={baseUrl} />
+      <DocumentTocSidebar width={internalDocumentRenderPaneSize?.width ?? 0} />
     </div>
   )
 }

--- a/frontend/src/components/render-page/renderers/document/document-toc-sidebar.tsx
+++ b/frontend/src/components/render-page/renderers/document/document-toc-sidebar.tsx
@@ -12,16 +12,15 @@ import React, { useState } from 'react'
 
 export interface DocumentTocSidebarProps {
   width: number
-  baseUrl: string
 }
 
-export const DocumentTocSidebar: React.FC<DocumentTocSidebarProps> = ({ width, baseUrl }) => {
+export const DocumentTocSidebar: React.FC<DocumentTocSidebarProps> = ({ width }) => {
   const [tocAst, setTocAst] = useState<TocAst>()
   useExtensionEventEmitterHandler(TableOfContentsMarkdownExtension.EVENT_NAME, setTocAst)
 
   return (
     <div className={styles.side}>
-      {tocAst !== undefined && <WidthBasedTableOfContents tocAst={tocAst} baseUrl={baseUrl} width={width} />}
+      {tocAst !== undefined && <WidthBasedTableOfContents tocAst={tocAst} width={width} />}
     </div>
   )
 }

--- a/frontend/src/components/render-page/renderers/document/width-based-table-of-contents.tsx
+++ b/frontend/src/components/render-page/renderers/document/width-based-table-of-contents.tsx
@@ -12,7 +12,6 @@ import React from 'react'
 export interface DocumentExternalTocProps {
   tocAst: TocAst
   width: number
-  baseUrl: string
 }
 
 const MAX_WIDTH_FOR_BUTTON_VISIBILITY = 1100
@@ -23,9 +22,8 @@ const MAX_WIDTH_FOR_BUTTON_VISIBILITY = 1100
  *
  * @param tocAst the {@link TocAst AST} that should be rendered.
  * @param width the width that should be used to determine if the button should be shown.
- * @param baseUrl the base url that will be used to generate the links //TODO: replace with consumer/provider (https://github.com/hedgedoc/hedgedoc/issues/5035)
  */
-export const WidthBasedTableOfContents: React.FC<DocumentExternalTocProps> = ({ tocAst, width, baseUrl }) => {
+export const WidthBasedTableOfContents: React.FC<DocumentExternalTocProps> = ({ tocAst, width }) => {
   const rendererBaseUrl = useBaseUrl(ORIGIN.RENDERER)
 
   if (width >= MAX_WIDTH_FOR_BUTTON_VISIBILITY) {

--- a/frontend/src/components/render-page/renderers/document/width-based-table-of-contents.tsx
+++ b/frontend/src/components/render-page/renderers/document/width-based-table-of-contents.tsx
@@ -5,6 +5,7 @@
  */
 import { TableOfContents } from '../../../editor-page/table-of-contents/table-of-contents'
 import { TableOfContentsHoveringButton } from '../../markdown-toc-button/table-of-contents-hovering-button'
+import { ORIGIN, useBaseUrl } from '../../../../hooks/common/use-base-url'
 import type { TocAst } from '@hedgedoc/markdown-it-plugins'
 import React from 'react'
 
@@ -25,9 +26,11 @@ const MAX_WIDTH_FOR_BUTTON_VISIBILITY = 1100
  * @param baseUrl the base url that will be used to generate the links //TODO: replace with consumer/provider (https://github.com/hedgedoc/hedgedoc/issues/5035)
  */
 export const WidthBasedTableOfContents: React.FC<DocumentExternalTocProps> = ({ tocAst, width, baseUrl }) => {
+  const rendererBaseUrl = useBaseUrl(ORIGIN.RENDERER)
+
   if (width >= MAX_WIDTH_FOR_BUTTON_VISIBILITY) {
-    return <TableOfContents ast={tocAst} baseUrl={baseUrl} />
+    return <TableOfContents ast={tocAst} baseUrl={rendererBaseUrl} />
   } else {
-    return <TableOfContentsHoveringButton tocAst={tocAst} baseUrl={baseUrl} />
+    return <TableOfContentsHoveringButton tocAst={tocAst} baseUrl={rendererBaseUrl} />
   }
 }


### PR DESCRIPTION
### Component/Part

render-page document width-based-table-of-contents

### Description

This PR replaces baseUrl with consumer/provider in width-based-table-of-contents.
It's a remaining TODO.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

- #5035
