### PR TITLE
fix: frontmatter headline

### DIFF
--- a/commons/src/frontmatter-extractor/extractor.spec.ts
+++ b/commons/src/frontmatter-extractor/extractor.spec.ts
@@ -96,4 +96,17 @@ describe('frontmatter extraction', () => {
       expect(extraction?.rawText).toEqual('multi\nline')
     })
   })
+
+  describe('is incomplete', () => {
+    it('if frontmatter is closed with one dash', () => {
+      const testNote = ['---', 'type: document', '-', 'content']
+      const extraction = extractFrontmatter(testNote)
+      expect(extraction?.incomplete).toBeTruthy()
+    })
+    it('if frontmatter is closed with two dash', () => {
+      const testNote = ['---', 'type: document', '-', 'content']
+      const extraction = extractFrontmatter(testNote)
+      expect(extraction?.incomplete).toBeTruthy()
+    })
+  })
 })

--- a/commons/src/frontmatter-extractor/extractor.ts
+++ b/commons/src/frontmatter-extractor/extractor.ts
@@ -7,6 +7,7 @@ import type { FrontmatterExtractionResult } from './types.js'
 
 const FRONTMATTER_BEGIN_REGEX = /^-{3,}$/
 const FRONTMATTER_END_REGEX = /^(?:-{3,}|\.{3,})$/
+const FRONTMATTER_INCOMPLETE_END_REGEX = /^-{1,2}$/
 
 /**
  * Extracts a frontmatter block from a given multiline string.
@@ -25,13 +26,21 @@ export const extractFrontmatter = (
     return undefined
   }
   for (let i = 1; i < lines.length; i++) {
+    if (FRONTMATTER_INCOMPLETE_END_REGEX.test(lines[i])) {
+      return {
+        rawText: '',
+        lineOffset: i + 1,
+        incomplete: true
+      }
+    }
     if (
       lines[i].length === lines[0].length &&
       FRONTMATTER_END_REGEX.test(lines[i])
     ) {
       return {
         rawText: lines.slice(1, i).join('\n'),
-        lineOffset: i + 1
+        lineOffset: i + 1,
+        incomplete: false
       }
     }
   }

--- a/commons/src/frontmatter-extractor/types.ts
+++ b/commons/src/frontmatter-extractor/types.ts
@@ -7,4 +7,5 @@
 export interface FrontmatterExtractionResult {
   rawText: string
   lineOffset: number
+  incomplete: boolean
 }

--- a/frontend/src/components/editor-page/editor-pane/linter/frontmatter-linter.ts
+++ b/frontend/src/components/editor-page/editor-pane/linter/frontmatter-linter.ts
@@ -18,7 +18,7 @@ export class FrontmatterLinter implements Linter {
   lint(view: EditorView): Diagnostic[] {
     const lines = view.state.doc.toString().split('\n')
     const frontmatterExtraction = extractFrontmatter(lines)
-    if (frontmatterExtraction === undefined) {
+    if (frontmatterExtraction === undefined || frontmatterExtraction.incomplete) {
       return []
     }
     const frontmatterLines = lines.slice(1, frontmatterExtraction.lineOffset - 1)

--- a/frontend/src/components/render-page/renderers/document/document-markdown-renderer.tsx
+++ b/frontend/src/components/render-page/renderers/document/document-markdown-renderer.tsx
@@ -19,12 +19,9 @@ import type { CommonMarkdownRendererProps, HeightChangeRendererProps } from '../
 import { DocumentTocSidebar } from './document-toc-sidebar'
 import styles from './markdown-document.module.scss'
 import useResizeObserver from '@react-hook/resize-observer'
-import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Logger } from '../../../../utils/logger'
+import React, { useMemo, useRef, useState } from 'react'
 
 export type DocumentMarkdownRendererProps = CommonMarkdownRendererProps & ScrollProps & HeightChangeRendererProps
-
-const logger = new Logger('DocumentMarkdownRenderer')
 
 /**
  * Renders a Markdown document and handles scrolling, yaml metadata and a floating table of contents.
@@ -66,11 +63,6 @@ export const DocumentMarkdownRenderer: React.FC<DocumentMarkdownRendererProps> =
 
   const markdownBodyRef = useRef<HTMLDivElement>(null)
   const currentLineMarkers = useRef<LineMarkers[]>()
-
-  // ToDo: Remove this
-  useEffect(() => {
-    logger.debug(markdownContentLines)
-  }, [markdownContentLines])
 
   const extensions = useMarkdownExtensions(
     baseUrl,

--- a/frontend/src/components/render-page/renderers/document/document-markdown-renderer.tsx
+++ b/frontend/src/components/render-page/renderers/document/document-markdown-renderer.tsx
@@ -19,9 +19,12 @@ import type { CommonMarkdownRendererProps, HeightChangeRendererProps } from '../
 import { DocumentTocSidebar } from './document-toc-sidebar'
 import styles from './markdown-document.module.scss'
 import useResizeObserver from '@react-hook/resize-observer'
-import React, { useMemo, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { Logger } from '../../../../utils/logger'
 
 export type DocumentMarkdownRendererProps = CommonMarkdownRendererProps & ScrollProps & HeightChangeRendererProps
+
+const logger = new Logger('DocumentMarkdownRenderer')
 
 /**
  * Renders a Markdown document and handles scrolling, yaml metadata and a floating table of contents.
@@ -63,6 +66,11 @@ export const DocumentMarkdownRenderer: React.FC<DocumentMarkdownRendererProps> =
 
   const markdownBodyRef = useRef<HTMLDivElement>(null)
   const currentLineMarkers = useRef<LineMarkers[]>()
+
+  // ToDo: Remove this
+  useEffect(() => {
+    logger.debug(markdownContentLines)
+  }, [markdownContentLines])
 
   const extensions = useMarkdownExtensions(
     baseUrl,

--- a/frontend/src/extensions/essential-app-extensions/extract-first-headline/extract-first-headline-node-processor.ts
+++ b/frontend/src/extensions/essential-app-extensions/extract-first-headline/extract-first-headline-node-processor.ts
@@ -5,7 +5,6 @@
  */
 import { NodeProcessor } from '../../../components/markdown-renderer/node-preprocessors/node-processor'
 import { extractFirstHeading } from '@hedgedoc/commons'
-import { Optional } from '@mrdrogdrog/optional'
 import type { Document } from 'domhandler'
 import type { EventEmitter2 } from 'eventemitter2'
 
@@ -20,9 +19,7 @@ export class ExtractFirstHeadlineNodeProcessor extends NodeProcessor {
   }
 
   process(nodes: Document): Document {
-    Optional.ofNullable(extractFirstHeading(nodes))
-      .filter((text) => text !== '')
-      .ifPresent((text) => this.eventEmitter.emit(ExtractFirstHeadlineNodeProcessor.EVENT_NAME, text))
+    this.eventEmitter.emit(ExtractFirstHeadlineNodeProcessor.EVENT_NAME, extractFirstHeading(nodes))
     return nodes
   }
 }

--- a/frontend/src/redux/note-details/build-state-from-updated-markdown-content.ts
+++ b/frontend/src/redux/note-details/build-state-from-updated-markdown-content.ts
@@ -83,6 +83,10 @@ const buildStateFromFrontmatterUpdate = (
   state: NoteDetails,
   frontmatterExtraction: FrontmatterExtractionResult
 ): NoteDetails => {
+  if (frontmatterExtraction.incomplete) {
+    frontmatterExtraction.rawText = state.rawFrontmatter
+    return buildStateFromFrontmatter(state, parseFrontmatter(frontmatterExtraction), frontmatterExtraction)
+  }
   if (frontmatterExtraction.rawText === state.rawFrontmatter) {
     return state
   }


### PR DESCRIPTION
### Component/Part
headline extractor

### Description
This PR fixes the headline extractor.

If one wrote a frontmatter the incomplete ending dashes where interpreted as a headline and therefore the last line in the frontmatter was handled as the first heading of the document.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x