### PR TITLE
fix(login): prevent default for new user confirmation form event

### DIFF
--- a/frontend/src/components/login-page/new-user/new-user-card.tsx
+++ b/frontend/src/components/login-page/new-user/new-user-card.tsx
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import type { FormEvent } from 'react'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Button, Card, Form } from 'react-bootstrap'
 import { Trans } from 'react-i18next'
@@ -36,18 +37,22 @@ export const NewUserCard: React.FC = () => {
   const onChangeUsername = useOnInputChange(setUsername)
   const onChangeDisplayName = useOnInputChange(setDisplayName)
 
-  const submitUserdata = useCallback(() => {
-    confirmPendingUser({
-      username,
-      displayName,
-      profilePicture: pictureChoice === ProfilePictureChoice.PROVIDER ? value?.photoUrl : undefined
-    })
-      .then(() => fetchAndSetUser())
-      .then(() => {
-        router.push('/')
+  const submitUserdata = useCallback(
+    (event: FormEvent) => {
+      event.preventDefault()
+      confirmPendingUser({
+        username,
+        displayName,
+        profilePicture: pictureChoice === ProfilePictureChoice.PROVIDER ? value?.photoUrl : undefined
       })
-      .catch(showErrorNotification('login.welcome.error'))
-  }, [username, displayName, pictureChoice, router, showErrorNotification, value?.photoUrl])
+        .then(() => fetchAndSetUser())
+        .then(() => {
+          router.push('/')
+        })
+        .catch(showErrorNotification('login.welcome.error'))
+    },
+    [username, displayName, pictureChoice, router, showErrorNotification, value?.photoUrl]
+  )
 
   const cancelUserCreation = useCallback(() => {
     cancelPendingUser()


### PR DESCRIPTION
### Component/Part
frontend -> login -> new-user form

### Description
The new user form which is shown when a new user logs in via an external auth provider did not include the event.preventDefault() statement. This meant that on submitting the form there was a race-condition between the JS code sending the data to the API and the browser reloading the page. Chromium-based browsers seem to handle events before handling page navigation, and because the form event initiates a page navigation on a successful API response it worked. Firefox seems to call the event handler and the page navigation in parallel, resulting in a loop on the new user form.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
see [matrix chat message](https://matrix.to/#/#hedgedoc:matrix.org/$PYtJkGNZV3S6C1DG5PCNrd_hF8WlDkaPY49dDdcN71o?via=matrix.org&via=envs.net&via=mozilla.org)
