### PR TITLE
[HD1] Test with Node 24 in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['18', '20', '22']
+        node: ['18', '20', '22', '24']
     name: Node ${{ matrix.node }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: ./.github/actions/setup-node
         with:
-          NODEJS_VERSION: '22'
+          NODEJS_VERSION: '24'
 
       - name: Run ESLint
         run: yarn run eslint

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -7,6 +7,7 @@
   `none` to completely disable uploads.
 - Allow links to protocols such as xmpp, webcal or geo
 - Switch from deprecated shortid to nanoid module, with 10 character long aliases in "public" links
+- Ensure compatibility with Node 24
 
 ### Bugfixes
 - Ignore the healthcheck endpoint in the "too busy" limiter


### PR DESCRIPTION
### Component/Part
testing in CI

### Description
This PR adds Node 24 (the current LTS) to the list of versions to use in CI.
Furthermore basic functionality tests were done with Node 24 prior to creating this PR.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
