### PR TITLE
Style fixes

### DIFF
--- a/frontend/global-styles/github-markdown.scss
+++ b/frontend/global-styles/github-markdown.scss
@@ -174,6 +174,7 @@
   table {
     border-spacing: 0;
     border-collapse: collapse;
+    word-break: keep-all;
   }
 
   td,

--- a/frontend/global-styles/github-markdown.scss
+++ b/frontend/global-styles/github-markdown.scss
@@ -140,10 +140,11 @@
   a {
     color: #0366d6;
     text-decoration: none;
+    border-bottom: solid 1px;
   }
 
   a:hover {
-    text-decoration: underline;
+    border-bottom: dashed 1px;
   }
 
   strong {

--- a/frontend/global-styles/github-markdown.scss
+++ b/frontend/global-styles/github-markdown.scss
@@ -1,5 +1,5 @@
 /*!
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file) & Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file) & Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -10,7 +10,6 @@
   line-height: 1.5;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
   font-size: 16px;
-  line-height: 1.5;
   word-wrap: break-word;
 
   .octicon {
@@ -89,7 +88,6 @@
   }
 
   strong {
-    font-weight: inherit;
     font-weight: bolder;
   }
 
@@ -591,19 +589,6 @@
 
   hr {
     border-bottom-color: #eee;
-  }
-
-  kbd {
-    display: inline-block;
-    padding: 3px 5px;
-    font: 11px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
-    line-height: 10px;
-    color: #444d56;
-    vertical-align: middle;
-    background-color: #fafbfc;
-    border: 1px solid #d1d5da;
-    border-radius: 3px;
-    box-shadow: inset 0 -1px 0 #d1d5da;
   }
 
   .markdown-body:after,

--- a/frontend/src/components/application-loader/loading-screen/loading-screen.tsx
+++ b/frontend/src/components/application-loader/loading-screen/loading-screen.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -26,7 +26,7 @@ export const LoadingScreen: React.FC<LoadingScreenProps> = ({ errorMessage }) =>
           <LoadingAnimation error={!!errorMessage} />
         </span>
       </div>
-      {errorMessage !== undefined && <Alert variant={'danger'}>{errorMessage}</Alert>}
+      {errorMessage && <Alert variant={'danger'}>{errorMessage}</Alert>}
     </div>
   )
 }

--- a/frontend/src/components/editor-page/sidebar/sidebar-button/sidebar-button.module.scss
+++ b/frontend/src/components/editor-page/sidebar/sidebar-button/sidebar-button.module.scss
@@ -1,5 +1,5 @@
 /*!
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -10,8 +10,8 @@
   width: 100%;
   display: flex;
   align-items: center;
-  border: solid 1px var(--sidebar-separator-color);
-  border-left: none;
+  border: none;
+  border-bottom: solid 1px var(--sidebar-separator-color);
   user-select: none;
   cursor: pointer;
   background: transparent;
@@ -19,6 +19,11 @@
   transition: height 0.2s, flex-basis 0.2s;
   overflow: hidden;
   color: var(--bs-emphasis-color);
+
+  &.main {
+    border-top: solid 1px var(--sidebar-separator-color);
+    border-bottom-width: 2px;
+  }
 
   &.hide {
     flex-basis: 0;

--- a/frontend/src/components/editor-page/sidebar/sidebar-menu-info-entry/sidebar-menu-info-entry.module.css
+++ b/frontend/src/components/editor-page/sidebar/sidebar-menu-info-entry/sidebar-menu-info-entry.module.css
@@ -1,10 +1,10 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 .entry {
-    border: solid 1px var(--sidebar-separator-color);
+    border-bottom: solid 1px var(--sidebar-separator-color);
 }
 
 .title {

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-menu-sidebar-menu.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-menu-sidebar-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -18,6 +18,8 @@ import {
   Github as IconGithub
 } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
+import { concatCssClasses } from '../../../../utils/concat-css-classes'
+import styles from '../sidebar-button/sidebar-button.module.scss'
 
 /**
  * Renders the export menu for the sidebar.
@@ -46,7 +48,7 @@ export const ExportMenuSidebarMenu: React.FC<SpecificSidebarMenuProps> = ({
         {...cypressId('menu-export')}
         hide={hide}
         icon={expand ? IconArrowLeft : IconCloudDownload}
-        className={className}
+        className={concatCssClasses(className, { [styles.main]: expand })}
         onClick={onClickHandler}>
         <Trans i18nKey={'editor.documentBar.export'} />
       </SidebarButton>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-menu-sidebar-menu.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-menu-sidebar-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -18,6 +18,8 @@ import {
   Github as IconGithub
 } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
+import styles from '../sidebar-button/sidebar-button.module.scss'
+import { concatCssClasses } from '../../../../utils/concat-css-classes'
 
 /**
  * Renders the import menu for the sidebar.
@@ -46,7 +48,7 @@ export const ImportMenuSidebarMenu: React.FC<SpecificSidebarMenuProps> = ({
         {...cypressId('menu-import')}
         hide={hide}
         icon={expand ? IconArrowLeft : IconCloudUpload}
-        className={className}
+        className={concatCssClasses(className, { [styles.main]: expand })}
         onClick={onClickHandler}>
         <Trans i18nKey={'editor.documentBar.import'} />
       </SidebarButton>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/note-info-sidebar-menu/note-info-sidebar-menu.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/note-info-sidebar-menu/note-info-sidebar-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -16,6 +16,8 @@ import { NoteInfoLineWordCount } from './note-info-line/note-info-line-word-coun
 import React, { Fragment, useCallback } from 'react'
 import { ArrowLeft as IconArrowLeft, GraphUp as IconGraphUp } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
+import styles from '../../sidebar-button/sidebar-button.module.scss'
+import { concatCssClasses } from '../../../../../utils/concat-css-classes'
 
 /**
  * Renders the note info menu for the sidebar.
@@ -44,7 +46,7 @@ export const NoteInfoSidebarMenu: React.FC<SpecificSidebarMenuProps> = ({
         {...cypressId('sidebar-menu-info')}
         hide={hide}
         icon={expand ? IconArrowLeft : IconGraphUp}
-        className={className}
+        className={concatCssClasses(className, { [styles.main]: expand })}
         onClick={onClickHandler}>
         <Trans i18nKey={'editor.noteInfo.title'} />
       </SidebarButton>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/users-online-sidebar-menu/users-online-sidebar-menu.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/users-online-sidebar-menu/users-online-sidebar-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,6 +15,7 @@ import { UserLine } from './user-line/user-line'
 import React, { Fragment, useCallback, useEffect, useMemo, useRef } from 'react'
 import { ArrowLeft as IconArrowLeft, People as IconPeople } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
+import buttonStyles from '../../sidebar-button/sidebar-button.module.scss'
 
 /**
  * Sidebar menu that contains the list of currently online users in the current note session.
@@ -69,7 +70,7 @@ export const UsersOnlineSidebarMenu: React.FC<SpecificSidebarMenuProps> = ({
         buttonRef={buttonRef}
         onClick={onClickHandler}
         icon={expand ? IconArrowLeft : IconPeople}
-        className={concatCssClasses(styles.entry, className)}>
+        className={concatCssClasses(styles.entry, buttonStyles.main, className)}>
         <Trans i18nKey={'editor.onlineStatus.online'} />
       </SidebarButton>
       <SidebarMenu expand={expand}>


### PR DESCRIPTION
### Component/Part
* frontend -> loading screen
* frontend -> renderer
* frontend -> sidebar

### Description
This PR fixes:
* the loading screen rendering an empty error box when no error is present (it should be hidden instead)
* table columns in the renderer being as small as possible, resulting in massive line-breaks
* visual accessibility for links in the renderer
* double borders on sidebar menus

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5085
fixes #2918
