### PR TITLE
fix(editor): use setNotePinStatus instead of setPinnedState

### DIFF
--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/pin-note-sidebar-entry/pin-note-sidebar-entry.module.css
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/pin-note-sidebar-entry/pin-note-sidebar-entry.module.css
@@ -1,9 +1,0 @@
-/*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
- *
- * SPDX-License-Identifier: AGPL-3.0-only
- */
-
-.highlighted {
-  color: #b51f08 !important;
-}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/pin-note-sidebar-entry/pin-note-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/pin-note-sidebar-entry/pin-note-sidebar-entry.tsx
@@ -14,7 +14,7 @@ import { Pin as IconPin } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
 import { WaitSpinner } from '../../../../common/wait-spinner/wait-spinner'
 import { useUiNotifications } from '../../../../notifications/ui-notification-boundary'
-import { setPinnedState } from '../../../../../api/explore'
+import { setNotePinStatus } from '../../../../../redux/pinned-notes/methods'
 
 /**
  * Sidebar entry button that toggles the pinned status of the current note in the history.
@@ -34,7 +34,7 @@ export const PinNoteSidebarEntry: React.FC<SpecificSidebarEntryProps> = ({ class
       return
     }
     setLoading(true)
-    setPinnedState(noteAlias, !isPinned)
+    setNotePinStatus(noteAlias, !isPinned)
       .catch(showErrorNotificationBuilder(`explore.pinnedNotes.${isPinned ? 'un' : ''}pinError`, { alias: noteAlias }))
       .finally(() => setLoading(false))
   }, [noteAlias, isPinned, showErrorNotificationBuilder])

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/pin-note-sidebar-entry/pin-note-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/pin-note-sidebar-entry/pin-note-sidebar-entry.tsx
@@ -8,9 +8,8 @@ import { useIsNotePinned } from '../../../../../hooks/common/use-is-note-pinned'
 import { concatCssClasses } from '../../../../../utils/concat-css-classes'
 import { SidebarButton } from '../../sidebar-button/sidebar-button'
 import type { SpecificSidebarEntryProps } from '../../types'
-import styles from './pin-note-sidebar-entry.module.css'
 import React, { useCallback, useState } from 'react'
-import { Pin as IconPin } from 'react-bootstrap-icons'
+import { Pin as IconPin, PinFill as IconPinFill } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
 import { WaitSpinner } from '../../../../common/wait-spinner/wait-spinner'
 import { useUiNotifications } from '../../../../notifications/ui-notification-boundary'
@@ -49,11 +48,7 @@ export const PinNoteSidebarEntry: React.FC<SpecificSidebarEntryProps> = ({ class
   }
 
   return (
-    <SidebarButton
-      icon={IconPin}
-      hide={hide}
-      onClick={onPinClicked}
-      className={concatCssClasses(className, { [styles['highlighted']]: isPinned })}>
+    <SidebarButton icon={isPinned ? IconPinFill : IconPin} hide={hide} onClick={onPinClicked} className={className}>
       <Trans i18nKey={`explore.pinnedNotes.is${isPinned ? 'Pinned' : 'Unpinned'}`} />
     </SidebarButton>
   )


### PR DESCRIPTION
### Component/Part
editor sidebar

### Description

This PR changes the method to pin the note in the sidebar from `setPinnedState` to `setNotePinStatus`.
This method updates the backend and changes the redux state in one call, instead of just calling the backend. With this the state get's updated, and the user see that they pinned a note immediately.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6484
