### PR TITLE
fix: add cancel button to media delete dialog

### DIFF
--- a/frontend/src/components/common/modals/__snapshots__/deletion-modal.spec.tsx.snap
+++ b/frontend/src/components/common/modals/__snapshots__/deletion-modal.spec.tsx.snap
@@ -31,6 +31,12 @@ exports[`DeletionModal renders correctly with deletionButtonI18nKey 1`] = `
       class="modal-footer"
     >
       <button
+        class="btn btn-secondary"
+        type="button"
+      >
+        common.cancel
+      </button>
+      <button
         class="btn btn-danger"
         type="button"
       >

--- a/frontend/src/components/common/modals/deletion-modal.tsx
+++ b/frontend/src/components/common/modals/deletion-modal.tsx
@@ -55,6 +55,9 @@ export const DeletionModal: React.FC<PropsWithChildren<DeletionModalProps>> = ({
       <Modal.Body>{children}</Modal.Body>
       <Modal.Footer>
         {footerContent}
+        <Button variant='secondary' onClick={onHide}>
+          <Trans i18nKey={'common.cancel'} />
+        </Button>
         <Button {...cypressId('deletionModal.confirmButton')} variant='danger' onClick={onConfirm} disabled={disabled}>
           <Trans i18nKey={deletionButtonI18nKey} />
         </Button>


### PR DESCRIPTION
### Component/Part
media deletion modal

### Description
This PR adds a cancel button to the media deletion modal

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x