### PR TITLE
fix: use more complex parsing for inline css statement splitting

### DIFF
--- a/html-to-react/src/utils/convertInlineStyleToMap.ts
+++ b/html-to-react/src/utils/convertInlineStyleToMap.ts
@@ -17,9 +17,34 @@ export function convertInlineStyleToMap(
     return {}
   }
 
-  return inlineStyle
-    .split(';')
-    .reduce<Record<string, string>>((styleObject, stylePropertyValue) => {
+  const statements: string[] = []
+  let i = -1
+  let offset = 0
+  do {
+    i++
+    let curr = inlineStyle[i]
+    let prev = inlineStyle[i - 1]
+
+    if ((curr === "'" || curr === '"') && prev !== '\\') {
+      const quote = curr
+      do {
+        i++
+        curr = inlineStyle[i]
+        prev = inlineStyle[i - 1]
+      } while (!(curr === quote && prev !== '\\') && i < inlineStyle.length)
+      continue
+    }
+
+    if (curr === ';' && prev !== '\\') {
+      statements.push(inlineStyle.slice(offset, i))
+      offset = i + 1
+      continue
+    }
+  } while (i < inlineStyle.length)
+  statements.push(inlineStyle.slice(offset, inlineStyle.length))
+
+  return statements.reduce<Record<string, string>>(
+    (styleObject, stylePropertyValue) => {
       // extract the style property name and value
       const [property, value] = stylePropertyValue
         .split(/^([^:]+):/)
@@ -45,5 +70,7 @@ export function convertInlineStyleToMap(
       styleObject[replacedProperty] = value
 
       return styleObject
-    }, {})
+    },
+    {}
+  )
 }


### PR DESCRIPTION
### Component/Part
react-to-html

### Description
Fixes incorrectly splitted statements in inline css that contain non-delimiting `;` characters.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [ ] Added / updated tests
- [ ] Added / updated documentation
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
Fixes #5839