### PR TITLE
Scroll to heading or element linked in URL fragment

### DIFF
--- a/frontend/src/components/common/renderer-iframe/hooks/use-send-fragment-to-renderer.ts
+++ b/frontend/src/components/common/renderer-iframe/hooks/use-send-fragment-to-renderer.ts
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useEditorToRendererCommunicator } from '../../../editor-page/render-context/editor-to-renderer-communicator-context-provider'
+import { CommunicationMessageType } from '../../../render-page/window-post-message-communicator/rendering-message'
+import { useEffect } from 'react'
+
+/**
+ * Sends the URL hash (fragment) to the renderer iframe for scrolling to the relevant heading
+ *
+ * @param rendererReady Defines if the target renderer is ready
+ */
+export const useSendFragmentToRenderer = (rendererReady: boolean): void => {
+  const iframeCommunicator = useEditorToRendererCommunicator()
+
+  useEffect(() => {
+    if (!rendererReady || !iframeCommunicator) {
+      return
+    }
+
+    const sendFragment = (): void => {
+      const hash = window.location.hash
+      if (hash.length <= 1) {
+        return
+      }
+      const elementId = hash.substring(1)
+      iframeCommunicator.sendMessageToOtherSide({
+        type: CommunicationMessageType.SCROLL_TO_ELEMENT,
+        elementId
+      })
+    }
+
+    // timeout is required to wait for the renderer to be ready to scroll
+    const timeoutId = setTimeout(sendFragment, 100)
+
+    window.addEventListener('hashchange', sendFragment)
+    return () => {
+      clearTimeout(timeoutId)
+      window.removeEventListener('hashchange', sendFragment)
+    }
+  }, [iframeCommunicator, rendererReady])
+}

--- a/frontend/src/components/common/renderer-iframe/renderer-iframe.tsx
+++ b/frontend/src/components/common/renderer-iframe/renderer-iframe.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -23,6 +23,7 @@ import { WaitSpinner } from '../wait-spinner/wait-spinner'
 import { useEffectOnRenderTypeChange } from './hooks/use-effect-on-render-type-change'
 import { useForceRenderPageUrlOnIframeLoadCallback } from './hooks/use-force-render-page-url-on-iframe-load-callback'
 import { useSendAdditionalConfigurationToRenderer } from './hooks/use-send-additional-configuration-to-renderer'
+import { useSendFragmentToRenderer } from './hooks/use-send-fragment-to-renderer'
 import { useSendMarkdownToRenderer } from './hooks/use-send-markdown-to-renderer'
 import { useSendScrollState } from './hooks/use-send-scroll-state'
 import styles from './style.module.scss'
@@ -157,6 +158,7 @@ export const RendererIframe: React.FC<RendererIframeProps> = ({
   useEffectOnRenderTypeChange(rendererType, onIframeLoad)
   useSendAdditionalConfigurationToRenderer(rendererReady)
   useSendMarkdownToRenderer(markdownContentLines, rendererReady)
+  useSendFragmentToRenderer(rendererReady)
 
   useSendScrollState(scrollState ?? null, rendererReady)
   useEditorReceiveHandler(

--- a/frontend/src/components/render-page/window-post-message-communicator/rendering-message.ts
+++ b/frontend/src/components/render-page/window-post-message-communicator/rendering-message.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -21,7 +21,8 @@ export enum CommunicationMessageType {
   SET_SLIDE_OPTIONS = 'SET_SLIDE_OPTIONS',
   IMAGE_UPLOAD = 'IMAGE_UPLOAD',
   EXTENSION_EVENT = 'EXTENSION_EVENT',
-  SET_PRINT_MODE = 'SET_PRINT_MODE'
+  SET_PRINT_MODE = 'SET_PRINT_MODE',
+  SCROLL_TO_ELEMENT = 'SCROLL_TO_ELEMENT'
 }
 
 export interface NoPayloadMessage<TYPE extends CommunicationMessageType> {
@@ -93,6 +94,11 @@ export interface OnWordCountCalculatedMessage {
   words: number
 }
 
+export interface ScrollToElementMessage {
+  type: CommunicationMessageType.SCROLL_TO_ELEMENT
+  elementId: string
+}
+
 export type CommunicationMessages =
   | NoPayloadMessage<CommunicationMessageType.RENDERER_READY>
   | NoPayloadMessage<CommunicationMessageType.ENABLE_RENDERER_SCROLL_SOURCE>
@@ -108,6 +114,7 @@ export type CommunicationMessages =
   | ImageUploadMessage
   | ExtensionEvent
   | SetPrintModeConfigurationMessage
+  | ScrollToElementMessage
 
 export type EditorToRendererMessageType =
   | CommunicationMessageType.SET_MARKDOWN_CONTENT
@@ -118,6 +125,7 @@ export type EditorToRendererMessageType =
   | CommunicationMessageType.SET_SLIDE_OPTIONS
   | CommunicationMessageType.DISABLE_RENDERER_SCROLL_SOURCE
   | CommunicationMessageType.SET_PRINT_MODE
+  | CommunicationMessageType.SCROLL_TO_ELEMENT
 
 export type RendererToEditorMessageType =
   | CommunicationMessageType.RENDERER_READY


### PR DESCRIPTION
### Component/Part
Editor/Renderer

### Description
This PR adds the automatic scrolling to the correct heading/element when referenced via a hash/fragment in the URL (#heading-1). Due to the renderer sandboxing in a iframe, this requires a message over the editor-to-renderer-communicator.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none