### PR TITLE
feat(editor): add button to open current note in read-only/slides mode

### DIFF
--- a/frontend/src/components/document-read-only-page/document-infobar.tsx
+++ b/frontend/src/components/document-read-only-page/document-infobar.tsx
@@ -3,44 +3,21 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { useApplicationState } from '../../hooks/common/use-application-state'
-import { useTranslatedText } from '../../hooks/common/use-translated-text'
-import { InternalLink } from '../common/links/internal-link'
 import { NoteInfoLineCreatedAt } from '../editor-page/sidebar/specific-sidebar-entries/note-info-sidebar-menu/note-info-line/note-info-line-created-at'
 import { NoteInfoLineUpdatedBy } from '../editor-page/sidebar/specific-sidebar-entries/note-info-sidebar-menu/note-info-line/note-info-line-updated-by'
 import styles from './document-infobar.module.scss'
 import React from 'react'
-import { Pencil as IconPencil } from 'react-bootstrap-icons'
 
 /**
  * Renders an info bar with metadata about the current note.
  */
 export const DocumentInfobar: React.FC = () => {
-  const noteDetails = useApplicationState((state) => state.noteDetails)
-  const linkTitle = useTranslatedText('views.readOnly.editNote')
-
-  if (noteDetails === null) {
-    return null
-  }
-
   return (
     <div className={`d-flex flex-row my-3 ${styles['document-infobar']}`}>
       <div className={'col-md'}>&nbsp;</div>
       <div className={'d-flex flex-fill'}>
-        <div className={'d-flex flex-column'}>
-          <NoteInfoLineCreatedAt />
-          <NoteInfoLineUpdatedBy />
-          <hr />
-        </div>
-        <span className={'ms-auto'}>
-          <InternalLink
-            text={''}
-            href={`/n/${noteDetails.primaryAlias}`}
-            icon={IconPencil}
-            className={'text-primary text-decoration-none mx-1'}
-            title={linkTitle}
-          />
-        </span>
+        <NoteInfoLineCreatedAt />
+        <NoteInfoLineUpdatedBy />
       </div>
       <div className={'col-md'}>&nbsp;</div>
     </div>

--- a/frontend/src/components/document-read-only-page/document-read-only-page-content.tsx
+++ b/frontend/src/components/document-read-only-page/document-read-only-page-content.tsx
@@ -10,6 +10,7 @@ import { RendererType } from '../render-page/window-post-message-communicator/re
 import { DocumentInfobar } from './document-infobar'
 import React, { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
+import { FullscreenButton } from '../render-page/fullscreen-button/fullscreen-button'
 
 /**
  * Renders the read-only version of a note with a header bar that contains information about the note.
@@ -27,6 +28,7 @@ export const DocumentReadOnlyPageContent: React.FC = () => {
         rendererType={RendererType.DOCUMENT}
         onRendererStatusChange={setRendererStatus}
       />
+      <FullscreenButton linkToEditor={true} />
     </Fragment>
   )
 }

--- a/frontend/src/components/editor-page/renderer-pane/renderer-pane.tsx
+++ b/frontend/src/components/editor-page/renderer-pane/renderer-pane.tsx
@@ -12,7 +12,8 @@ import { RendererType } from '../../render-page/window-post-message-communicator
 import { useOnScrollWithLineOffset } from './hooks/use-on-scroll-with-line-offset'
 import { useScrollStateWithoutLineOffset } from './hooks/use-scroll-state-without-line-offset'
 import { NoteType } from '@hedgedoc/commons'
-import React from 'react'
+import React, { Fragment } from 'react'
+import { FullscreenButton } from '../../render-page/fullscreen-button/fullscreen-button'
 
 export type RendererPaneProps = Omit<
   RendererIframeProps,
@@ -37,13 +38,16 @@ export const RendererPane: React.FC<RendererPaneProps> = ({ scrollState, onScrol
   }
 
   return (
-    <RendererIframe
-      {...props}
-      onScroll={adjustedOnScroll}
-      scrollState={adjustedScrollState}
-      rendererType={noteType === NoteType.SLIDE ? RendererType.SLIDESHOW : RendererType.DOCUMENT}
-      markdownContentLines={trimmedContentLines}
-      onRendererStatusChange={setRendererStatus}
-    />
+    <Fragment>
+      <RendererIframe
+        {...props}
+        onScroll={adjustedOnScroll}
+        scrollState={adjustedScrollState}
+        rendererType={noteType === NoteType.SLIDE ? RendererType.SLIDESHOW : RendererType.DOCUMENT}
+        markdownContentLines={trimmedContentLines}
+        onRendererStatusChange={setRendererStatus}
+      />
+      <FullscreenButton linkToEditor={false} />
+    </Fragment>
   )
 }

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/share-note-sidebar-entry/share-modal/note-url-field.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/share-note-sidebar-entry/share-modal/note-url-field.tsx
@@ -3,10 +3,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { useApplicationState } from '../../../../../../hooks/common/use-application-state'
-import { useBaseUrl } from '../../../../../../hooks/common/use-base-url'
 import { CopyableField } from '../../../../../common/copyable/copyable-field/copyable-field'
-import React, { useMemo } from 'react'
+import React from 'react'
+import { useNoteLinks } from '../../../../../../hooks/common/use-note-links'
 
 export enum LinkType {
   EDITOR = 'n',
@@ -23,17 +22,7 @@ export interface LinkFieldProps {
  * @param type defines the URL type. (editor, read only document, slideshow, etc.)
  */
 export const NoteUrlField: React.FC<LinkFieldProps> = ({ type }) => {
-  const baseUrl = useBaseUrl()
-  const noteAlias = useApplicationState((state) => state.noteDetails?.primaryAlias)
-
-  const url = useMemo(() => {
-    if (noteAlias === undefined) {
-      return null
-    }
-    const url = new URL(baseUrl)
-    url.pathname += `${type}/${noteAlias}`
-    return url.toString()
-  }, [baseUrl, noteAlias, type])
-
+  const noteLinks = useNoteLinks()
+  const url = noteLinks[type]
   return !url ? null : <CopyableField content={url} shareOriginUrl={url} />
 }

--- a/frontend/src/components/render-page/fullscreen-button/fullscreen-button.module.scss
+++ b/frontend/src/components/render-page/fullscreen-button/fullscreen-button.module.scss
@@ -4,20 +4,15 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-.markdown-toc-sidebar-button {
+.fullscreen-button {
   position: fixed;
-  right: 5rem;
+  right: 4rem;
   bottom: 1rem;
-
-  & > :global(.dropup) {
-    position: sticky;
-    bottom: 20px;
-    right: 0;
-  }
+  z-index: 900;
 }
 
 @media print {
-  .markdown-toc-sidebar-button {
+  .fullscreen-button {
     display: none;
   }
 }

--- a/frontend/src/components/render-page/fullscreen-button/fullscreen-button.tsx
+++ b/frontend/src/components/render-page/fullscreen-button/fullscreen-button.tsx
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import styles from './fullscreen-button.module.scss'
+import React from 'react'
+import {
+  ArrowsFullscreen as IconArrowsFullscreen,
+  CollectionPlay as IconCollectionPlay,
+  type Icon,
+  Pencil as IconPencil
+} from 'react-bootstrap-icons'
+import Link from 'next/link'
+import { UiIcon } from '../../common/icons/ui-icon'
+import { Button } from 'react-bootstrap'
+import { useNoteLinks } from '../../../hooks/common/use-note-links'
+import { useApplicationState } from '../../../hooks/common/use-application-state'
+import { NoteType } from '@hedgedoc/commons'
+import { LinkType } from '../../editor-page/sidebar/specific-sidebar-entries/share-note-sidebar-entry/share-modal/note-url-field'
+
+interface FullscreenButtonProps {
+  linkToEditor: boolean
+}
+
+/**
+ * Renders a button hovering over the parent.
+ * When clicking it, you either get the read-only view or the presentation mode depending on the type of note you currently view.
+ */
+export const FullscreenButton: React.FC<FullscreenButtonProps> = ({ linkToEditor }) => {
+  const noteLinks = useNoteLinks()
+  const noteType = useApplicationState((state) => state.noteDetails.frontmatter.type)
+
+  if (!noteType) {
+    return null
+  }
+
+  let correctLink: string | null
+  let icon: Icon | null
+
+  if (linkToEditor) {
+    correctLink = noteLinks[LinkType.EDITOR]
+    icon = IconPencil
+  } else {
+    switch (noteType) {
+      case NoteType.SLIDE:
+        correctLink = noteLinks[LinkType.SLIDESHOW]
+        icon = IconCollectionPlay
+        break
+      case NoteType.DOCUMENT:
+      default:
+        correctLink = noteLinks[LinkType.DOCUMENT]
+        icon = IconArrowsFullscreen
+    }
+  }
+
+  return (
+    <Link href={correctLink} passHref={true} target={'_blank'} className={styles['fullscreen-button']}>
+      <Button variant={'secondary'}>
+        <UiIcon icon={icon} />
+      </Button>
+    </Link>
+  )
+}

--- a/frontend/src/components/render-page/markdown-toc-button/table-of-contents-hovering-button.tsx
+++ b/frontend/src/components/render-page/markdown-toc-button/table-of-contents-hovering-button.tsx
@@ -26,7 +26,7 @@ export const TableOfContentsHoveringButton: React.FC<MarkdownTocButtonProps> = (
   return (
     <div className={styles['markdown-toc-sidebar-button']}>
       <Dropdown drop={'up'}>
-        <Dropdown.Toggle id='toc-overlay-button' variant={'secondary'} className={'no-arrow'}>
+        <Dropdown.Toggle variant={'secondary'} className={'no-arrow'}>
           <UiIcon icon={IconListOl} />
         </Dropdown.Toggle>
         <Dropdown.Menu>

--- a/frontend/src/hooks/common/use-note-links.ts
+++ b/frontend/src/hooks/common/use-note-links.ts
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useBaseUrl } from './use-base-url'
+import { useApplicationState } from './use-application-state'
+import { useMemo } from 'react'
+import { LinkType } from '../../components/editor-page/sidebar/specific-sidebar-entries/share-note-sidebar-entry/share-modal/note-url-field'
+
+/**
+ * Provides the URLs to the current note in different view modes.
+ */
+export const useNoteLinks = () => {
+  const baseUrl = useBaseUrl()
+  const primaryAlias = useApplicationState((state) => state.noteDetails.primaryAlias)
+
+  return useMemo(() => {
+    const editor = primaryAlias ? new URL(`n/${primaryAlias}`, baseUrl).toString() : ''
+    const presentation = primaryAlias ? new URL(`p/${primaryAlias}`, baseUrl).toString() : ''
+    const readOnly = primaryAlias ? new URL(`s/${primaryAlias}`, baseUrl).toString() : ''
+    return {
+      [LinkType.EDITOR]: editor,
+      [LinkType.SLIDESHOW]: presentation,
+      [LinkType.DOCUMENT]: readOnly
+    } as const
+  }, [baseUrl, primaryAlias])
+}


### PR DESCRIPTION
### Component/Part
editor

### Description
This PR adds a floating fullscreen button

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#5133 
