### PR TITLE
fix(NotesModule): Add HistoryEntry to resolve API note visibility

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -8,6 +8,10 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 ## [Unreleased]
 
+### Bugfixes
+
+- Fixed API-created notes not appearing in frontend due to missing history entries
+
 ### Removals
 
 - Dropbox Login

--- a/backend/src/notes/notes.module.ts
+++ b/backend/src/notes/notes.module.ts
@@ -8,6 +8,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { GroupsModule } from '../groups/groups.module';
+import { HistoryEntry } from '../history/history-entry.entity';
 import { LoggerModule } from '../logger/logger.module';
 import { NoteGroupPermission } from '../permissions/note-group-permission.entity';
 import { NoteUserPermission } from '../permissions/note-user-permission.entity';
@@ -30,6 +31,7 @@ import { Tag } from './tag.entity';
       NoteUserPermission,
       User,
       Alias,
+      HistoryEntry,
     ]),
     RevisionsModule,
     UsersModule,


### PR DESCRIPTION
### Component/Part
backend/notes

### Description  
This PR fixes a bug where notes created via the API (`/api/v2/notes`) don't appear in the frontend or user history because they lack corresponding `HistoryEntry` records.

### Steps
- [x] Added implementation
- [x] Added / updated tests (none needed - simple dependency fix)
- [x] Added / updated documentation (none needed)
- [x] Added changelog snippet
- [x] I read the contribution documentation and made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `develop` for 2.x

### Related Issue(s)
#6125