### PR TITLE
fix(csp): allow 'data:' images in pads

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -11,7 +11,7 @@ const defaultDirectives = {
   fontSrc: ['\'self\''],
   manifestSrc: ['\'self\''],
   frameSrc: ['\'self\'', 'https://player.vimeo.com', 'https://www.slideshare.net/slideshow/embed_code/key/', 'https://www.youtube.com'],
-  imgSrc: ['*'], // we allow using arbitrary images
+  imgSrc: ['*', 'data:'], // we allow using arbitrary images & explicit data for mermaid
   scriptSrc: [
     config.serverURL + '/build/',
     config.serverURL + '/js/',

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -4,6 +4,7 @@
 
 ### Bugfixes
 - Fix a crash when cannot read user profile in Oauth
+- Fix CSP Header for mermaid embedded images ([#5887](https://github.com/hedgedoc/hedgedoc/pull/5887) by [@domrim](https://github.com/domrim))
 
 ## <i class="fa fa-tag"></i> 1.10.0 <i class="fa fa-calendar-o"></i> 2024-09-01
 


### PR DESCRIPTION
### Component/Part
CSP

### Description
For embedded mermaid images `img-src: data:` has to be included in the CSP Header.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
