### PR TITLE
fix(editor): don't show error if alias is empty

### DIFF
--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/aliases-sidebar-entry/aliases-modal/__snapshots__/aliases-add-form.spec.tsx.snap
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/aliases-sidebar-entry/aliases-modal/__snapshots__/aliases-add-form.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`AliasesAddForm renders the input form 1`] = `
       class="me-1 mb-1 input-group has-validation"
     >
       <input
-        class="form-control is-invalid"
+        class="form-control"
         data-testid="addAliasInput"
         placeholder="editor.modal.aliases.addAlias"
         required=""

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/aliases-sidebar-entry/aliases-modal/aliases-add-form.spec.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/aliases-sidebar-entry/aliases-modal/aliases-add-form.spec.tsx
@@ -9,7 +9,7 @@ import type { NoteDetails } from '../../../../../../redux/note-details/types'
 import { mockI18n } from '../../../../../../test-utils/mock-i18n'
 import { mockNotePermissions } from '../../../../../../test-utils/mock-note-permissions'
 import { AliasesAddForm } from './aliases-add-form'
-import { act, render, screen } from '@testing-library/react'
+import { act, render, type RenderResult, screen } from '@testing-library/react'
 import testEvent from '@testing-library/user-event'
 import React from 'react'
 import { mockUiNotifications } from '../../../../../../test-utils/mock-ui-notifications'
@@ -20,6 +20,9 @@ jest.mock('../../../../../../hooks/common/use-application-state')
 jest.mock('../../../../../notifications/ui-notification-boundary')
 
 describe('AliasesAddForm', () => {
+  let view: RenderResult
+  let input: HTMLElement
+  let button: HTMLElement
   beforeEach(async () => {
     await mockI18n()
     mockUiNotifications()
@@ -28,6 +31,9 @@ describe('AliasesAddForm', () => {
     mockNotePermissions('test', 'test', undefined, {
       noteDetails: { primaryAlias: 'mock-alias-primary' } as NoteDetails
     })
+    view = render(<AliasesAddForm />)
+    input = await screen.findByTestId('addAliasInput')
+    button = await screen.findByTestId('addAliasButton')
   })
 
   afterAll(() => {
@@ -36,17 +42,25 @@ describe('AliasesAddForm', () => {
   })
 
   it('renders the input form', async () => {
-    const view = render(<AliasesAddForm />)
     expect(view.container).toMatchSnapshot()
-    const button = await screen.findByTestId('addAliasButton')
+  })
+  it('valid alias does not show error and enables submit button', async () => {
     expect(button).toBeDisabled()
-    const input = await screen.findByTestId('addAliasInput')
     await testEvent.type(input, 'mock-alias-new')
+    expect(input).not.toHaveClass('is-invalid')
     expect(button).toBeEnabled()
     await act<void>(() => {
       button.click()
     })
     expect(AliasModule.addAlias).toHaveBeenCalledWith('mock-alias-primary', 'mock-alias-new')
     expect(NoteDetailsReduxModule.updateMetadata).toBeCalled()
+  })
+
+  it('invalid alias shows error and disables submit button', async () => {
+    input = await screen.findByTestId('addAliasInput')
+    await testEvent.type(input, ' ')
+    expect(input).toHaveClass('is-invalid')
+    button = await screen.findByTestId('addAliasButton')
+    expect(button).toBeDisabled()
   })
 })

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/aliases-sidebar-entry/aliases-modal/aliases-add-form.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/aliases-sidebar-entry/aliases-modal/aliases-add-form.tsx
@@ -46,6 +46,9 @@ export const AliasesAddForm: React.FC = () => {
   const onNewAliasInputChange = useOnInputChange(setNewAlias)
 
   const newAliasValid = useMemo(() => {
+    if (newAlias === '') {
+      return true
+    }
     return ALIAS_REGEX.test(newAlias)
   }, [newAlias])
 


### PR DESCRIPTION
### Component/Part
editor

### Description
This PR fixes the new alias input field

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6480
