### PR TITLE
docs(database): remove mention of mysql

### DIFF
--- a/docs/content/references/config/database.md
+++ b/docs/content/references/config/database.md
@@ -6,13 +6,16 @@ We officially support and test these databases:
 - PostgreSQL
 - MariaDB
 
+!!! warning  
+    We don't necessarily support MySQL.
+
 <!-- markdownlint-disable proper-names -->
-| environment variable  | default | example             | description                                                                                |
-|-----------------------|---------|---------------------|--------------------------------------------------------------------------------------------|
-| `HD_DATABASE_TYPE`    | -       | `postgres`          | The database type you want to use. This can be `postgres`, `mysql`, `mariadb` or `sqlite`. |
+| environment variable  | default | example             | description                                                                            |
+|-----------------------|---------|---------------------|----------------------------------------------------------------------------------------|
+| `HD_DATABASE_TYPE`    | -       | `postgres`          | The database type you want to use. This can be `postgres`, `mariadb` or `sqlite`. |
 | `HD_DATABASE_NAME`    | -       | `hedgedoc`          | The name of the database to use. When using SQLite, this is the path to the database file. |
-| `HD_DATABASE_HOST`    | -       | `db.example.com`    | The host, where the database runs. *Only if you're **not** using `sqlite`.*                |
-| `HD_DATABASE_PORT`    | -       | `5432`              | The port, where the database runs. *Only if you're **not** using `sqlite`.*                |
-| `HD_DATABASE_USER`    | -       | `hedgedoc`          | The user that logs in the database. *Only if you're **not** using `sqlite`.*               |
-| `HD_DATABASE_PASS`    | -       | `password`          | The password to log into the database. *Only if you're **not** using `sqlite`.*            |
+| `HD_DATABASE_HOST`    | -       | `db.example.com`    | The host, where the database runs. *Only if you're **not** using `sqlite`.*            |
+| `HD_DATABASE_PORT`    | -       | `5432`              | The port, where the database runs. *Only if you're **not** using `sqlite`.*            |
+| `HD_DATABASE_USER`    | -       | `hedgedoc`          | The user that logs in the database. *Only if you're **not** using `sqlite`.*           |
+| `HD_DATABASE_PASS`    | -       | `password`          | The password to log into the database. *Only if you're **not** using `sqlite`.*        |
 <!-- markdownlint-enable proper-names -->


### PR DESCRIPTION
### Component/Part
docs

### Description
This PR removes a dangling reference to mysql.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ ] Added implementation
- [ ] Added / updated tests
- [x] Added / updated documentation
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
