### PR TITLE
fix(translation): change the placeholder text

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -231,7 +231,7 @@
       "failed": "Error while uploading {{fileName}}"
     },
     "untitledNote": "Untitled",
-    "placeholder": "← Start by entering a title here\n===\nVisit {{host}}features if you don't know what to do.\nHappy hacking :)",
+    "placeholder": "← Start by entering a title here\n===\nVisit {{host}}cheatsheet if you don't know what to do.\nLet the ideas grow :)",
     "infoToc": "Structure your note with headings to see a table-of-contents here.",
     "onlineStatus": {
       "online": "Online",


### PR DESCRIPTION
### Component/Part
translation

### Description
The url the placeholder text linked to is not accurate anymore and needed to be changed. Also the "Happy hacking" part seemed outdated so we changed it to "Let the ideas grow" in accordance with the new slogan of HedgeDoc

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
