### PR TITLE
enhancement(realtime): send metadata update on revision save

### DIFF
--- a/backend/src/realtime/realtime-note/realtime-note.service.ts
+++ b/backend/src/realtime/realtime-note/realtime-note.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -49,6 +49,9 @@ export class RealtimeNoteService implements BeforeApplicationShutdown {
         realtimeNote.getRealtimeDoc().getCurrentContent(),
         realtimeNote.getRealtimeDoc().encodeStateAsUpdate(),
       )
+      .then(() => {
+        realtimeNote.announceMetadataUpdate();
+      })
       .catch((reason) => this.logger.error(reason));
   }
 
@@ -117,7 +120,7 @@ export class RealtimeNoteService implements BeforeApplicationShutdown {
     const realtimeNote = this.realtimeNoteStore.find(note.id);
     if (!realtimeNote) return;
 
-    realtimeNote.announcePermissionChange();
+    realtimeNote.announceMetadataUpdate();
     const allConnections = realtimeNote.getConnections();
     await this.updateOrCloseConnection(allConnections, note);
   }

--- a/backend/src/realtime/realtime-note/realtime-note.spec.ts
+++ b/backend/src/realtime/realtime-note/realtime-note.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -82,11 +82,11 @@ describe('realtime note', () => {
     const sendMessage2Spy = jest.spyOn(client2.getTransporter(), 'sendMessage');
 
     const metadataMessage = { type: MessageType.METADATA_UPDATED };
-    sut.announcePermissionChange();
+    sut.announceMetadataUpdate();
     expect(sendMessage1Spy).toHaveBeenCalledWith(metadataMessage);
     expect(sendMessage2Spy).toHaveBeenCalledWith(metadataMessage);
     sut.removeClient(client2);
-    sut.announcePermissionChange();
+    sut.announceMetadataUpdate();
     expect(sendMessage1Spy).toHaveBeenCalledTimes(2);
     expect(sendMessage2Spy).toHaveBeenCalledTimes(1);
   });

--- a/backend/src/realtime/realtime-note/realtime-note.ts
+++ b/backend/src/realtime/realtime-note/realtime-note.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -149,9 +149,10 @@ export class RealtimeNote extends EventEmitter2<RealtimeNoteEventMap> {
   }
 
   /**
-   * Announce to all clients that the permissions of the note have been changed.
+   * Announce to all clients that the metadata of the note have been changed.
+   * This could for example be a permission change or a revision being saved.
    */
-  public announcePermissionChange(): void {
+  public announceMetadataUpdate(): void {
     this.sendToAllClients({ type: MessageType.METADATA_UPDATED });
   }
 


### PR DESCRIPTION
### Component/Part
backend -> realtime processing

### Description
When the frontend is notified about metadata updates, it refreshes the data and therefore refreshes information like the timestamp of the last revision save in the sidebar.

This PR adds such a notification from the backend to all clients on each revision save, so that the "last saved at" value in the frontend is correct.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #3657 
