### PR TITLE
Image: use relative url

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -100,6 +100,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - If only one external login provider is configured, the sign-in button will directly link to it.
 - Links in Gist-Frames work only if explicitly opened in new tabs.
 - Changed default editor-placeholder to include the full url to the /features-page as new users might not find it otherwise.
+- Changed image path to be relative.
 
 ---
 

--- a/frontend/src/components/editor-page/editor-pane/hooks/use-handle-upload.tsx
+++ b/frontend/src/components/editor-page/editor-pane/hooks/use-handle-upload.tsx
@@ -15,7 +15,6 @@ import type { CursorSelection } from '../tool-bar/formatters/types/cursor-select
 import type { EditorView } from '@codemirror/view'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useBaseUrl } from '../../../../hooks/common/use-base-url'
 import type { ApiError } from 'next/dist/server/api-utils'
 
 /**
@@ -39,7 +38,6 @@ type handleUploadSignature = (
 export const useHandleUpload = (): handleUploadSignature => {
   const { t } = useTranslation()
   const { showErrorNotificationBuilder } = useUiNotifications()
-  const baseUrl = useBaseUrl()
 
   return useCallback(
     (view, file, cursorSelection, description, additionalUrlText) => {
@@ -62,8 +60,7 @@ export const useHandleUpload = (): handleUploadSignature => {
       })
       uploadFile(noteAlias, file)
         .then((uuid) => {
-          const fullUrl = `${baseUrl}media/${uuid}`
-          const replacement = `![${description ?? file.name ?? ''}](${fullUrl}${additionalUrlText ?? ''})`
+          const replacement = `![${description ?? file.name ?? ''}](media/${uuid}${additionalUrlText ?? ''})`
           changeContent(({ markdownContent }) => [
             replaceInContent(markdownContent, uploadPlaceholder, replacement),
             undefined
@@ -81,6 +78,6 @@ export const useHandleUpload = (): handleUploadSignature => {
           ])
         })
     },
-    [showErrorNotificationBuilder, t, baseUrl]
+    [showErrorNotificationBuilder, t]
   )
 }


### PR DESCRIPTION
### Component/Part
Frontend / image url

### Description
Embedding the full URL into the notes is a bit annoying if you want to change hostname (or e.g. hosting from a local IP). Using the relative URL should work in all cases afaik.

I would also like to remove that `additionalUrlText` argument, which is a bit confusing (not sure it works as intended?). It is only used in file `use-on-image-upload-from-renderer.ts` - and not sure it even is set to anything

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

