### PR TITLE
feat(backend): set charset to utf8mb4 for mariadb

### DIFF
--- a/backend/src/config/database.config.ts
+++ b/backend/src/config/database.config.ts
@@ -117,6 +117,7 @@ export function getKnexConfig(databaseConfig: DatabaseConfig): Knex.Config {
           database: databaseConfig.name,
           password: databaseConfig.password,
           dateStrings: true,
+          charset: 'utf8mb4',
         },
         pool: {
           min: 0,

--- a/backend/test/test-setup.ts
+++ b/backend/test/test-setup.ts
@@ -236,6 +236,7 @@ export class TestSetupBuilder {
             host: process.env.HD_DATABASE_HOST || 'localhost',
             port: parseInt(process.env.HD_DATABASE_PORT || '3306'),
             dateStrings: true,
+            charset: 'utf8mb4',
           },
         };
       default:


### PR DESCRIPTION
### Component/Part
backend

### Description
This PR adds the charset utf8mb4

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #134 
