### PR TITLE
fix(backend revision): Update patch column when removing revisions

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -122,3 +122,7 @@ License: CC0-1.0
 Files: frontend/**/__snapshots__/*.snap
 Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: AGPL-3.0-only
+
+Files: backend/**/__snapshots__/*.snap
+Copyright: 2024 The HedgeDoc developers (see AUTHORS file)
+License: AGPL-3.0-only

--- a/backend/src/revisions/__snapshots__/revisions.service.spec.ts.snap
+++ b/backend/src/revisions/__snapshots__/revisions.service.spec.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RevisionsService purgeRevisions purges the revision history 1`] = `
+"Index: test-note
+===================================================================
+--- test-note
++++ test-note
+@@ -0,0 +1,6 @@
++---
++title: new title
++description: new description
++tags: [ "tag1" ]
++---
++new content
+"
+`;

--- a/backend/src/revisions/revisions.service.ts
+++ b/backend/src/revisions/revisions.service.ts
@@ -59,6 +59,17 @@ export class RevisionsService {
     const oldRevisions = revisions.filter(
       (item) => item.id !== latestRevision.id,
     );
+
+    // update content diff
+    if (oldRevisions.length > 0) {
+      latestRevision.patch = createPatch(
+        note.publicId,
+        '',
+        latestRevision.content,
+      );
+      await this.revisionRepository.save(latestRevision);
+    }
+
     // delete the old revisions
     return await this.revisionRepository.remove(oldRevisions);
   }


### PR DESCRIPTION
### Component/Part

backend revision

### Description

This PR fixes the following feature's bug.

```javascript
  /**
   * @async
   * Purge revision history of a note.
   * @param {Note} note - the note to purge the history
   * @return {Revision[]} an array of purged revisions
   */
  async purgeRevisions(note: Note): Promise<Revision[]> {
```

If we delete all revisions except the latest one, we need to update the patch column of the latest one.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

- https://github.com/hedgedoc/hedgedoc/pull/5349#issuecomment-1913119203
