### PR TITLE
fix(oauth2): Fix crash when profile fields are missing

### DIFF
--- a/lib/web/auth/oauth2/index.js
+++ b/lib/web/auth/oauth2/index.js
@@ -20,7 +20,7 @@ class OAuth2CustomStrategy extends Strategy {
 
   userProfile (accessToken, done) {
     this._oauth2.get(this._userProfileURL, accessToken, function (err, body, res) {
-      let json
+      let json, profile
 
       if (err) {
         return done(new InternalOAuthError('Failed to fetch user profile', err))
@@ -33,7 +33,11 @@ class OAuth2CustomStrategy extends Strategy {
       }
 
       checkAuthorization(json, done)
-      const profile = parseProfile(json)
+      try {
+        profile = parseProfile(json)
+      } catch (ex) {
+        return done('Failed to identify user profile information', null)
+      }
       profile.provider = 'oauth2'
 
       done(null, profile)
@@ -97,7 +101,7 @@ function checkAuthorization (data, done) {
 
 OAuth2CustomStrategy.prototype.userProfile = function (accessToken, done) {
   this._oauth2.get(this._userProfileURL, accessToken, function (err, body, res) {
-    let json
+    let json, profile
 
     if (err) {
       return done(new InternalOAuthError('Failed to fetch user profile', err))
@@ -110,7 +114,11 @@ OAuth2CustomStrategy.prototype.userProfile = function (accessToken, done) {
     }
 
     checkAuthorization(json, done)
-    const profile = parseProfile(json)
+    try {
+      profile = parseProfile(json)
+    } catch (ex) {
+      return done('Failed to identify user profile information', null)
+    }
     profile.provider = 'oauth2'
 
     done(null, profile)

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## <i class="fa fa-tag"></i> 1.x.x <i class="fa fa-calendar-o"></i> UNRELEASED
+
+### Bugfixes
+- Fix a crash when cannot read user profile in Oauth
+
 ## <i class="fa fa-tag"></i> 1.10.0 <i class="fa fa-calendar-o"></i> 2024-09-01
 
 This release fixes a security issue when using MySQL/MariaDB. We recommend upgrading as soon as possible, when you use

--- a/yarn.lock
+++ b/yarn.lock
@@ -2938,26 +2938,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.2":
-  version: 1.20.2
-  resolution: "body-parser@npm:1.20.2"
-  dependencies:
-    bytes: "npm:3.1.2"
-    content-type: "npm:~1.0.5"
-    debug: "npm:2.6.9"
-    depd: "npm:2.0.0"
-    destroy: "npm:1.2.0"
-    http-errors: "npm:2.0.0"
-    iconv-lite: "npm:0.4.24"
-    on-finished: "npm:2.4.1"
-    qs: "npm:6.11.0"
-    raw-body: "npm:2.5.2"
-    type-is: "npm:~1.6.18"
-    unpipe: "npm:1.0.0"
-  checksum: 10/3cf171b82190cf91495c262b073e425fc0d9e25cc2bf4540d43f7e7bbca27d6a9eae65ca367b6ef3993eea261159d9d2ab37ce444e8979323952e12eb3df319a
-  languageName: node
-  linkType: hard
-
 "body-parser@npm:1.20.3":
   version: 1.20.3
   resolution: "body-parser@npm:1.20.3"


### PR DESCRIPTION
### Component/Part
auth/oauth2

### Description
This PR fix the issue https://github.com/hedgedoc/hedgedoc/issues/5521 .
If `parseProfile` function throw an error (in example with the bug mentionend in the issue) it will show an error message in the browser and will not crash. 
Its just a new try/catch

### Steps
- [x] Added implementation
- [ ] Added / updated tests
- [ ] Added / updated documentation
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
https://github.com/hedgedoc/hedgedoc/issues/5521