### PR TITLE
fix: prevent emoji autocomplete

### DIFF
--- a/frontend/src/extensions/essential-app-extensions/emoji/emoji-app-extension.ts
+++ b/frontend/src/extensions/essential-app-extensions/emoji/emoji-app-extension.ts
@@ -28,14 +28,16 @@ export class EmojiAppExtension extends AppExtension {
   }
 
   buildAutocompletion(): CompletionSource[] {
-    return [
-      regexCompletion(
-        /:(?:[\w-+]+:?)?/,
-        emojiShortcodes.map((shortcode) => ({
-          detail: t('editor.autocompletions.emoji') ?? undefined,
-          label: `:${shortcode}:`
-        }))
-      )
+    const completions = [
+      {
+        detail: '',
+        label: ':'
+      },
+      ...emojiShortcodes.map((shortcode) => ({
+        detail: t('editor.autocompletions.emoji') ?? undefined,
+        label: `:${shortcode}:`
+      }))
     ]
+    return [regexCompletion(/:(?:[\w-+]+:?)?/, completions)]
   }
 }


### PR DESCRIPTION
### Component/Part
frontend

### Description
This PR fixes an issue with the emoji autocompletion by adding an empty entry to the emoji autocompletion which allows us to press enter to continue without any random emojis in the note where we did not intend them.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #5251