### PR TITLE
fix(readOnly): untangle edit button from toc button

### DIFF
--- a/frontend/src/components/render-page/fullscreen-button/fullscreen-button.module.css
+++ b/frontend/src/components/render-page/fullscreen-button/fullscreen-button.module.css
@@ -6,9 +6,14 @@
 
 .fullscreen-button {
   position: fixed;
-  right: 4rem;
   bottom: 1rem;
   z-index: 900;
+  &.editor {
+    right: 4rem;
+  }
+  &.readonly {
+    right: 1.5rem;
+  }
 }
 
 @media print {

--- a/frontend/src/components/render-page/fullscreen-button/fullscreen-button.tsx
+++ b/frontend/src/components/render-page/fullscreen-button/fullscreen-button.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import styles from './fullscreen-button.module.scss'
+import styles from './fullscreen-button.module.css'
 import React from 'react'
 import {
   ArrowsFullscreen as IconArrowsFullscreen,
@@ -18,6 +18,7 @@ import { useNoteLinks } from '../../../hooks/common/use-note-links'
 import { useApplicationState } from '../../../hooks/common/use-application-state'
 import { NoteType } from '@hedgedoc/commons'
 import { LinkType } from '../../editor-page/sidebar/specific-sidebar-entries/share-note-sidebar-entry/share-modal/note-url-field'
+import { concatCssClasses } from '../../../utils/concat-css-classes'
 
 interface FullscreenButtonProps {
   linkToEditor: boolean
@@ -55,7 +56,15 @@ export const FullscreenButton: React.FC<FullscreenButtonProps> = ({ linkToEditor
   }
 
   return (
-    <Link href={correctLink} passHref={true} target={'_blank'} className={styles['fullscreen-button']}>
+    <Link
+      href={correctLink}
+      passHref={true}
+      target={'_blank'}
+      className={concatCssClasses({
+        [styles['fullscreen-button']]: true,
+        [styles['editor']]: !linkToEditor,
+        [styles['readonly']]: linkToEditor
+      })}>
       <Button variant={'secondary'}>
         <UiIcon icon={icon} />
       </Button>


### PR DESCRIPTION
### Component/Part
readonly page

### Description
This PR fixes the overlapping edit and toc buttons.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6485