### PR TITLE
fix(frontend): build messages

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -31,7 +31,7 @@ if (isMockMode) {
 
 if (isBuildTime) {
   console.warn(`This process runs in build mode. During build time this means:
- - Editor and Renderer base urls are https://example.org
+ - Editor and Renderer base urls are '' (empty string)
  - No frontend config will be fetched
 `)
 }


### PR DESCRIPTION
### Component/Part
frontend build script

### Description

The urls are not https://example.org since https://github.com/hedgedoc/hedgedoc/pull/5598 and this message should have been changed then as well.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x