### PR TITLE
fix: caddy candidate order

### DIFF
--- a/dev-reverse-proxy/package.json
+++ b/dev-reverse-proxy/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {
-    "start:dev": "caddy run || ./caddy run",
-    "start": "caddy run || ./caddy run"
+    "start:dev": " ./caddy run || caddy run",
+    "start": "./caddy run || caddy run"
   }
 }


### PR DESCRIPTION
### Component/Part
caddy run config

### Description
This PR improves the caddy run config.

We should use the most specific caddy first and go to more general caddy executables as is the norm and expected from systems in general.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->


- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

