### PR TITLE
refactor: remove NoteService.toNotePermissionsDto

### DIFF
--- a/backend/src/api/private/notes/notes.controller.ts
+++ b/backend/src/api/private/notes/notes.controller.ts
@@ -196,7 +196,7 @@ export class NotesController {
   ): Promise<NotePermissionsDto> {
     const userId = await this.userService.getUserIdByUsername(username);
     await this.permissionService.setUserPermission(noteId, userId, canEdit);
-    return await this.noteService.toNotePermissionsDto(noteId);
+    return await this.permissionService.getPermissionsDtoForNote(noteId);
   }
 
   @UseInterceptors(GetNoteIdInterceptor)
@@ -209,7 +209,7 @@ export class NotesController {
     try {
       const userId = await this.userService.getUserIdByUsername(username);
       await this.permissionService.removeUserPermission(noteId, userId);
-      return await this.noteService.toNotePermissionsDto(noteId);
+      return await this.permissionService.getPermissionsDtoForNote(noteId);
     } catch (e) {
       if (e instanceof NotInDBError) {
         throw new BadRequestException(
@@ -240,7 +240,7 @@ export class NotesController {
     }
     const groupId = await this.groupService.getGroupIdByName(groupName);
     await this.permissionService.setGroupPermission(noteId, groupId, canEdit);
-    return await this.noteService.toNotePermissionsDto(noteId);
+    return await this.permissionService.getPermissionsDtoForNote(noteId);
   }
 
   @UseInterceptors(GetNoteIdInterceptor)
@@ -253,7 +253,7 @@ export class NotesController {
   ): Promise<NotePermissionsDto> {
     const groupId = await this.groupService.getGroupIdByName(groupName);
     await this.permissionService.removeGroupPermission(noteId, groupId);
-    return await this.noteService.toNotePermissionsDto(noteId);
+    return await this.permissionService.getPermissionsDtoForNote(noteId);
   }
 
   @UseInterceptors(GetNoteIdInterceptor)


### PR DESCRIPTION
We already have this function in the PermissionService

### Component/Part
Backend > NoteService

### Description
This PR removes the `toNotePermissionsDto` method from `NoteService` as such a method is already included in the `PermissionService`.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x