### PR TITLE
chore: Drop X (Twitter) from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 [![version][github-version-badge]][github-release-page]
 [![POEditor][poeditor-image]][poeditor-url]
 [![Mastodon][social-mastodon-image]][social-mastodon]
-[![Twitter][social-twitter-image]][social-twitter]
 ![REUSE Compliance Check][reuse-workflow-badge]
 ![Nest.JS CI][nestjs-workflow-badge]
 [![codecov][codecov-badge]][codecov-url]
@@ -87,10 +86,6 @@ the [github repository](https://github.com/hedgedoc/hedgedoc-logo).
 [social-mastodon]: https://social.hedgedoc.org/mastodon
 
 [social-mastodon-image]: https://img.shields.io/mastodon/follow/109259563190314667?domain=https%3A%2F%2Ffosstodon.org&style=social
-
-[social-twitter]: https://social.hedgedoc.org/twitter
-
-[social-twitter-image]: https://img.shields.io/twitter/follow/HedgeDocOrg?style=social
 
 [reuse-workflow-badge]: https://github.com/hedgedoc/hedgedoc/workflows/REUSE%20Compliance%20Check/badge.svg
 


### PR DESCRIPTION
### Component/Part

readme

### Description

This patch drops X link for already suspended account.
It's actually linked to mastodon's account.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

- #5338 
