### PR TITLE
Fix Apache back-end reverse-proxying directives

### DIFF
--- a/docs/content/how-to/reverse-proxy.md
+++ b/docs/content/how-to/reverse-proxy.md
@@ -167,15 +167,15 @@ Here is an example config snippet for [Apache][apache]:
       RewriteCond %{HTTP:Upgrade} =websocket             [NC]
       RewriteRule /(.*)  ws://127.0.0.1:3000/$1          [P,L]
     
-      ProxyPass /api http://127.0.0.1:3000/
-      ProxyPass /apidoc http://127.0.0.1:3000/
-      ProxyPass /public http://127.0.0.1:3000/
-      ProxyPass /realtime http://127.0.0.1:3000/
+      ProxyPass /api http://127.0.0.1:3000/api
+      ProxyPass /apidoc http://127.0.0.1:3000/apidoc
+      ProxyPass /public http://127.0.0.1:3000/public
+      ProxyPass /realtime http://127.0.0.1:3000/realtime
       
-      ProxyPassReverse /api http://127.0.0.1:3000/
-      ProxyPassReverse /apidoc http://127.0.0.1:3000/
-      ProxyPassReverse /public http://127.0.0.1:3000/
-      ProxyPassReverse /realtime http://127.0.0.1:3000/
+      ProxyPassReverse /api http://127.0.0.1:3000/api
+      ProxyPassReverse /apidoc http://127.0.0.1:3000/apidoc
+      ProxyPassReverse /public http://127.0.0.1:3000/public
+      ProxyPassReverse /realtime http://127.0.0.1:3000/realtime
       
       ProxyPass / http://127.0.0.1:3001/
       ProxyPassReverse / http://127.0.0.1:3001/


### PR DESCRIPTION
### Component/Part
Documentation

### Description
This PR fixes the Apache reverse-proxying directives (`ProxyPass`) of the back-end missing a path parameter, e.g. causing the front-end to hit `//private/config` when actually requesting `/api/private/config`.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ ] Added implementation
- [ ] Added / updated tests
- [x] Added / updated documentation
- [ ] Added changelog snippet
- [ ] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Closes #5431
