### PR TITLE
[1.x] Fix screen readers announcing headings twice

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -10,6 +10,7 @@
 - Fix a crash when having numeric-only values in opengraph frontmatter
 - Fix unnecessary session creation on healthcheck endpoint
 - Fix defect metadata being sent for minio uploads
+- Fix screen readers announcing headings twice
 
 ## <i class="fa fa-tag"></i> 1.9.9 <i class="fa fa-calendar-o"></i> 2023-07-30
 

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -845,6 +845,7 @@ function imgPlayiframe (element, src) {
 
 const anchorForId = id => {
   const anchor = document.createElement('a')
+  anchor.ariaHidden = 'true'
   anchor.className = 'anchor hidden-xs'
   anchor.href = `#${id}`
   anchor.innerHTML = '<i class="fa fa-link"></i>'


### PR DESCRIPTION
### Component/Part
renderer

### Description
This PR fixes the duplicated headings for screen readers.

Because screen readers don't know that the anchor icon is not meant to be read,
they might read the title (which is the same as the heading itself) in addition
to the heading, thus causing a duplicated output.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
fixes #5589
