### PR TITLE
Allow custom uri protocols in links except for scripts

### DIFF
--- a/frontend/src/components/common/html-to-react/__snapshots__/html-to-react.spec.tsx.snap
+++ b/frontend/src/components/common/html-to-react/__snapshots__/html-to-react.spec.tsx.snap
@@ -27,4 +27,40 @@ exports[`HTML to React will forward the parser options 1`] = `
 </div>
 `;
 
+exports[`HTML to React will render links with non-http protocols 1`] = `
+<div>
+  <a
+    href="tel:+1234567890"
+  >
+    tel
+  </a>
+  <a
+    href="mailto:test@example.com"
+  >
+    mailto
+  </a>
+  <a
+    href="geo:25.197,55.274"
+  >
+    geo
+  </a>
+  <a
+    href="xmpp:test"
+  >
+    xmpp
+  </a>
+</div>
+`;
+
+exports[`HTML to React won't render script links 1`] = `
+<div>
+  <a>
+    js
+  </a>
+  <a>
+    vbs
+  </a>
+</div>
+`;
+
 exports[`HTML to React won't render script tags 1`] = `<div />`;

--- a/frontend/src/components/common/html-to-react/html-to-react.spec.tsx
+++ b/frontend/src/components/common/html-to-react/html-to-react.spec.tsx
@@ -17,6 +17,24 @@ describe('HTML to React', () => {
     expect(view.container).toMatchSnapshot()
   })
 
+  it("won't render script links", () => {
+    const view = render(
+      <HtmlToReact htmlCode={'<a href="javascript:alert(true)">js</a><a href="vbscript:WScript.Evil">vbs</a>'} />
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+
+  it('will render links with non-http protocols', () => {
+    const view = render(
+      <HtmlToReact
+        htmlCode={
+          '<a href="tel:+1234567890">tel</a><a href="mailto:test@example.com">mailto</a><a href="geo:25.197,55.274">geo</a><a href="xmpp:test">xmpp</a>'
+        }
+      />
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+
   it('will forward the DomPurify settings', () => {
     const view = render(
       <HtmlToReact domPurifyConfig={{ ADD_TAGS: ['test-tag'] }} htmlCode={'<test-tag>Test!</test-tag>'} />

--- a/frontend/src/components/common/html-to-react/html-to-react.tsx
+++ b/frontend/src/components/common/html-to-react/html-to-react.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -16,6 +16,8 @@ export interface HtmlToReactProps {
   parserOptions?: ParserOptions
 }
 
+const REGEX_URI_SCHEME_NO_SCRIPTS = /^(?!.*script:).+:?/i
+
 /**
  * Renders
  * @param htmlCode
@@ -26,7 +28,12 @@ export interface HtmlToReactProps {
 export const HtmlToReact: React.FC<HtmlToReactProps> = ({ htmlCode, domPurifyConfig, parserOptions }) => {
   const elements = useMemo(() => {
     const sanitizedHtmlCode = measurePerformance('html-to-react: sanitize', () => {
-      return sanitize(htmlCode, { ...domPurifyConfig, RETURN_DOM_FRAGMENT: false, RETURN_DOM: false })
+      return sanitize(htmlCode, {
+        ...domPurifyConfig,
+        RETURN_DOM_FRAGMENT: false,
+        RETURN_DOM: false,
+        ALLOWED_URI_REGEXP: REGEX_URI_SCHEME_NO_SCRIPTS
+      })
     })
     return measurePerformance('html-to-react: convertHtmlToReact', () => {
       return convertHtmlToReact(sanitizedHtmlCode, parserOptions)


### PR DESCRIPTION
### Component/Part
renderer -> sanitization

### Description
This PR allows custom URI protocols to be used as link targets except for script ones like `javascript:` or `vbscript:`.

Safety considerations: Allowing links to other registered protocols is not much more problematic than linking to arbitrary websites. The important part is that browsers should not execute code in the link in the page context. Currently the only protocol capable of this is `javascript:`. Older versions of MSIE allowed also `vbscript:`, but this is not that relevant for HedgeDoc. To be on the safe side this change blocks all URI protocols ending in script.

Having an allow-list is much harder as this puts the decision about the safety of other protocols into our hands, although we can't assess them. If we just allow one scheme but not another, one could argue that for example the `spotify:` uri scheme is allowed but `ethereum:` not despite both being registered at the IANA - and IMO we shouldn't prioritize ones over others here.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5520 
