### PR TITLE
fix: ellide css custom properties when converting css inline styles to map

### DIFF
--- a/html-to-react/src/utils/convertInlineStyleToMap.ts
+++ b/html-to-react/src/utils/convertInlineStyleToMap.ts
@@ -61,10 +61,12 @@ export function convertInlineStyleToMap(
       // additionally don't uppercase any -ms- prefix
       // e.g. -ms-style-property = msStyleProperty
       //      -webkit-style-property = WebkitStyleProperty
-      const replacedProperty = property
-        .toLowerCase()
-        .replace(/^-ms-/, 'ms-')
-        .replace(/-(.)/g, (_, character: string) => character.toUpperCase())
+      const replacedProperty = property.startsWith('--')
+        ? property
+        : property
+            .toLowerCase()
+            .replace(/^-ms-/, 'ms-')
+            .replace(/-(.)/g, (_, character: string) => character.toUpperCase())
 
       // add the new style property and value to the style object
       styleObject[replacedProperty] = value


### PR DESCRIPTION
### Component/Part
react-to-html

### Description
fixes incorrectly transformed inline css custom properties

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5596
