### PR TITLE
chore(backend): Add timer berfore deleting realtime note

### DIFF
--- a/backend/src/realtime/realtime-note/realtime-note.spec.ts
+++ b/backend/src/realtime/realtime-note/realtime-note.spec.ts
@@ -108,4 +108,41 @@ describe('realtime note', () => {
     expect(sendMessage1Spy).toHaveBeenNthCalledWith(2, deletedMessage);
     expect(sendMessage2Spy).toHaveBeenNthCalledWith(1, deletedMessage);
   });
+
+  describe('removeClient', () => {
+    it('destory if the number of connected clients reaches zero and the lifetime is exceeded', () => {
+      const sut = new RealtimeNote(mockedNote, 'nothing');
+      const client1 = new MockConnectionBuilder(sut).withLoggedInUser().build();
+      const docDestroy = jest.spyOn(sut, 'destroy');
+
+      sut.addClient(client1);
+      sut.removeClient(client1);
+      jest.advanceTimersByTime(5000);
+
+      sut.addClient(client1);
+      sut.removeClient(client1);
+      jest.advanceTimersByTime(10500);
+
+      expect(docDestroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("doesn't destory when a client reconnects quickly", () => {
+      const sut = new RealtimeNote(mockedNote, 'nothing');
+      const client1 = new MockConnectionBuilder(sut).withLoggedInUser().build();
+      const docDestroy = jest.spyOn(sut, 'destroy');
+
+      // Assuming the case where the only connected user reloads the browser
+      sut.addClient(client1);
+      sut.removeClient(client1);
+      jest.advanceTimersByTime(5000);
+
+      sut.addClient(client1);
+      sut.removeClient(client1);
+      jest.advanceTimersByTime(5000);
+
+      sut.addClient(client1);
+
+      expect(docDestroy).toHaveBeenCalledTimes(0);
+    });
+  });
 });


### PR DESCRIPTION
### Component/Part

Backend realtime note

### Description

This PR adds a timer before `RealtimeNote` gets deleted.

- adds 3 seconds lifetime to `RealtimeNote` without clients
- prevents from creating revision even if the last user reloads the screen

Please see issue #3608 for details.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

- #3608
