### PR TITLE
API tokens: add prefix and more strict validation

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -21,6 +21,8 @@ import { TimestampMillis } from '../utils/timestamp';
 import { AuthTokenDto, AuthTokenWithSecretDto } from './auth-token.dto';
 import { AuthToken } from './auth-token.entity';
 
+export const AUTH_TOKEN_PREFIX = 'hd2';
+
 @Injectable()
 export class AuthService {
   constructor(
@@ -32,8 +34,8 @@ export class AuthService {
   }
 
   async validateToken(tokenString: string): Promise<User> {
-    const [keyId, secret] = tokenString.split('.');
-    if (!secret) {
+    const [prefix, keyId, secret, ...rest] = tokenString.split('.');
+    if (!keyId || !secret || prefix !== AUTH_TOKEN_PREFIX || rest.length > 0) {
       throw new TokenNotValidError('Invalid AuthToken format');
     }
     if (secret.length != 86) {
@@ -105,7 +107,7 @@ export class AuthService {
     )) as AuthToken;
     return this.toAuthTokenWithSecretDto(
       createdToken,
-      `${createdToken.keyId}.${secret}`,
+      `${AUTH_TOKEN_PREFIX}.${createdToken.keyId}.${secret}`,
     );
   }
 

--- a/backend/test/private-api/tokens.e2e-spec.ts
+++ b/backend/test/private-api/tokens.e2e-spec.ts
@@ -51,7 +51,7 @@ describe('Tokens', () => {
       Date.now(),
     );
     expect(response.body.lastUsedAt).toBe(null);
-    expect(response.body.secret.length).toBe(98);
+    expect(response.body.secret.length).toBe(102);
   });
 
   it(`GET /tokens`, async () => {


### PR DESCRIPTION
### Component/Part
backend -> auth -> API tokens

### Description
This PR adds a `hd2.` prefix to API tokens. This has the following benefits:
- HedgeDoc API tokens are more easily recognizable by a user e.g. in their clipboard history
- secret scanning solutions could be used to find accidentally published API tokens
- if future HedgeDoc versions have a new token format but need to keep backward-compatibility, the prefix can be used for distinguishing.

Prefixing API tokens is a common thing done for example by [GitHub](https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/) or [GitLab](https://docs.gitlab.com/ee/security/token_overview.html#token-prefixes) as well. As neither the instance domain, associated account nor any more information is included this does not weaken its security and [not considered bad practise](https://security.stackexchange.com/a/218152).

This PR also makes the token validation more strict as it formerly allowed extra characters after the secret that were just ignored and now rejects such cases.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
