### PR TITLE
Updating Cloudflare warning in Reverse Proxy guide.

### DIFF
--- a/docs/content/guides/reverse-proxy.md
+++ b/docs/content/guides/reverse-proxy.md
@@ -7,8 +7,8 @@ This documentation will cover HTTPS setup, with comments for HTTP setup.
 
 ## Cloudflare
 !!! warning
-    If you use Cloudflare as reverse proxy then you **MUST** disable the minify features for HTML, CSS and JS, or your HedgeDoc instance may be broken.
-    For more information please read the [Cloudflare documentation](https://support.cloudflare.com/hc/en-us/articles/200168196-How-do-I-minify-HTML-CSS-and-JavaScript-to-optimize-my-site-).
+    If you use Cloudflare as reverse proxy, then you **MUST** disable Rocket Loader, or your HedgeDoc instance may be broken.
+    For more information please read the [Cloudflare documentation](https://developers.cloudflare.com/speed/optimization/content/rocket-loader).
 
 ## HedgeDoc config
 


### PR DESCRIPTION
Cloudflare has deprecated the Auto Minify feature as of August 2024, so this warning is no longer correct.

However while setting up HedgeDoc, I noticed another issue when I had Rocket Loader enabled, which also does it's own form of optimization which breaks HedgeDoc's CSP.

### Component/Part
<!-- e.g database -->
Documentation

### Description
This PR updates the documentation warning for using Cloudflare. 

As of August 2024, Cloudflare has deprecated and removed the Auto Minify feature
Link: https://community.cloudflare.com/t/deprecating-auto-minify/655677

However now we have a new Cloudflare product which may break your HedgeDoc instance, [Rocket Loader](https://developers.cloudflare.com/speed/optimization/content/rocket-loader). 

This PR updates the docs to address this.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

