### PR TITLE
fix(packages): backend was missing uuid package

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -76,6 +76,7 @@
     "rxjs": "7.8.1",
     "sqlite3": "5.1.7",
     "typeorm": "0.3.20",
+    "uuid": "10.0.0",
     "ws": "8.17.1",
     "yjs": "13.6.18"
   },
@@ -100,6 +101,7 @@
     "@types/pg": "8.11.0",
     "@types/source-map-support": "0.5.10",
     "@types/supertest": "2.0.16",
+    "@types/uuid": "9.0.8",
     "@types/ws": "8.5.10",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,6 +2531,7 @@ __metadata:
     "@types/pg": "npm:8.11.0"
     "@types/source-map-support": "npm:0.5.10"
     "@types/supertest": "npm:2.0.16"
+    "@types/uuid": "npm:9.0.8"
     "@types/ws": "npm:8.5.10"
     "@typescript-eslint/eslint-plugin": "npm:6.21.0"
     "@typescript-eslint/parser": "npm:6.21.0"
@@ -2581,6 +2582,7 @@ __metadata:
     tsconfig-paths: "npm:4.2.0"
     typeorm: "npm:0.3.20"
     typescript: "npm:5.5.4"
+    uuid: "npm:10.0.0"
     ws: "npm:8.17.1"
     yjs: "npm:13.6.18"
   languageName: unknown


### PR DESCRIPTION
### Component/Part
backend -> dependencies

### Description
Due to failing docker builds it was brought to our attention, that the backend relied on the uuid package without declaring it as dependency. This worked in all development and build scenarios as the frontend declares uuid as dependency already and top-level `yarn install` installs all dependencies from all workspaces. However as the docker build only runs for either the backend or the frontend, this failed.

This PR adds the dependency to the backend as well.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
