### PR TITLE
fix: change frontend browserslist to fix build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,19 +23,13 @@
     "test:ci": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_ENV=test jest --coverage",
     "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_ENV=test jest"
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "Firefox ESR",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
+  "browserslist": [
+    "Chrome 118",
+    ">0.2%",
+    "Firefox ESR",
+    "not dead",
+    "not op_mini all"
+  ],
   "dependencies": {
     "@codemirror/autocomplete": "6.11.1",
     "@codemirror/commands": "6.3.3",


### PR DESCRIPTION
### Component/Part
Frontend

### Description
Next 14.1 has a bug when specific browser targets are added. I've added https://github.com/vercel/next.js/issues/60909#issuecomment-1905103530 as workaround.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
