### PR TITLE
docs: fix number of permissions HD1 has

### DIFF
--- a/public/docs/features.md
+++ b/public/docs/features.md
@@ -58,7 +58,7 @@ Similarly to the *save* feature, you can also import a Markdown file from **Drop
 ### Permissions
 
 It is possible to change the access permission of a note through the little button on the top right of the view.
-There are four possible options:
+There are six possible options:
 
 |                                                                                      | Owner read/write | Signed-in read | Signed-in write | Guest read | Guest write |
 |:------------------------------------------------------------------------------------ |:----------------:|:--------------:|:---------------:|:----------:|:-----------:|


### PR DESCRIPTION
### Component/Part
docs / features page

### Description
This PR fixes the features page. It named the wrong number of permissions.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x