### PR TITLE
Update Nginx reverse proxy config example

### DIFF
--- a/docs/content/guides/reverse-proxy.md
+++ b/docs/content/guides/reverse-proxy.md
@@ -64,7 +64,7 @@ server {
         server_name hedgedoc.example.com;
 
         location / {
-                proxy_pass http://127.0.0.1:3000;
+                proxy_pass http://127.0.0.1:3000/;
                 proxy_set_header Host $host; 
                 proxy_set_header X-Real-IP $remote_addr; 
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; 
@@ -72,7 +72,7 @@ server {
         }
 
         location /socket.io/ {
-                proxy_pass http://127.0.0.1:3000;
+                proxy_pass http://127.0.0.1:3000/socket.io/;
                 proxy_set_header Host $host; 
                 proxy_set_header X-Real-IP $remote_addr; 
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; 
@@ -92,10 +92,11 @@ server {
 
 !!! warning
 
-    NGINX `proxy_pass` directives must NOT have trailing slashes. If the trailing
-    slashes are present, the browser will not be able to establish a WebSocket
-    connection to the server, and the editor interface will display an endless loading
-    animation.
+    NGINX `proxy_pass` directives must have trailing slashes. If the trailing
+    slashes are not present, clients will get stuck in a redirect loop.
+    If `/socket.io/` is not present in the second `proxy_pass` line, the
+    browser will not be able to establish a WebSocket connection to the server,
+    and the editor interface will display an endless loading animation.
 
 ### Apache
 You will need these modules enabled: `proxy`, `proxy_http` and `proxy_wstunnel`.  


### PR DESCRIPTION
### Component/Part
Documentation

### Description
The warning in the Nginx section of the reverse proxy guide is misleading:
Omitting trailing slashes in Nginx' `proxy_pass` directives causes redirect loops (see related issue), while the issue described in the warning is a different one, caused by an incorrect socket.io URL.
This config has been successfully tested with HedgeDoc 1.9.8 and Nginx 1.22.1.

Fixes: 74b573e


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#1024 
