### PR TITLE
fix(explore): multiple small fixes

### DIFF
--- a/frontend/src/app/(editor)/explore/layout.tsx
+++ b/frontend/src/app/(editor)/explore/layout.tsx
@@ -9,7 +9,6 @@ import type { PropsWithChildren } from 'react'
 import React, { Fragment, useEffect } from 'react'
 import { Container } from 'react-bootstrap'
 import { Welcome } from '../../../components/explore-page/welcome'
-import { ModeSelection } from '../../../components/explore-page/mode-selection/mode-selection'
 import { PinnedNotes } from '../../../components/explore-page/pinned-notes/pinned-notes'
 import { loadPinnedNotes } from '../../../redux/pinned-notes/methods'
 import { useUiNotifications } from '../../../components/notifications/ui-notification-boundary'
@@ -32,10 +31,7 @@ export default function ExploreLayout({ children }: ExploreLayoutProps) {
         <Welcome />
       </Container>
       <PinnedNotes />
-      <Container>
-        <ModeSelection />
-        {children}
-      </Container>
+      <Container>{children}</Container>
     </Fragment>
   )
 }

--- a/frontend/src/components/explore-page/explore-notes-section/explore-notes-section.module.css
+++ b/frontend/src/components/explore-page/explore-notes-section/explore-notes-section.module.css
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+.filter-and-nav-box {
+  position: sticky;
+  z-index: 1020;
+  top: 0;
+  padding-block-end: 0.25rem;
+  background-color: var(--bs-body-bg);
+}

--- a/frontend/src/components/explore-page/explore-notes-section/explore-notes-section.tsx
+++ b/frontend/src/components/explore-page/explore-notes-section/explore-notes-section.tsx
@@ -13,6 +13,8 @@ import { useUrlParamState } from '../../../hooks/common/use-url-param-state'
 import { SortButton } from './filters/sort-button'
 import { NotesList } from './notes-list/notes-list'
 import { SortMode } from '@hedgedoc/commons'
+import { ModeSelection } from '../mode-selection/mode-selection'
+import styles from './explore-notes-section.module.css'
 
 export interface ExploreNotesSectionProps {
   mode: Mode
@@ -44,11 +46,14 @@ export const ExploreNotesSection: React.FC<ExploreNotesSectionProps> = ({ mode }
 
   return (
     <Fragment>
-      <search className={'d-flex gap-2 mb-2'}>
-        <FilterByNoteType value={filterByType} onChange={setFilterByType} />
-        <FilterBySearchTerm value={searchFilter} onChange={setSearchFilter} />
-        <SortButton selected={sortMode} onChange={setSortMode} showLastVisitedOptions={mode === Mode.VISITED} />
-      </search>
+      <div className={styles['filter-and-nav-box']}>
+        <ModeSelection />
+        <search className={'d-flex gap-2 mb-2'}>
+          <FilterByNoteType value={filterByType} onChange={setFilterByType} />
+          <FilterBySearchTerm value={searchFilter} onChange={setSearchFilter} />
+          <SortButton selected={sortMode} onChange={setSortMode} showLastVisitedOptions={mode === Mode.VISITED} />
+        </search>
+      </div>
       <NotesList mode={mode} sort={sortMode} searchFilter={searchFilter} typeFilter={filterByType} />
     </Fragment>
   )

--- a/frontend/src/components/explore-page/explore-notes-section/notes-list/note-entry.module.css
+++ b/frontend/src/components/explore-page/explore-notes-section/notes-list/note-entry.module.css
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+.metadata-box {
+  width: 12rem;
+  margin-inline-end: 1rem;
+}

--- a/frontend/src/components/explore-page/explore-notes-section/notes-list/note-entry.tsx
+++ b/frontend/src/components/explore-page/explore-notes-section/notes-list/note-entry.tsx
@@ -21,6 +21,7 @@ import type { NoteExploreEntryInterface } from '@hedgedoc/commons'
 import { useTranslatedText } from '../../../../hooks/common/use-translated-text'
 import { Trans, useTranslation } from 'react-i18next'
 import { PinNoteMenuEntry } from './pin-note-menu-entry'
+import styles from './note-entry.module.css'
 
 interface NoteListEntryProps extends NoteExploreEntryInterface {
   isPinned: boolean
@@ -94,10 +95,10 @@ export const NoteListEntry: React.FC<NoteListEntryProps> = ({
         {tags.length > 0 && <br />}
         <NoteTags tags={tags} />
       </div>
-      <div className={'me-4'}>
+      <div className={styles['metadata-box']}>
         <UserAvatarForUsername username={owner} />
         <br />
-        <small className={'text-muted float-end'}>
+        <small className={'text-muted'}>
           <Trans i18nKey={relativeTime.key} values={{ timeAgo: relativeTime.value }} />
         </small>
       </div>

--- a/frontend/src/components/explore-page/explore-notes-section/notes-list/notes-list.module.css
+++ b/frontend/src/components/explore-page/explore-notes-section/notes-list/notes-list.module.css
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+.infinite-scroll {
+  min-height: 10rem;
+}

--- a/frontend/src/components/explore-page/explore-notes-section/notes-list/notes-list.tsx
+++ b/frontend/src/components/explore-page/explore-notes-section/notes-list/notes-list.tsx
@@ -14,6 +14,7 @@ import InfiniteScroll from 'react-infinite-scroll-component'
 import { useUiNotifications } from '../../../notifications/ui-notification-boundary'
 import { useApplicationState } from '../../../../hooks/common/use-application-state'
 import equal from 'fast-deep-equal'
+import styles from './note-entry.module.css'
 
 export interface NotesListProps {
   mode: Mode
@@ -92,6 +93,7 @@ export const NotesList: React.FC<NotesListProps> = ({ mode, sort, searchFilter, 
 
   return (
     <InfiniteScroll
+      className={styles['infinite-scroll']}
       dataLength={entries.length}
       next={fetchNextPage}
       hasMore={moreDataAvailable}

--- a/frontend/src/components/explore-page/explore-notes-section/notes-list/notes-list.tsx
+++ b/frontend/src/components/explore-page/explore-notes-section/notes-list/notes-list.tsx
@@ -103,7 +103,7 @@ export const NotesList: React.FC<NotesListProps> = ({ mode, sort, searchFilter, 
         </div>
       }
       endMessage={
-        <div className={'text-center fs-4'}>
+        <div className={'text-center fs-4 mt-4'}>
           <p>
             <Trans i18nKey={'explore.noMoreNotesFound'} />
           </p>


### PR DESCRIPTION
### Component/Part
explore page

### Description
This PR adds a few changes to explore page:
- Fixes a problem with the height of the notes list with one element in it (the height is no always at least 12rem or about two entries)
- Add extra margin to endMessag of infinite scroll. This way it looks more clean
- The metadata box (user, lastedit, menu) is now always at a fixed size and looks cleaner
- The navigation and search box is now sticky

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x