### PR TITLE
fix(readOnly): make image lightbox usable

### DIFF
--- a/frontend/src/components/document-read-only-page/document-read-only-page-content.tsx
+++ b/frontend/src/components/document-read-only-page/document-read-only-page-content.tsx
@@ -11,6 +11,8 @@ import { DocumentInfobar } from './document-infobar'
 import React, { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FullscreenButton } from '../render-page/fullscreen-button/fullscreen-button'
+import { CommunicatorImageLightbox } from '../markdown-renderer/extensions/image/communicator-image-lightbox'
+import { ExtensionEventEmitterProvider } from '../markdown-renderer/hooks/use-extension-event-emitter'
 
 /**
  * Renders the read-only version of a note with a header bar that contains information about the note.
@@ -22,12 +24,15 @@ export const DocumentReadOnlyPageContent: React.FC = () => {
   return (
     <Fragment>
       <DocumentInfobar />
-      <RendererIframe
-        frameClasses={'flex-fill h-100 w-100'}
-        markdownContentLines={markdownContentLines}
-        rendererType={RendererType.DOCUMENT}
-        onRendererStatusChange={setRendererStatus}
-      />
+      <ExtensionEventEmitterProvider>
+        <CommunicatorImageLightbox />
+        <RendererIframe
+          frameClasses={'flex-fill h-100 w-100'}
+          markdownContentLines={markdownContentLines}
+          rendererType={RendererType.DOCUMENT}
+          onRendererStatusChange={setRendererStatus}
+        />
+      </ExtensionEventEmitterProvider>
       <FullscreenButton linkToEditor={true} />
     </Fragment>
   )


### PR DESCRIPTION
### Component/Part
readOnly page

### Description
This PR fixes the image lightbox in the readOnly page

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6486
