### PR TITLE
Upgrade netlify CLI for 2.0 docs deployment

### DIFF
--- a/.github/workflows/docs-netlify-deploy.yml
+++ b/.github/workflows/docs-netlify-deploy.yml
@@ -10,7 +10,8 @@ on:
     paths: ['docs/**']
 
 env:
-  NETLIFY_VERSION: 13.2.2
+  # renovate: datasource=npm depName=netlify-cli
+  NETLIFY_VERSION: 24.1.1
   NODEJS_VERSION: 24
   PYTHON_VERSION: 3.11
 
@@ -49,4 +50,4 @@ jobs:
       - name: Run netlify CLI deployment
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        run: "npx -y netlify-cli@${{ env.NETLIFY_VERSION }} deploy --build --prod --message \"${{ github.event.head_commit.id }}\""
+        run: "npx -y netlify-cli@${{ env.NETLIFY_VERSION }} deploy --prod --message \"${{ github.event.head_commit.id }}\""


### PR DESCRIPTION
### Component/Part
CI -> Deployment of 2.0 docs

### Description
This PR upgrades the netlify CLI version used to deploy the docs content for upcoming HedgeDoc 2.0 to docs.hedgedoc.dev. The workflow broke some time ago, probably due to the version being outdated. In order to keep this up to date, a renovate config line was added.

### Steps

- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
