### PR TITLE
docs: add deprecation warning for node v18

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -6,6 +6,10 @@ This release changes the default configuration of the HSTS preload attribute to 
 HSTS preload list requirements. This shouldn't impact any instance. However, if you intend to use HSTS preloading
 you should enable the config setting `hsts.preload` or set environment variable `CMD_HSTS_PRELOAD=true`.
 
+This release deprecates support for Node v18.
+As the LTS support for v18 runs out in April 2025, the next release will only work with Node v20 and upwards.
+Consider this your early warning to upgrade any running instances to at least Node v20.
+
 ### Enhancements
 - Add fixed rate-limiting to the login and register endpoints
 - Add configurable rate-limiting to the new notes endpoint


### PR DESCRIPTION
We don't want to mix security fixes with major dependency updates, so this release will still work with v18, but the next one won't support it anymore.

### Component/Part
release notes

### Description
This PR adds a deprecation warning for node v18

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
