### PR TITLE
Fix logo for dark backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,20 @@ SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->
 
-![HedgeDoc Logo](docs/content/images/hedgedoc_logo_black.svg)
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/content/images/hedgedoc_logo_white.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/content/images/hedgedoc_logo_black.svg">
+    <img alt="Hedgedoc Logo" src="docs/content/images/hedgedoc_logo_white.svg">
+  </picture>
+</p>
+
 
 [![#HedgeDoc on matrix.org][matrix.org-image]][matrix.org-url]
 [![version][github-version-badge]][github-release-page]
 [![POEditor][poeditor-image]][poeditor-url]
 [![Mastodon][social-mastodon-image]][social-mastodon]
 ![REUSE Compliance Check][reuse-workflow-badge]
-![Nest.JS CI][nestjs-workflow-badge]
 [![codecov][codecov-badge]][codecov-url]
 
 HedgeDoc lets you create real-time collaborative markdown notes. 


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description

Before:

<img width="978" height="368" alt="image" src="https://github.com/user-attachments/assets/96441284-cd0f-41a3-b9f7-7278e70e57fd" />

After:

<img width="872" height="303" alt="image" src="https://github.com/user-attachments/assets/834b3fe0-cae3-414c-a4ce-5769d1851b20" />

Note that the disappearing nose is still a problem with GitHub's `#000000` background.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ ] Added implementation
- [ ] Added / updated tests
- [ ] Added / updated documentation
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
