### PR TITLE
Fix CSRF token refresh after logout

### DIFF
--- a/frontend/src/components/landing-layout/navigation/sign-out-dropdown-button.tsx
+++ b/frontend/src/components/landing-layout/navigation/sign-out-dropdown-button.tsx
@@ -13,6 +13,7 @@ import React, { useCallback } from 'react'
 import { Dropdown } from 'react-bootstrap'
 import { BoxArrowRight as IconBoxArrowRight } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
+import { refreshCsrfToken } from '../../../redux/csrf-token/methods'
 
 /**
  * Renders a sign-out button as a dropdown item for the user-dropdown.
@@ -25,7 +26,10 @@ export const SignOutDropdownButton: React.FC = () => {
   const onSignOut = useCallback(() => {
     clearUser()
     doLogout()
-      .then((logoutResponse) => router.push(logoutResponse.redirect))
+      .then(async (logoutResponse) => {
+        await refreshCsrfToken()
+        router.push(logoutResponse.redirect)
+      })
       .catch(showErrorNotificationBuilder('login.logoutFailed'))
   }, [showErrorNotificationBuilder, router])
 


### PR DESCRIPTION
### Component/Part
frontend -> session handling

### Description
This PR fixes the issue where the CSRF token was invalidated after logout due to session invalidation. A new token is now fetched immediately post-logout to avoid requiring a full page reload.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none