### PR TITLE
chore: add docker compose for auth provider

### DIFF
--- a/backend/docker-compose.auth.yml
+++ b/backend/docker-compose.auth.yml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+services:
+  ldap:
+    # renovate: datasource=docker depName=rroemhild/test-openldap
+    image: rroemhild/test-openldap
+    ports:
+      - "10389:10389"
+      - "10636:10636"


### PR DESCRIPTION
### Component/Part
docker compose files

### Description
This PR adds a docker compose file for auth provider

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x