### PR TITLE
deps: pin node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "packageManager": "yarn@4.0.2",
   "resolutions": {
+    "@types/node": "20.10.8",
     "domhandler": "5.0.3",
     "@codemirror/state": "6.3.3",
     "@codemirror/autocomplete": "6.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4996,15 +4996,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 20.10.4
-  resolution: "@types/node@npm:20.10.4"
-  dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 2c8b70cba731eb2ae3ae046daa74903bfcbb0e7b9196da767e5895054f6d252296ae7a04fb1dbbcb53bb004c4c658c05eaea2731bc9e2dd9e08f7e88d672f563
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:20.10.8":
   version: 20.10.8
   resolution: "@types/node@npm:20.10.8"


### PR DESCRIPTION
### Component/Part
Dependencies

### Description
This PR adds a resolution for the nodes type to fix a version mismatch when compiling without cache.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
