### PR TITLE
[1.x] Fix Minio uploads having defect metadata

### DIFF
--- a/lib/web/imageRouter/minio.js
+++ b/lib/web/imageRouter/minio.js
@@ -35,7 +35,9 @@ exports.uploadImage = function (imagePath, callback) {
     const key = path.join('uploads', path.basename(imagePath))
     const protocol = config.minio.secure ? 'https' : 'http'
 
-    minioClient.putObject(config.s3bucket, key, buffer, buffer.size, getImageMimeType(imagePath), function (err, data) {
+    minioClient.putObject(config.s3bucket, key, buffer, buffer.size, {
+      'Content-Type': getImageMimeType(imagePath) || 'application/octet-stream'
+    }, function (err, data) {
       if (err) {
         callback(new Error(err), null)
         return

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -8,6 +8,7 @@
 ### Bugfixes
 - Fix a crash when having numeric-only values in opengraph frontmatter
 - Fix unnecessary session creation on healthcheck endpoint
+- Fix defect metadata being sent for minio uploads
 
 ## <i class="fa fa-tag"></i> 1.9.9 <i class="fa fa-calendar-o"></i> 2023-07-30
 


### PR DESCRIPTION
### Component/Part
image router -> minio

### Description
A change in the minio JS SDK resulted in uploads being stored with a defect metadata object in minio, resulting in all files served as application/octet-stream.
This was caused as the fifth argument to [putObject](https://min.io/docs/minio/linux/developers/javascript/API.html#putObject) is a metadata object and not the content-type alone anymore.
This PR fixes that.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
