### PR TITLE
Disable Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,11 +9,9 @@
     "group:typescript-eslintMonorepo",
     "docker:enableMajor",
     "docker:pinDigests",
-    "default:automergeDigest",
     ":gitSignOff",
     ":prHourlyLimitNone",
     ":maintainLockFilesWeekly",
-    ":automergePatch",
     ":separateMajorReleases"
   ],
   "baseBranches": [


### PR DESCRIPTION
### Component/Part
Renovate dependency automation

### Description
Due to ongoing package fraud on npm, we decided to disable auto-merge of patch updates for dependencies

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
