### PR TITLE
fix(frontend): do not hardcode example.org, do not prebuild motd

### DIFF
--- a/frontend/src/components/global-dialogs/motd-modal/fetch-motd.ts
+++ b/frontend/src/components/global-dialogs/motd-modal/fetch-motd.ts
@@ -1,9 +1,10 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { defaultConfig } from '../../../api/common/default-config'
+import { isBuildTime } from '../../../utils/test-modes'
 
 export interface MotdApiResponse {
   motdText: string
@@ -18,6 +19,9 @@ export interface MotdApiResponse {
  * @return A promise that gets resolved if the motd was fetched successfully.
  */
 export const fetchMotd = async (baseUrl: string): Promise<MotdApiResponse | undefined> => {
+  if (isBuildTime) {
+    return
+  }
   const motdUrl = `${baseUrl}public/motd.md`
   const response = await fetch(motdUrl, {
     ...defaultConfig

--- a/frontend/src/utils/base-url-from-env-extractor.ts
+++ b/frontend/src/utils/base-url-from-env-extractor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -56,9 +56,9 @@ export class BaseUrlFromEnvExtractor {
   public extractBaseUrls(): BaseUrls {
     if (isBuildTime) {
       return {
-        editor: 'https://example.org/',
-        renderer: 'https://example.org/',
-        internalApiUrl: 'https://example.org/'
+        editor: '',
+        renderer: '',
+        internalApiUrl: ''
       }
     }
 


### PR DESCRIPTION
### Component/Part
frontend -> motd

### Description
The motd.md is user-supplied and should therefore not be prebuild during the HedgeDoc build process. As that required the presence of the base URL which is also not available in the build context, it fell back to our fallback value example.org, thus breaking offline builds. By removing the example.org domains and disabling the prebuild for the motd, this seems fixed.

#### Reproduce offline build
1. `git clone --depth=1 -b fix/base-urls-example-org https://github.com/hedgedoc/hedgedoc.git`
2. `cd hedgedoc`
3. `yarn install`
4. `nmcli networking off`
5. `yarn build` -> should work
6. `nmcli networking on`

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5527
