### PR TITLE
fix(ci): cache cypress binary correctly

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -25,6 +25,21 @@ runs:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
         key: ${{ runner.os }}-yarn
 
+    - name: Get cypress version
+      id: cypress-version
+      run: echo "cyver=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_OUTPUT
+      working-directory: frontend/
+      shell: bash
+
+    - name: Cache cypress binaries
+      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      id: cypress-cache
+      with:
+        path: /home/runner/.cache/cypress
+        key: cypress-${{ runner.os }}-${{ steps.cypress-version.outputs.cyver }}
+        restore-keys: |
+          cypress-${{ runner.os }}-${{ steps.cypress-version.outputs.cyver }}
+
     - name: Set up NodeJS
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
@@ -34,3 +49,5 @@ runs:
       run: yarn install --immutable
       working-directory: .
       shell: bash
+      env:
+        CYPRESS_CACHE_FOLDER: /home/runner/.cache/cypress

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
 
     - name: Cache yarn cache
-      uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+      uses: actions/cache@v4.2.3 # v4.2.1
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -32,7 +32,7 @@ runs:
       shell: bash
 
     - name: Cache cypress binaries
-      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      uses: actions/cache@v4.2.3 # v4.1.2
       id: cypress-cache
       with:
         path: /home/runner/.cache/cypress
@@ -41,7 +41,7 @@ runs:
           cypress-${{ runner.os }}-${{ steps.cypress-version.outputs.cyver }}
 
     - name: Set up NodeJS
-      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      uses: actions/setup-node@v4.4.0 # v4.1.0
       with:
         node-version: ${{ inputs.NODEJS_VERSION }}
 

--- a/.github/workflows/docs-netlify-deploy.yml
+++ b/.github/workflows/docs-netlify-deploy.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4.2.2 # v4.2.2
 
       - name: Set up NodeJS
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@v4.4.0 # v4.1.0
         with:
           node-version: ${{ env.NODEJS_VERSION }}
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -211,13 +211,13 @@ jobs:
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           CYPRESS_CONTAINER_ID: ${{ matrix.containers }}
 
-      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # master
+      - uses: actions/upload-artifact@v4.6.2 # master
         if: always()
         with:
           name: screenlog-${{ matrix.containers }}
           path: frontend/screenlog.0
 
-      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # master
+      - uses: actions/upload-artifact@v4.6.2
         if: always()
         with:
           name: screenshots-${{ matrix.containers }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -156,17 +156,11 @@ jobs:
     if: "(github.event_name == 'pull_request_target') == github.event.pull_request.head.repo.fork"
     needs: frontend-build
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.2849.52-1@sha256:3dd9d85309ed42d4befeda0b80e15b93c5ede2d419b6fc93a341ffc7337e3505
-      options: --shm-size=2g
     strategy:
       fail-fast: false
       matrix:
         containers: [ 1, 2, 3 ]
     steps:
-      - name: Install additional packages
-        run: apt-get update && apt-get install -y jq zstd screen curl
-
       - name: Check out repo
         uses: actions/checkout@v4.2.2 # v4.2.2
         with:
@@ -176,6 +170,12 @@ jobs:
         uses: ./.github/actions/setup-node
         with:
           NODEJS_VERSION: ${{ env.NODEJS_VERSION }}
+
+      - name: Show cypress info
+        run: yarn cypress info
+        working-directory: frontend/
+        env:
+          CYPRESS_CACHE_FOLDER: /home/runner/.cache/cypress
 
       - name: Download build
         uses: actions/download-artifact@v4
@@ -203,6 +203,7 @@ jobs:
         run: yarn test:e2e:ci --filter=@hedgedoc/frontend
         shell: bash
         env:
+          CYPRESS_CACHE_FOLDER: /home/runner/.cache/cypress
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -52,7 +52,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@v4.6.2 # v4.4.3
         with:
           name: SARIF file
           path: results.sarif

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -142,7 +142,7 @@
     "@typescript-eslint/eslint-plugin": "8.14.0",
     "@typescript-eslint/parser": "8.14.0",
     "csstype": "3.1.3",
-    "cypress": "13.15.2",
+    "cypress": "13.17.0",
     "cypress-commands": "3.0.0",
     "cypress-fill-command": "1.0.2",
     "dotenv-cli": "7.4.4",

--- a/turbo.json
+++ b/turbo.json
@@ -100,7 +100,8 @@
       ],
       "env": [
         "CYPRESS_CONTAINER_ID"
-      ]
+      ],
+      "passThroughEnv": ["*"]
     },
     "@hedgedoc/backend#test:e2e:ci": {
       "dependsOn": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2722,7 +2722,7 @@ __metadata:
     copy-webpack-plugin: "npm:12.0.2"
     cross-env: "npm:7.0.3"
     csstype: "npm:3.1.3"
-    cypress: "npm:13.15.2"
+    cypress: "npm:13.17.0"
     cypress-commands: "npm:3.0.0"
     cypress-fill-command: "npm:1.0.2"
     d3-graphviz: "npm:5.6.0"
@@ -8999,9 +8999,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:13.15.2":
-  version: 13.15.2
-  resolution: "cypress@npm:13.15.2"
+"cypress@npm:13.17.0":
+  version: 13.17.0
+  resolution: "cypress@npm:13.17.0"
   dependencies:
     "@cypress/request": "npm:^3.0.6"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -9048,7 +9048,7 @@ __metadata:
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/07b1019a82941f3a5986d38dcd630a3ad08398dcd53c2e9bd316dad822b65fa7e4d9822be4e0cc8229747ac1b2bb4fc29747f0b509ff13b1853218a2ce2427aa
+  checksum: 10c0/159ce620e32d2785082aaa1f4f30f203dcec466df4a8e80dfa299035358772fd513c35820070ba8db52e2bf58078a372ff7009068e26967f993656e7da62e221
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
CI

### Description

It seems cypress installs its own binary under a different path than
the path where it later looks for it for running the tests. This
change adds proper versioned caching for the binary to avoid re-
downloads and configures the binary path accordingly.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ ] Added implementation
- [ ] Added / updated tests
- [ ] Added / updated documentation
- [ ] Added changelog snippet
- [ ] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
