### PR TITLE
fix(turborepo): passthrough HD_* env vars by config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
     "markdown-it-plugins"
   ],
   "scripts": {
-    "build": "dotenv -c production -- turbo --env-mode=loose run build",
-    "build:test": "dotenv -c production -- turbo --env-mode=loose run build:test",
-    "lint": "dotenv -c development -- turbo --env-mode=loose run lint",
-    "lint:fix": "dotenv -c development -- turbo --env-mode=loose run lint:fix",
-    "format": "dotenv -c development -- turbo --env-mode=loose run format",
-    "start:dev": "dotenv -c development -- turbo --env-mode=loose run start:dev",
-    "start": "dotenv -c production -- turbo --env-mode=loose run start",
-    "test:ci": "dotenv -c test -- turbo --env-mode=loose run test:ci --concurrency 1",
-    "test": "dotenv -c test -- turbo --env-mode=loose run test --concurrency 1",
-    "test:e2e:ci": "dotenv -c test -- turbo --env-mode=loose run test:e2e:ci"
+    "build": "dotenv -c production -- turbo run build",
+    "build:test": "dotenv -c production -- turbo run build:test",
+    "lint": "dotenv -c development -- turbo run lint",
+    "lint:fix": "dotenv -c development -- turbo run lint:fix",
+    "format": "dotenv -c development -- turbo run format",
+    "start:dev": "dotenv -c development -- turbo run start:dev",
+    "start": "dotenv -c production -- turbo run start",
+    "test:ci": "dotenv -c test -- turbo run test:ci --concurrency 1",
+    "test": "dotenv -c test -- turbo run test --concurrency 1",
+    "test:e2e:ci": "dotenv -c test -- turbo run test:e2e:ci"
   },
   "packageManager": "yarn@4.5.3",
   "resolutions": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalPassThroughEnv": [
+    "HD_*",
+    "CADDY_HOST"
+  ],
   "tasks": {
     "build": {},
     "@hedgedoc/html-to-react#build": {


### PR DESCRIPTION
### Component/Part
turbo monorepo configuration

### Description
This PR changes the way turbo handles environment variables and is required due to a bug in turborepo.

It seems there's a bug in turborepo which results in turbo not passing through arbitrary environment variables despite `--env-mode=loose` being set. This config option resolves the problem by passing through all HedgeDoc environment variables prefixed by `HD_`. This somewhat also enhances stability and reproducability of builds since other env vars wouldn't interfere anymore.
The additional variable `CADDY_HOST` is required to make overriding the listening port in our Caddyfile work.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
