### PR TITLE
fix(router): do not create sessions for /_health

### DIFF
--- a/app.js
+++ b/app.js
@@ -152,7 +152,7 @@ app.use('/uploads', express.static(path.resolve(__dirname, config.uploadsPath), 
 app.use('/default.md', express.static(path.resolve(__dirname, config.defaultNotePath), { maxAge: config.staticCacheTime }))
 
 // session
-app.use(useUnless(['/status', '/metrics'], session({
+app.use(useUnless(['/status', '/metrics', '/_health'], session({
   name: config.sessionName,
   secret: config.sessionSecret,
   resave: false, // don't save session if unmodified

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -7,6 +7,7 @@
 
 ### Bugfixes
 - Fix a crash when having numeric-only values in opengraph frontmatter
+- Fix unnecessary session creation on healthcheck endpoint
 
 ## <i class="fa fa-tag"></i> 1.9.9 <i class="fa fa-calendar-o"></i> 2023-07-30
 


### PR DESCRIPTION
### Component/Part
app router -> session creation

### Description
When the /_health endpoint for the docker container healthcheck was introduced, it seems that it was forgotten to exclude that route from the session creation. As the healthcheck runs quite periodically, this created a huge amount of session entries in the database.

This PR excludes the route from session creation.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Updated changelog
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5429 
