### PR TITLE
Improve performance of backend e2e tests

### DIFF
--- a/backend/jest-e2e.json
+++ b/backend/jest-e2e.json
@@ -19,5 +19,7 @@
   },
   "coverageDirectory": "./coverage-e2e",
   "testTimeout": 15000,
-  "reporters": ["default", "github-actions"]
+  "reporters": ["default", "github-actions"],
+  "maxWorkers": 4,
+  "workerIdleMemoryLimit": "1GB"
 }

--- a/backend/test/test-setup.ts
+++ b/backend/test/test-setup.ts
@@ -150,6 +150,7 @@ export class TestSetup {
    * Cleans up Fastify, NestJS, and the database from a test run.
    */
   public async cleanup(): Promise<void> {
+    this.app.getHttpServer().closeAllConnections();
     await this.app.close();
     if (this.knexInstance) {
       await this.knexInstance.destroy();


### PR DESCRIPTION
### Component/Part
Backend tests

### Description
This PR improves the performance of backend end-to-end tests by:  
- Reducing the number of workers and memory allocated per worker in the Jest configuration  
- Forcefully closing open HTTP connections during test cleanup to reduce wait times associated with keepalive requests

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
