### PR TITLE
feat(frontend): Correctly align todo list checkbox

### DIFF
--- a/frontend/global-styles/markdown-tweaks.scss
+++ b/frontend/global-styles/markdown-tweaks.scss
@@ -23,6 +23,12 @@
     }
   }
 
+  // Fixes checkboxes moving to bottom row if task is multiline
+  ul.contains-task-list > li.task-list-item:has(input.task-list-item-checkbox) {
+    display: flex;
+    align-items: baseline;
+  }
+
   .alert {
     & > p, & > ul {
       margin-bottom: 0;


### PR DESCRIPTION
### Component/Part
frontend

### Description
If a task in a markdown todo list has multiple lines, the checkbox is now correctly placed at the first line and not the last line.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [ ] Added / updated tests
- [ ] Added / updated documentation
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#5907 
