### PR TITLE
Fix CSRF token refresh after user account deletion

### DIFF
--- a/frontend/src/components/profile-page/account-management/account-deletion-modal.tsx
+++ b/frontend/src/components/profile-page/account-management/account-deletion-modal.tsx
@@ -12,6 +12,7 @@ import { useUiNotifications } from '../../notifications/ui-notification-boundary
 import React, { useCallback } from 'react'
 import { Button, Modal } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
+import { refreshCsrfToken } from '../../../redux/csrf-token/methods'
 
 /**
  * Confirmation modal for deleting your account.
@@ -27,7 +28,10 @@ export const AccountDeletionModal: React.FC<ModalVisibilityProps> = ({ show, onH
     deleteUser()
       .then(() => {
         clearUser()
-        return dispatchUiNotification(
+        return refreshCsrfToken()
+      })
+      .then(() => {
+        dispatchUiNotification(
           'profile.modal.deleteUser.notificationTitle',
           'profile.modal.deleteUser.notificationText',
           {}


### PR DESCRIPTION
### Component/Part
Authentication/CSRF

### Description
This PR fixes the issue where CSRF tokens were not being refreshed correctly after a user deleted their account..

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
This was already fixed for regular logouts in #6432 but we forgot that the delete user functionality logs out the user as well, therefore the requirement for a fresh token is given here as well.