### PR TITLE
docs(setup): list of supported docker architectures

### DIFF
--- a/docs/content/setup/docker.md
+++ b/docs/content/setup/docker.md
@@ -6,7 +6,7 @@
     - [Docker Compose](https://docs.docker.com/compose/install/)
 
 The official docker images are [available on quay.io](https://quay.io/repository/hedgedoc/hedgedoc).
-We currently only support the `amd64` architecture.
+We currently support the `amd64` and `arm64` architectures.
 
 
 The easiest way to get started with HedgeDoc and Docker is to use the following `docker-compose.yml`:


### PR DESCRIPTION
### Component/Part
Docs -> Setup -> Docker

### Description
This PR updates the docs since they mentioned that we only support `amd64` architecture for docker images, when in fact we support `arm64` too since HD 1.9.8.

See 1.10.1 manifest for example: https://quay.io/repository/hedgedoc/hedgedoc/manifest/sha256:a65798c1735d086e0b0fdb57719eeb7d0143b044469ae26b95a46137ea7b1a79

### Steps
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5985 
