### PR TITLE
chore: bump version to 1.10.2

### DIFF
--- a/docs/content/dev/openapi.yml
+++ b/docs/content/dev/openapi.yml
@@ -3,7 +3,7 @@ openapi: 3.0.1
 info:
   title: HedgeDoc
   description: HedgeDoc is an open source collaborative note editor. Several tasks of HedgeDoc can be automated through this API.
-  version: 1.10.1
+  version: 1.10.2
   contact:
     name: HedgeDoc on GitHub
     url: https://github.com/hedgedoc/hedgedoc

--- a/docs/content/setup/docker.md
+++ b/docs/content/setup/docker.md
@@ -28,7 +28,7 @@ services:
     restart: always
   app:
     # Make sure to use the latest release from https://hedgedoc.org/latest-release
-    image: quay.io/hedgedoc/hedgedoc:1.10.1
+    image: quay.io/hedgedoc/hedgedoc:1.10.2
     environment:
       - CMD_DB_URL=postgres://hedgedoc:password@database:5432/hedgedoc
       - CMD_DOMAIN=localhost

--- a/docs/content/setup/manual-setup.md
+++ b/docs/content/setup/manual-setup.md
@@ -19,7 +19,7 @@
 
 1. Check if you meet the [requirements at the top of this document](#manual-installation).
 2. Download the [latest release](https://hedgedoc.org/latest-release/) and extract it.  
-   <small>Alternatively, you can use Git to clone the repository and checkout a release, e.g. with `git clone -b 1.10.1 https://github.com/hedgedoc/hedgedoc.git`.</small>
+   <small>Alternatively, you can use Git to clone the repository and checkout a release, e.g. with `git clone -b 1.10.2 https://github.com/hedgedoc/hedgedoc.git`.</small>
 3. Enter the directory and execute `bin/setup`, which will install the dependencies and create example configs.
 4. Configure HedgeDoc: To get started, you can use this minimal `config.json`:
    ```json
@@ -61,7 +61,7 @@ If you want to upgrade HedgeDoc from an older version, follow these steps:
    and the latest release.
 2. Fully stop your old HedgeDoc server.
 3. [Download](https://hedgedoc.org/latest-release/) the new release and extract it over the old directory.  
-   <small>If you use Git, you can check out the new tag with e.g. `git fetch origin && git checkout 1.10.1`</small>
+   <small>If you use Git, you can check out the new tag with e.g. `git fetch origin && git checkout 1.10.2`</small>
 5. Run `bin/setup`. This will take care of installing dependencies. It is safe to run on an existing installation.
 6. *:octicons-light-bulb-16: If you used the release tarball for 1.7.0 or newer, this step can be skipped.*  
    Build the frontend bundle by running `yarn install --immutable` and `yarn build`. The extra `yarn install --immutable` is necessary as `bin/setup` does not install the       build dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HedgeDoc",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "The best platform to write and share markdown.",
   "main": "app.js",
   "license": "AGPL-3.0",

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -2,6 +2,8 @@
 
 ## <i class="fa fa-tag"></i> 1.x.x <i class="fa fa-calendar-o"></i> UNRELEASED
 
+## <i class="fa fa-tag"></i> 1.10.2 <i class="fa fa-calendar-o"></i> 2025-02-14
+
 **PLEASE CHECK THIS IF YOU USE SAML AUTHENTICATION:**
 This release had to set default values for the username and email address attribute mapping for SAML authentication for
 security reasons.
@@ -10,7 +12,7 @@ See: https://docs.hedgedoc.org/configuration/#saml-login `CMD_SAML_ATTRIBUTE_USE
 
 ### Bugfixes
 - Check if a valid user id is present when using OAuth2
-- Abort SAML login if NameID is undefined instead of logging in with a user named "undefined"
+- Abort SAML login if NameID is undefined instead of logging in with a user named "undefined" (Thanks [@Haanifee](https://github.com/Haanifee))
 - Set default values for username and email attribute mapping in SAML configuration
 
 ## <i class="fa fa-tag"></i> 1.10.1 <i class="fa fa-calendar-o"></i> 2025-02-02


### PR DESCRIPTION
### Component/Part
internal version

### Description
This PR bumps the version of HedgeDoc to 1.10.2

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated documentation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
