### PR TITLE
Per-user Undo/Redo stack

### DIFF
--- a/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
+++ b/frontend/src/components/editor-page/editor-pane/editor-pane.tsx
@@ -182,7 +182,7 @@ export const EditorPane: React.FC<EditorPaneProps> = ({ scrollState, onScroll, o
         height={'100%'}
         maxHeight={'100%'}
         maxWidth={'100%'}
-        basicSetup={true}
+        basicSetup={{ history: false }}
         className={codeMirrorClassName}
         theme={darkModeActivated ? oneDark : undefined}
       />

--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-code-mirror-yjs-extension.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-code-mirror-yjs-extension.ts
@@ -1,17 +1,20 @@
 /*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { useApplicationState } from '../../../../../hooks/common/use-application-state'
 import { YTextSyncViewPlugin } from '../../codemirror-extensions/document-sync/y-text-sync-view-plugin'
 import type { Extension } from '@codemirror/state'
-import { ViewPlugin } from '@codemirror/view'
+import { type EditorView, keymap, ViewPlugin } from '@codemirror/view'
 import type { RealtimeDoc, YDocSyncClientAdapter } from '@hedgedoc/commons'
 import { useEffect, useMemo, useState } from 'react'
 
 /**
  * Creates a {@link Extension code mirror extension} that synchronizes an editor with the given {@link YText ytext}.
+ *
+ * Configures keybindings for undo and redo by using the Yjs {@link UndoManager} for per-user undo and redo.
+ * Mod-Z for undo, Mod-Y and Mod-Shift-Z for redo. Mod = Ctrl or Cmd depending on OS.
  *
  * @param doc The {@link RealtimeDoc realtime doc} that contains the markdown content text channel
  * @param syncAdapter The sync adapter that processes the communication for content synchronisation.
@@ -28,12 +31,42 @@ export const useCodeMirrorYjsExtension = (doc: RealtimeDoc, syncAdapter: YDocSyn
     }
   }, [connected, editorReady, syncAdapter, synchronized])
 
-  return useMemo(
-    () => [
-      ViewPlugin.define(
-        (view) => new YTextSyncViewPlugin(view, doc.getMarkdownContentChannel(), () => setEditorReady(true))
-      )
-    ],
-    [doc]
-  )
+  return useMemo(() => {
+    const yjsViewPlugin = ViewPlugin.define(
+      (view) => new YTextSyncViewPlugin(view, doc.getMarkdownContentChannel(), () => setEditorReady(true))
+    )
+    const undoAction = (view: EditorView): boolean => {
+      const plugin = view.plugin(yjsViewPlugin)
+      if (!plugin) {
+        return false
+      }
+      plugin.undoManager.undo()
+      return true
+    }
+    const redoAction = (view: EditorView): boolean => {
+      const plugin = view.plugin(yjsViewPlugin)
+      if (!plugin) {
+        return false
+      }
+      plugin.undoManager.redo()
+      return true
+    }
+
+    const yjsUndoRedoKeymap = keymap.of([
+      {
+        key: 'Mod-z',
+        run: undoAction
+      },
+      {
+        key: 'Mod-y',
+        run: redoAction
+      },
+      {
+        key: 'Mod-Shift-z',
+        run: redoAction
+      }
+    ])
+
+    return [yjsViewPlugin, yjsUndoRedoKeymap]
+  }, [doc])
 }


### PR DESCRIPTION
### Component/Part
Frontend -> Editor

### Description
This PR adds an own undo/redo stack per user in the editor.
This uses the yjs undo-manager and some keybindings for CodeMirror to call that manager. The undo-manager ensures to only undo or redo changes of the current user.

It can be tested by creating a note and opening it in two browsers.
Use some content like:

```markdown
User 1: 
User 2: 
```

Then write alternating with browser 1 and browser 2 into the note. Pressing <kbd>CTRL</kbd>+<kbd>Z</kbd> (Linux/Windows) or <kbd>CMD</kbd>+<kbd>Z</kbd> (Mac) should undo only the changes in the own line. Likewise, <kbd>CTRL</kbd>+<kbd>Y</kbd> should redo them.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
closes #3609 
