### PR TITLE
Add speaker view and speaker notes to slide-options.md

### DIFF
--- a/docs/content/references/slide-options.md
+++ b/docs/content/references/slide-options.md
@@ -167,13 +167,21 @@ custom background image:
 You can add speaker notes to your slides. 
 
 ```markdown
-# Example slide
+---
+type: slide
+...
 
-Slide content
+# This is a test slide
 
-<aside class="notes">
-Notes go here
-</aside>
+I am on your slide
+
+Note: Find me in the notes section in the down right corner in speaker view
+
+---
+
+# Another slide
+
+...
 ```
 
 The notes are not displayed in the presentation view, but you can press `S` there to open a new window with the speaker view. 


### PR DESCRIPTION
### Component/Part
Documentation -> references -> slide options

### Description
This PR adds documentation for speaker view and speaker notes in the references section of the documentation. those are reveal.js features and they work as intended in hedgedoc. as both are tool often and widely used for presentations, I think they should be mentioned.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

