### PR TITLE
refactor(test): Replace inline snapshot with file snapshot

### DIFF
--- a/backend/src/notes/__snapshots__/notes.service.spec.ts.snap
+++ b/backend/src/notes/__snapshots__/notes.service.spec.ts.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotesService toNoteDto works 1`] = `
+{
+  "content": "mockContent",
+  "editedByAtPosition": [],
+  "metadata": {
+    "aliases": [
+      {
+        "name": "testAlias",
+        "noteId": "testId",
+        "primaryAlias": true,
+      },
+    ],
+    "createdAt": undefined,
+    "description": "mockDescription",
+    "editedBy": [
+      "hardcoded",
+    ],
+    "id": "testId",
+    "permissions": {
+      "owner": "hardcoded",
+      "sharedToGroups": [
+        {
+          "canEdit": true,
+          "groupName": "testGroup",
+        },
+      ],
+      "sharedToUsers": [
+        {
+          "canEdit": true,
+          "username": "hardcoded",
+        },
+      ],
+    },
+    "primaryAddress": "testAlias",
+    "tags": [
+      "tag1",
+    ],
+    "title": "mockTitle",
+    "updateUsername": "hardcoded",
+    "updatedAt": 2019-02-04T20:34:12.000Z,
+    "version": undefined,
+    "viewCount": 1337,
+  },
+}
+`;
+
+exports[`NotesService toNoteMetadataDto works 1`] = `
+{
+  "aliases": [
+    {
+      "name": "testAlias",
+      "noteId": "testId",
+      "primaryAlias": true,
+    },
+  ],
+  "createdAt": undefined,
+  "description": "mockDescription",
+  "editedBy": [
+    "hardcoded",
+  ],
+  "id": "testId",
+  "permissions": {
+    "owner": "hardcoded",
+    "sharedToGroups": [
+      {
+        "canEdit": true,
+        "groupName": "testGroup",
+      },
+    ],
+    "sharedToUsers": [
+      {
+        "canEdit": true,
+        "username": "hardcoded",
+      },
+    ],
+  },
+  "primaryAddress": "testAlias",
+  "tags": [
+    "tag1",
+  ],
+  "title": "mockTitle",
+  "updateUsername": "hardcoded",
+  "updatedAt": 2019-02-04T20:34:12.000Z,
+  "version": undefined,
+  "viewCount": 1337,
+}
+`;
+
+exports[`NotesService toNotePermissionsDto works 1`] = `
+{
+  "owner": "hardcoded",
+  "sharedToGroups": [
+    {
+      "canEdit": true,
+      "groupName": "testGroup",
+    },
+  ],
+  "sharedToUsers": [
+    {
+      "canEdit": true,
+      "username": "hardcoded",
+    },
+  ],
+}
+`;

--- a/backend/src/notes/notes.service.spec.ts
+++ b/backend/src/notes/notes.service.spec.ts
@@ -688,23 +688,7 @@ describe('NotesService', () => {
     it('works', async () => {
       const [note] = await getMockData();
       const permissions = await service.toNotePermissionsDto(note);
-      expect(permissions).toMatchInlineSnapshot(`
-        {
-          "owner": "hardcoded",
-          "sharedToGroups": [
-            {
-              "canEdit": true,
-              "groupName": "testGroup",
-            },
-          ],
-          "sharedToUsers": [
-            {
-              "canEdit": true,
-              "username": "hardcoded",
-            },
-          ],
-        }
-      `);
+      expect(permissions).toMatchSnapshot();
     });
   });
 
@@ -716,47 +700,7 @@ describe('NotesService', () => {
       ]);
 
       const metadataDto = await service.toNoteMetadataDto(note);
-      expect(metadataDto).toMatchInlineSnapshot(`
-        {
-          "aliases": [
-            {
-              "name": "testAlias",
-              "noteId": "testId",
-              "primaryAlias": true,
-            },
-          ],
-          "createdAt": undefined,
-          "description": "mockDescription",
-          "editedBy": [
-            "hardcoded",
-          ],
-          "id": "testId",
-          "permissions": {
-            "owner": "hardcoded",
-            "sharedToGroups": [
-              {
-                "canEdit": true,
-                "groupName": "testGroup",
-              },
-            ],
-            "sharedToUsers": [
-              {
-                "canEdit": true,
-                "username": "hardcoded",
-              },
-            ],
-          },
-          "primaryAddress": "testAlias",
-          "tags": [
-            "tag1",
-          ],
-          "title": "mockTitle",
-          "updateUsername": "hardcoded",
-          "updatedAt": 2019-02-04T20:34:12.000Z,
-          "version": undefined,
-          "viewCount": 1337,
-        }
-      `);
+      expect(metadataDto).toMatchSnapshot();
     });
 
     it('returns publicId if no alias exists', async () => {
@@ -774,51 +718,7 @@ describe('NotesService', () => {
       ]);
 
       const noteDto = await service.toNoteDto(note);
-      expect(noteDto).toMatchInlineSnapshot(`
-        {
-          "content": "mockContent",
-          "editedByAtPosition": [],
-          "metadata": {
-            "aliases": [
-              {
-                "name": "testAlias",
-                "noteId": "testId",
-                "primaryAlias": true,
-              },
-            ],
-            "createdAt": undefined,
-            "description": "mockDescription",
-            "editedBy": [
-              "hardcoded",
-            ],
-            "id": "testId",
-            "permissions": {
-              "owner": "hardcoded",
-              "sharedToGroups": [
-                {
-                  "canEdit": true,
-                  "groupName": "testGroup",
-                },
-              ],
-              "sharedToUsers": [
-                {
-                  "canEdit": true,
-                  "username": "hardcoded",
-                },
-              ],
-            },
-            "primaryAddress": "testAlias",
-            "tags": [
-              "tag1",
-            ],
-            "title": "mockTitle",
-            "updateUsername": "hardcoded",
-            "updatedAt": 2019-02-04T20:34:12.000Z,
-            "version": undefined,
-            "viewCount": 1337,
-          },
-        }
-      `);
+      expect(noteDto).toMatchSnapshot();
     });
   });
 });

--- a/backend/src/revisions/__snapshots__/revisions.service.spec.ts.snap
+++ b/backend/src/revisions/__snapshots__/revisions.service.spec.ts.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RevisionsService createRevision creates a new revision 1`] = `
+[
+  Tag {
+    "name": "tag1",
+  },
+]
+`;
+
+exports[`RevisionsService createRevision creates a new revision 2`] = `
+"Index: test-note
+===================================================================
+--- test-note
++++ test-note
+@@ -1,1 +1,6 @@
+-old content
++---
++title: new title
++description: new description
++tags: [ "tag1" ]
++---
++new content
+"
+`;
+
 exports[`RevisionsService purgeRevisions purges the revision history 1`] = `
 "Index: test-note
 ===================================================================
@@ -44,4 +68,49 @@ exports[`RevisionsService removeOldRevisions remove all revisions except latest 
 +---
 +new content
 "
+`;
+
+exports[`RevisionsService toRevisionDto converts a revision 1`] = `
+{
+  "anonymousAuthorCount": 0,
+  "authorUsernames": [
+    "mockusername",
+  ],
+  "content": "mockContent",
+  "createdAt": 2020-05-20T09:58:00.000Z,
+  "description": "mockDescription",
+  "edits": [
+    {
+      "createdAt": 2020-03-04T22:32:00.000Z,
+      "endPos": 93,
+      "startPos": 34,
+      "updatedAt": 2021-02-10T12:23:00.000Z,
+      "username": "mockusername",
+    },
+  ],
+  "id": 3246,
+  "length": 1854,
+  "patch": "mockPatch",
+  "tags": [
+    "mockTag",
+  ],
+  "title": "mockTitle",
+}
+`;
+
+exports[`RevisionsService toRevisionMetadataDto converts a revision 1`] = `
+{
+  "anonymousAuthorCount": 0,
+  "authorUsernames": [
+    "mockusername",
+  ],
+  "createdAt": 2020-05-20T09:58:00.000Z,
+  "description": "mockDescription",
+  "id": 3246,
+  "length": 1854,
+  "tags": [
+    "mockTag",
+  ],
+  "title": "mockTitle",
+}
 `;

--- a/backend/src/revisions/revisions.service.spec.ts
+++ b/backend/src/revisions/revisions.service.spec.ts
@@ -265,23 +265,7 @@ describe('RevisionsService', () => {
           }),
         ]),
       });
-      expect(await service.toRevisionMetadataDto(revision))
-        .toMatchInlineSnapshot(`
-        {
-          "anonymousAuthorCount": 0,
-          "authorUsernames": [
-            "mockusername",
-          ],
-          "createdAt": 2020-05-20T09:58:00.000Z,
-          "description": "mockDescription",
-          "id": 3246,
-          "length": 1854,
-          "tags": [
-            "mockTag",
-          ],
-          "title": "mockTitle",
-        }
-      `);
+      expect(await service.toRevisionMetadataDto(revision)).toMatchSnapshot();
     });
   });
 
@@ -314,33 +298,7 @@ describe('RevisionsService', () => {
           }),
         ]),
       });
-      expect(await service.toRevisionDto(revision)).toMatchInlineSnapshot(`
-        {
-          "anonymousAuthorCount": 0,
-          "authorUsernames": [
-            "mockusername",
-          ],
-          "content": "mockContent",
-          "createdAt": 2020-05-20T09:58:00.000Z,
-          "description": "mockDescription",
-          "edits": [
-            {
-              "createdAt": 2020-03-04T22:32:00.000Z,
-              "endPos": 93,
-              "startPos": 34,
-              "updatedAt": 2021-02-10T12:23:00.000Z,
-              "username": "mockusername",
-            },
-          ],
-          "id": 3246,
-          "length": 1854,
-          "patch": "mockPatch",
-          "tags": [
-            "mockTag",
-          ],
-          "title": "mockTitle",
-        }
-      `);
+      expect(await service.toRevisionDto(revision)).toMatchSnapshot();
     });
   });
 
@@ -362,31 +320,11 @@ describe('RevisionsService', () => {
       const createdRevision = await service.createRevision(note, newContent);
       expect(createdRevision).not.toBeUndefined();
       expect(createdRevision?.content).toBe(newContent);
-      await expect(createdRevision?.tags).resolves.toMatchInlineSnapshot(`
-        [
-          Tag {
-            "name": "tag1",
-          },
-        ]
-      `);
+      await expect(createdRevision?.tags).resolves.toMatchSnapshot();
       expect(createdRevision?.title).toBe('new title');
       expect(createdRevision?.description).toBe('new description');
       await expect(createdRevision?.note).resolves.toBe(note);
-      expect(createdRevision?.patch).toMatchInlineSnapshot(`
-        "Index: test-note
-        ===================================================================
-        --- test-note
-        +++ test-note
-        @@ -1,1 +1,6 @@
-        -old content
-        +---
-        +title: new title
-        +description: new description
-        +tags: [ "tag1" ]
-        +---
-        +new content
-        "
-      `);
+      expect(createdRevision?.patch).toMatchSnapshot();
     });
 
     it("won't create a revision if content is unchanged", async () => {

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/revisions-sidebar-entry/revisions-modal/__snapshots__/invert-unified-patch.spec.ts.snap
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/revisions-sidebar-entry/revisions-modal/__snapshots__/invert-unified-patch.spec.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`invert unified patch inverts a patch correctly 1`] = `
+{
+  "hunks": [
+    {
+      "linedelimiters": [
+        "
+",
+        "
+",
+        "
+",
+        "
+",
+        "
+",
+        "
+",
+      ],
+      "lines": [
+        "+a",
+        "+b",
+        " c",
+        " d",
+        "-d",
+        " e",
+      ],
+      "newLines": 5,
+      "newStart": 1,
+      "oldLines": 4,
+      "oldStart": 1,
+    },
+  ],
+  "index": undefined,
+  "newFileName": "a",
+  "newHeader": "2022-07-03 21:21:07.499933337 +0200",
+  "oldFileName": "b",
+  "oldHeader": "2022-07-03 21:22:28.650972217 +0200",
+}
+`;

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/revisions-sidebar-entry/revisions-modal/invert-unified-patch.spec.ts
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/revisions-sidebar-entry/revisions-modal/invert-unified-patch.spec.ts
@@ -18,44 +18,6 @@ describe('invert unified patch', () => {
 +d
  e`)[0]
     const result = invertUnifiedPatch(parsedPatch)
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "hunks": [
-          {
-            "linedelimiters": [
-              "
-      ",
-              "
-      ",
-              "
-      ",
-              "
-      ",
-              "
-      ",
-              "
-      ",
-            ],
-            "lines": [
-              "+a",
-              "+b",
-              " c",
-              " d",
-              "-d",
-              " e",
-            ],
-            "newLines": 5,
-            "newStart": 1,
-            "oldLines": 4,
-            "oldStart": 1,
-          },
-        ],
-        "index": undefined,
-        "newFileName": "a",
-        "newHeader": "2022-07-03 21:21:07.499933337 +0200",
-        "oldFileName": "b",
-        "oldHeader": "2022-07-03 21:22:28.650972217 +0200",
-      }
-    `)
+    expect(result).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
### Component/Part

test

### Description

This PR replaces all existing embedded(inline) snapshots with normal(file) snapshots.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

- https://github.com/hedgedoc/hedgedoc/pull/5574#discussion_r1614953408
- https://github.com/hedgedoc/hedgedoc/pull/5349#discussion_r1614960141
