### PR TITLE
Feat: Add OIDC state parameter

### DIFF
--- a/backend/src/api/private/auth/oidc/oidc.controller.ts
+++ b/backend/src/api/private/auth/oidc/oidc.controller.ts
@@ -41,12 +41,15 @@ export class OidcController {
     @Param('oidcIdentifier') oidcIdentifier: string,
   ): { url: string } {
     const code = this.oidcService.generateCode();
+    const state = this.oidcService.generateState();
     request.session.oidcLoginCode = code;
+    request.session.oidcLoginState = state;
     request.session.authProviderType = ProviderType.OIDC;
     request.session.authProviderIdentifier = oidcIdentifier;
     const authorizationUrl = this.oidcService.getAuthorizationUrl(
       oidcIdentifier,
       code,
+      state,
     );
     return { url: authorizationUrl };
   }

--- a/backend/src/sessions/session.service.ts
+++ b/backend/src/sessions/session.service.ts
@@ -43,6 +43,9 @@ export interface SessionState {
   /** The (random) OIDC code for verifying that OIDC responses match the OIDC requests */
   oidcLoginCode?: string;
 
+  /** The (random) OIDC state for verifying that OIDC responses match the OIDC requests */
+  oidcLoginState?: string;
+
   /** The user id as provided from the external auth provider, required for matching to a HedgeDoc identity */
   providerUserId?: string;
 


### PR DESCRIPTION
### Component/Part

Auth/OIDC

### Description

While integrating HedgeDoc 2 with Authelia, I encountered an invalid_state error from Authelia. This is because HedgeDoc 2 does not use state during OIDC authorization. Honestly, I'm not very familiar with OIDC, but from my understanding, implementing both PKCE and [state](https://arc.net/l/quote/ogpluvht) is a good security practice. Therefore, I created this PR.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->
 - [x] Added implementation
 - Added / updated tests (Perhaps implemented by #5792)
 - [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
made sure that:
My commits are signed-off to accept the DCO.
This PR targets the correct branch: master for 1.x & docs, develop for 2.x

### Related Issue(s)

None