### PR TITLE
fix(frontend): fix dompurify.sanitize import

### DIFF
--- a/frontend/src/components/common/html-to-react/html-to-react.tsx
+++ b/frontend/src/components/common/html-to-react/html-to-react.tsx
@@ -6,8 +6,7 @@
 import { measurePerformance } from '../../../utils/measure-performance'
 import type { ParserOptions } from '@hedgedoc/html-to-react'
 import { convertHtmlToReact } from '@hedgedoc/html-to-react'
-import type DOMPurify from 'dompurify'
-import { sanitize } from 'dompurify'
+import DOMPurify from 'dompurify'
 import React, { Fragment, useMemo } from 'react'
 
 export interface HtmlToReactProps {
@@ -28,7 +27,7 @@ const REGEX_URI_SCHEME_NO_SCRIPTS = /^(?!.*script:).+:?/i
 export const HtmlToReact: React.FC<HtmlToReactProps> = ({ htmlCode, domPurifyConfig, parserOptions }) => {
   const elements = useMemo(() => {
     const sanitizedHtmlCode = measurePerformance('html-to-react: sanitize', () => {
-      return sanitize(htmlCode, {
+      return DOMPurify.sanitize(htmlCode, {
         ...domPurifyConfig,
         RETURN_DOM_FRAGMENT: false,
         RETURN_DOM: false,


### PR DESCRIPTION
### Component/Part
Frontend

### Description
The update to dompurify 3.2.4 (902abf72e65903d78ade7bb08c322b9648d07384) broke the import of dompurify.sanitize, which now fails with a TypeScript error (likely related to the introduction of type definitions in 3.2.0). Using the DOMPurify default export fixes the issue.

The issue is reproducible both with the local development server and with the published frontend container; without this fix, the frontend is completely broken.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
