### PR TITLE
fix(frontend): only show register infos when links are configured

### DIFF
--- a/frontend/src/components/login-page/local-login/register/__snapshots__/register-infos.spec.tsx.snap
+++ b/frontend/src/components/login-page/local-login/register/__snapshots__/register-infos.spec.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Register Infos does not show any links if the frontend config links are null: no links 1`] = `<div />`;
+
+exports[`Register Infos only shows privacy links: privacy link 1`] = `
+<div>
+  login.register.infoTermsPrivacy
+  <ul>
+    <li>
+      <a
+        class=""
+        dir="auto"
+        href="https://example.com/privacy"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        appbar.help.legal.privacy
+      </a>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Register Infos only shows termsOfUse links: termsOfUse link 1`] = `
+<div>
+  login.register.infoTermsPrivacy
+  <ul>
+    <li>
+      <a
+        class=""
+        dir="auto"
+        href="https://example.com/terms-of-use"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        appbar.help.legal.termsOfUse
+      </a>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Register Infos show privacy and termsOfUse links: privacy and termsOfUse link 1`] = `
+<div>
+  login.register.infoTermsPrivacy
+  <ul>
+    <li>
+      <a
+        class=""
+        dir="auto"
+        href="https://example.com/terms-of-use"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        appbar.help.legal.termsOfUse
+      </a>
+    </li>
+    <li>
+      <a
+        class=""
+        dir="auto"
+        href="https://example.com/privacy"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        appbar.help.legal.privacy
+      </a>
+    </li>
+  </ul>
+</div>
+`;

--- a/frontend/src/components/login-page/local-login/register/register-infos.spec.tsx
+++ b/frontend/src/components/login-page/local-login/register/register-infos.spec.tsx
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { mockI18n } from '../../../../test-utils/mock-i18n'
+import { render } from '@testing-library/react'
+import { FrontendConfigContextProvider } from '../../../common/frontend-config-context/frontend-config-context-provider'
+import { RegisterInfos } from './register-infos'
+import type { FrontendConfigInterface } from '@hedgedoc/commons'
+import { PermissionLevel } from '@hedgedoc/commons'
+
+describe('Register Infos', () => {
+  let mockFrontendConfig: FrontendConfigInterface
+  beforeAll(mockI18n)
+  beforeEach(() => {
+    mockFrontendConfig = {
+      version: {
+        major: 0,
+        minor: 0,
+        patch: 0,
+        fullString: '',
+        preRelease: undefined,
+        commit: undefined
+      },
+      guestAccess: PermissionLevel.DENY,
+      allowRegister: false,
+      allowProfileEdits: false,
+      allowChooseUsername: false,
+      authProviders: [],
+      branding: {
+        name: null,
+        logo: null
+      },
+      useImageProxy: false,
+      specialUrls: {
+        privacy: null,
+        termsOfUse: null,
+        imprint: null
+      },
+      plantUmlServer: null,
+      maxDocumentLength: 0
+    }
+  })
+
+  it('does not show any links if the frontend config links are null', async () => {
+    const view = render(
+      <FrontendConfigContextProvider config={mockFrontendConfig}>
+        <RegisterInfos />
+      </FrontendConfigContextProvider>
+    )
+    expect(view.container).toMatchSnapshot('no links')
+  })
+
+  it('only shows termsOfUse links', async () => {
+    mockFrontendConfig.specialUrls.termsOfUse = 'https://example.com/terms-of-use'
+    const view = render(
+      <FrontendConfigContextProvider config={mockFrontendConfig}>
+        <RegisterInfos />
+      </FrontendConfigContextProvider>
+    )
+    expect(view.container).toMatchSnapshot('termsOfUse link')
+  })
+
+  it('only shows privacy links', async () => {
+    mockFrontendConfig.specialUrls.privacy = 'https://example.com/privacy'
+    const view = render(
+      <FrontendConfigContextProvider config={mockFrontendConfig}>
+        <RegisterInfos />
+      </FrontendConfigContextProvider>
+    )
+    expect(view.container).toMatchSnapshot('privacy link')
+  })
+
+  it('show privacy and termsOfUse links', async () => {
+    mockFrontendConfig.specialUrls.termsOfUse = 'https://example.com/terms-of-use'
+    mockFrontendConfig.specialUrls.privacy = 'https://example.com/privacy'
+    const view = render(
+      <FrontendConfigContextProvider config={mockFrontendConfig}>
+        <RegisterInfos />
+      </FrontendConfigContextProvider>
+    )
+    expect(view.container).toMatchSnapshot('privacy and termsOfUse link')
+  })
+})

--- a/frontend/src/components/login-page/local-login/register/register-infos.tsx
+++ b/frontend/src/components/login-page/local-login/register/register-infos.tsx
@@ -15,7 +15,7 @@ export const RegisterInfos: React.FC = () => {
   useTranslation()
   const specialUrls = useFrontendConfig().specialUrls
 
-  if (specialUrls.termsOfUse === undefined && specialUrls.privacy === undefined) {
+  if (specialUrls.termsOfUse === null && specialUrls.privacy === null) {
     return null
   }
 
@@ -23,12 +23,12 @@ export const RegisterInfos: React.FC = () => {
     <>
       <Trans i18nKey='login.register.infoTermsPrivacy' />
       <ul>
-        {specialUrls.termsOfUse !== undefined && (
+        {specialUrls.termsOfUse !== null && (
           <li>
             <TranslatedExternalLink i18nKey='appbar.help.legal.termsOfUse' href={specialUrls.termsOfUse ?? ''} />
           </li>
         )}
-        {specialUrls.privacy !== undefined && (
+        {specialUrls.privacy !== null && (
           <li>
             <TranslatedExternalLink i18nKey='appbar.help.legal.privacy' href={specialUrls.privacy ?? ''} />
           </li>


### PR DESCRIPTION
### Component/Part
<!-- e.g database -->

### Description
This PR fixes when the register info links are shown.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6469
