### PR TITLE
fix(frontend): improve accessibility on the permissions modal

### DIFF
--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-add-entry-field.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-add-entry-field.tsx
@@ -9,7 +9,7 @@ import { UiIcon } from '../../../../../common/icons/ui-icon'
 import type { PermissionDisabledProps } from './permission-disabled.prop'
 import React, { useCallback, useState } from 'react'
 import { Button, FormControl, InputGroup } from 'react-bootstrap'
-import { Plus as IconPlus } from 'react-bootstrap-icons'
+import { PlusLg as IconPlus } from 'react-bootstrap-icons'
 
 export interface PermissionAddEntryFieldProps {
   onAddEntry: (identifier: string) => void
@@ -42,8 +42,8 @@ export const PermissionAddEntryField: React.FC<PermissionAddEntryFieldProps & Pe
       <InputGroup className={'me-1 mb-1'}>
         <FormControl value={newEntryIdentifier} placeholder={placeholderText} onChange={onChange} disabled={disabled} />
         <Button
-          variant='light'
-          className={'text-secondary ms-2'}
+          variant='primary'
+          className={'text-ms-2'}
           title={placeholderText}
           onClick={onSubmit}
           disabled={disabled}>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-entry-buttons.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-entry-buttons.tsx
@@ -75,10 +75,7 @@ export const PermissionEntryButtons: React.FC<PermissionEntryButtonsProps & Perm
 
   return (
     <div>
-      <Button variant='light' className={'text-danger me-2'} disabled={disabled} title={removeTitle} onClick={onRemove}>
-        <UiIcon icon={IconX} />
-      </Button>
-      <ToggleButtonGroup type='radio' name='edit-mode' value={currentSetting}>
+      <ToggleButtonGroup className={'me-2'} type='radio' name='edit-mode' value={currentSetting}>
         <Button
           disabled={disabled}
           title={setReadOnlyTitle}
@@ -94,6 +91,9 @@ export const PermissionEntryButtons: React.FC<PermissionEntryButtonsProps & Perm
           <UiIcon icon={IconPencil} />
         </Button>
       </ToggleButtonGroup>
+      <Button variant='danger' disabled={disabled} title={removeTitle} onClick={onRemove}>
+        <UiIcon icon={IconX} />
+      </Button>
     </div>
   )
 }

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-owner-change.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-owner-change.tsx
@@ -38,7 +38,7 @@ export const PermissionOwnerChange: React.FC<PermissionOwnerChangeProps> = ({ on
     <InputGroup className={'me-1 mb-1'}>
       <FormControl value={ownerFieldValue} placeholder={placeholderText} onChange={onChangeField} />
       <Button
-        variant='light'
+        variant='primary'
         title={buttonTitleText}
         onClick={onClickConfirm}
         className={'ms-2'}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-owner-info.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry/permissions-modal/permission-owner-info.tsx
@@ -36,7 +36,7 @@ export const PermissionOwnerInfo: React.FC<PermissionOwnerInfoProps & Permission
   return (
     <Fragment>
       <UserAvatarForUsername username={noteOwner} />
-      <Button variant='light' disabled={disabled} title={buttonTitle} onClick={onEditOwner}>
+      <Button variant='primary' disabled={disabled} title={buttonTitle} onClick={onEditOwner}>
         <UiIcon icon={IconPencil} />
       </Button>
     </Fragment>


### PR DESCRIPTION
### Component/Part

editor-page sidebar permissions-modal

### Description

This PR improves accessibility on permission modal.
The change policy is the same as #5348 .

![image](https://github.com/hedgedoc/hedgedoc/assets/38120991/bbae9bd9-d3b7-4ba4-a883-f86d739801a6)

![image](https://github.com/hedgedoc/hedgedoc/assets/38120991/c7c79f97-f356-408f-908a-64c42f59fd1a)

![image](https://github.com/hedgedoc/hedgedoc/assets/38120991/d43fc7df-652a-469c-a76e-ae783fabf94a)

![image](https://github.com/hedgedoc/hedgedoc/assets/38120991/d6103416-d251-43ae-b906-5a570988cd24)

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

- #5087 
