### PR TITLE
Rate-limiting improvements

### DIFF
--- a/backend/src/config/mock/security.config.mock.ts
+++ b/backend/src/config/mock/security.config.mock.ts
@@ -24,8 +24,8 @@ export function createDefaultMockSecurityConfig(): SecurityConfig {
         window: 300,
       },
       auth: {
-        max: 20,
-        window: 600,
+        max: 40,
+        window: 900,
       },
       bypass: [],
     },

--- a/backend/src/config/security.config.spec.ts
+++ b/backend/src/config/security.config.spec.ts
@@ -18,8 +18,8 @@ describe('securityConfig: rate limiting', () => {
     HD_SECURITY_RATE_LIMIT_AUTHENTICATED_WINDOW: '300',
     HD_SECURITY_RATE_LIMIT_UNAUTHENTICATED_MAX: '100',
     HD_SECURITY_RATE_LIMIT_UNAUTHENTICATED_WINDOW: '300',
-    HD_SECURITY_RATE_LIMIT_AUTH_MAX: '20',
-    HD_SECURITY_RATE_LIMIT_AUTH_WINDOW: '600',
+    HD_SECURITY_RATE_LIMIT_AUTH_MAX: '40',
+    HD_SECURITY_RATE_LIMIT_AUTH_WINDOW: '900',
     HD_SECURITY_RATE_LIMIT_BYPASS: '127.0.0.1,::1',
     /* oxlint-enable @typescript-eslint/naming-convention */
   };
@@ -41,8 +41,8 @@ describe('securityConfig: rate limiting', () => {
       expect(config.rateLimit.authenticated.window).toEqual(300);
       expect(config.rateLimit.unauthenticated.max).toEqual(100);
       expect(config.rateLimit.unauthenticated.window).toEqual(300);
-      expect(config.rateLimit.auth.max).toEqual(20);
-      expect(config.rateLimit.auth.window).toEqual(600);
+      expect(config.rateLimit.auth.max).toEqual(40);
+      expect(config.rateLimit.auth.window).toEqual(900);
       expect(config.rateLimit.bypass).toEqual(['127.0.0.1', '::1']);
       restore();
     });
@@ -61,8 +61,8 @@ describe('securityConfig: rate limiting', () => {
       expect(config.rateLimit.authenticated.window).toEqual(300);
       expect(config.rateLimit.unauthenticated.max).toEqual(100);
       expect(config.rateLimit.unauthenticated.window).toEqual(300);
-      expect(config.rateLimit.auth.max).toEqual(20);
-      expect(config.rateLimit.auth.window).toEqual(600);
+      expect(config.rateLimit.auth.max).toEqual(40);
+      expect(config.rateLimit.auth.window).toEqual(900);
       expect(config.rateLimit.bypass).toEqual([]);
       restore();
     });

--- a/backend/src/config/security.config.ts
+++ b/backend/src/config/security.config.ts
@@ -54,12 +54,12 @@ const securityConfigSchema = z.object({
         .describe('HD_SECURITY_RATE_LIMIT_UNAUTHENTICATED_WINDOW'),
     }),
     auth: z.object({
-      max: z.number().int().nonnegative().default(20).describe('HD_SECURITY_RATE_LIMIT_AUTH_MAX'),
+      max: z.number().int().nonnegative().default(40).describe('HD_SECURITY_RATE_LIMIT_AUTH_MAX'),
       window: z
         .number()
         .int()
         .positive()
-        .default(600)
+        .default(900)
         .describe('HD_SECURITY_RATE_LIMIT_AUTH_WINDOW'),
     }),
     bypass: z

--- a/backend/src/security/rate-limiting.spec.ts
+++ b/backend/src/security/rate-limiting.spec.ts
@@ -84,6 +84,15 @@ describe('rate limiting', () => {
     expect(getMaxLimitByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(Infinity);
   });
 
+  it('never rate limits monitoring requests', () => {
+    const request = createMockedRequest({
+      url: '/api/private/monitoring/prometheus',
+      ip: '192.0.2.4',
+    });
+    expect(getTimeWindowByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(0);
+    expect(getMaxLimitByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(Infinity);
+  });
+
   it('uses auth limits for auth endpoints', () => {
     const request = createMockedRequest({ url: '/api/private/auth/login' });
     expect(getTimeWindowByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(600000);

--- a/backend/src/security/rate-limiting.spec.ts
+++ b/backend/src/security/rate-limiting.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { describe, expect, it } from '@jest/globals';
+import type { errorResponseBuilderContext } from '@fastify/rate-limit';
+import { Mock } from 'ts-mockery';
+
+import type { FastifyRequest } from 'fastify';
+import type { CompleteRequest } from '../api/utils/request.type';
+import type { SecurityConfig } from '../config/security.config';
+import {
+  buildRateLimitResponse,
+  generateRateLimitKey,
+  getMaxLimitByRequestWithSecurityConfig,
+  getTimeWindowByRequestWithSecurityConfig,
+} from './rate-limiting';
+import type { SessionState } from '../sessions/session-state';
+
+describe('rate limiting', () => {
+  const securityConfig = Mock.of<SecurityConfig>({
+    rateLimit: {
+      publicApi: { max: 150, window: 300 },
+      authenticated: { max: 600, window: 300 },
+      unauthenticated: { max: 100, window: 300 },
+      auth: { max: 20, window: 600 },
+    },
+  });
+
+  function createMockedRequest(options: {
+    url: string;
+    routeUrl?: string;
+    ip?: string;
+    userId?: number | null;
+  }): FastifyRequest {
+    return Mock.of<CompleteRequest>({
+      url: options.url,
+      ip: options.ip ?? '203.0.113.10',
+      routeOptions: options.routeUrl ? { url: options.routeUrl } : undefined,
+      session: Mock.of<SessionState>({
+        userId: options.userId ?? null,
+      }),
+    }) as FastifyRequest;
+  }
+
+  it('generates a user based key for authenticated requests', () => {
+    const request = createMockedRequest({ url: '/api/v2/notes', userId: 42 });
+    expect(generateRateLimitKey(request)).toBe('user:42');
+  });
+
+  it('falls back to the ip based key for unauthenticated requests', () => {
+    const request = createMockedRequest({ url: '/api/v2/notes', ip: '198.51.100.5' });
+    expect(generateRateLimitKey(request)).toBe('ip:198.51.100.5');
+  });
+
+  it('uses the routeUrl if provided (test with authenticated v2 request)', () => {
+    const request = createMockedRequest({ url: '/ignored', routeUrl: '/api/v2/notes', userId: 7 });
+    expect(getTimeWindowByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(300000);
+    expect(getMaxLimitByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(150);
+  });
+
+  it('uses the public api limits for authenticated v2 requests', () => {
+    const request = createMockedRequest({ url: '/api/v2/notes', userId: 7 });
+    expect(getTimeWindowByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(300000);
+    expect(getMaxLimitByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(150);
+  });
+
+  it('uses the unauthenticated limits for unauthenticated v2 requests', () => {
+    const request = createMockedRequest({ url: '/api/v2/notes' });
+    expect(getTimeWindowByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(300000);
+    expect(getMaxLimitByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(100);
+  });
+
+  it('uses the authenticated private api limits for authenticated requests', () => {
+    const request = createMockedRequest({ url: '/api/private/notes', userId: 7 });
+    expect(getTimeWindowByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(300000);
+    expect(getMaxLimitByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(600);
+  });
+
+  it('never rate limits logout requests', () => {
+    const request = createMockedRequest({ url: '/api/private/auth/logout', userId: 7 });
+    expect(getTimeWindowByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(0);
+    expect(getMaxLimitByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(Infinity);
+  });
+
+  it('uses auth limits for auth endpoints', () => {
+    const request = createMockedRequest({ url: '/api/private/auth/login' });
+    expect(getTimeWindowByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(600000);
+    expect(getMaxLimitByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(20);
+  });
+
+  it('returns infinity when the configured max is zero', () => {
+    const request = createMockedRequest({ url: '/api/private/auth/login' });
+    const config = Mock.of<SecurityConfig>({
+      rateLimit: {
+        publicApi: { max: 150, window: 300 },
+        authenticated: { max: 600, window: 300 },
+        unauthenticated: { max: 100, window: 300 },
+        auth: { max: 0, window: 600 },
+      },
+    });
+
+    expect(getMaxLimitByRequestWithSecurityConfig(config)(request, 'key')).toBe(Infinity);
+  });
+
+  it('builds the expected rate limit response', () => {
+    const context = Mock.of<errorResponseBuilderContext>({
+      after: '10 seconds',
+      ttl: 2500,
+    });
+
+    expect(buildRateLimitResponse(Mock.of<FastifyRequest>({}), context)).toEqual({
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded. Please try again later (10 seconds).',
+      expiresIn: 2500,
+    });
+  });
+});

--- a/backend/src/security/rate-limiting.spec.ts
+++ b/backend/src/security/rate-limiting.spec.ts
@@ -24,7 +24,7 @@ describe('rate limiting', () => {
       publicApi: { max: 150, window: 300 },
       authenticated: { max: 600, window: 300 },
       unauthenticated: { max: 100, window: 300 },
-      auth: { max: 20, window: 600 },
+      auth: { max: 40, window: 900 },
     },
   });
 
@@ -95,8 +95,8 @@ describe('rate limiting', () => {
 
   it('uses auth limits for auth endpoints', () => {
     const request = createMockedRequest({ url: '/api/private/auth/login' });
-    expect(getTimeWindowByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(600000);
-    expect(getMaxLimitByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(20);
+    expect(getTimeWindowByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(900000);
+    expect(getMaxLimitByRequestWithSecurityConfig(securityConfig)(request, 'key')).toBe(40);
   });
 
   it('returns infinity when the configured max is zero', () => {

--- a/backend/src/security/rate-limiting.ts
+++ b/backend/src/security/rate-limiting.ts
@@ -53,15 +53,15 @@ function getRateLimitConfigByRequest(
   const path = req.routeOptions?.url ?? req.url;
   const userId = getUserIdFromSession(req);
 
-  // Logout is never rate-limited
-  if (path === '/api/private/auth/logout') {
+  // Logout and monitoring are never rate-limited
+  if (path === '/api/private/auth/logout' || path.startsWith('/api/private/monitoring')) {
     return {
       max: Infinity,
     };
   }
 
   // Auth endpoints except logout
-  if (path.includes('/api/private/auth/')) {
+  if (path.startsWith('/api/private/auth/')) {
     return securityConfig.rateLimit.auth;
   }
 

--- a/backend/src/security/rate-limiting.ts
+++ b/backend/src/security/rate-limiting.ts
@@ -20,7 +20,7 @@ interface RateLimitConfig {
  * @returns The user ID if authenticated, null otherwise
  */
 function getUserIdFromSession(req: FastifyRequest): number | null {
-  return (req as RequestWithSession).session?.userId;
+  return (req as RequestWithSession).session?.userId ?? null;
 }
 
 /**
@@ -53,18 +53,25 @@ function getRateLimitConfigByRequest(
   const path = req.routeOptions?.url ?? req.url;
   const userId = getUserIdFromSession(req);
 
-  // Auth endpoints
+  // Logout is never rate-limited
+  if (path === '/api/private/auth/logout') {
+    return {
+      max: Infinity,
+    };
+  }
+
+  // Auth endpoints except logout
   if (path.includes('/api/private/auth/')) {
     return securityConfig.rateLimit.auth;
   }
 
   // Public API, authenticated
-  if (path.startsWith('/api/v2') && userId !== undefined) {
+  if (path.startsWith('/api/v2') && userId !== null) {
     return securityConfig.rateLimit.publicApi;
   }
 
   // Private API, authenticated
-  if (path.startsWith('/api/private') && userId !== undefined) {
+  if (path.startsWith('/api/private') && userId !== null) {
     return securityConfig.rateLimit.authenticated;
   }
 

--- a/docs/content/references/config/security.md
+++ b/docs/content/references/config/security.md
@@ -45,6 +45,6 @@ Setting a `*_MAX` value to `0` effectively disables rate limiting for that tier
 | `HD_SECURITY_RATE_LIMIT_AUTHENTICATED_WINDOW`   | 300     | Time window in seconds for authenticated usage                     |
 | `HD_SECURITY_RATE_LIMIT_UNAUTHENTICATED_MAX`    | 100     | Maximum requests for unauthenticated usage                         |
 | `HD_SECURITY_RATE_LIMIT_UNAUTHENTICATED_WINDOW` | 300     | Time window in seconds for unauthenticated usage                   |
-| `HD_SECURITY_RATE_LIMIT_AUTH_MAX`               | 20      | Maximum of auth request attempts                                   |
-| `HD_SECURITY_RATE_LIMIT_AUTH_WINDOW`            | 600     | Time window in seconds for auth request attempts                   |
+| `HD_SECURITY_RATE_LIMIT_AUTH_MAX`               | 40      | Maximum of auth request attempts                                   |
+| `HD_SECURITY_RATE_LIMIT_AUTH_WINDOW`            | 900     | Time window in seconds for auth request attempts                   |
 | `HD_SECURITY_RATE_LIMIT_BYPASS`                 | *none*  | Bypass rate limiting for these IP addresses (comma-separated list) |

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -610,6 +610,10 @@
     "noteCreationFailed": {
       "title": "Note could not be created",
       "description": "The note could not be created. Maybe you don't have permission to create notes."
+    },
+    "rateLimitExceeded": {
+      "title": "Rate limit exceeded",
+      "description": "You have made too many requests in short time. Please wait a moment and try again {{resetIn}}."
     }
   },
   "notifications": {

--- a/frontend/src/api/common/api-error.ts
+++ b/frontend/src/api/common/api-error.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { DateTime } from 'luxon'
+
 export class ApiError extends Error {
   constructor(
     public readonly statusCode: number,
@@ -11,5 +13,15 @@ export class ApiError extends Error {
     public readonly backendErrorMessage?: string
   ) {
     super()
+  }
+}
+
+export class RateLimitError extends Error {
+  constructor(public readonly retryAfterSeconds: number) {
+    super()
+  }
+
+  getResetIn(): string {
+    return DateTime.local().plus({ seconds: this.retryAfterSeconds }).toRelative()
   }
 }

--- a/frontend/src/api/common/api-request-builder/api-request-builder.ts
+++ b/frontend/src/api/common/api-request-builder/api-request-builder.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { ApiError } from '../api-error'
+import { ApiError, RateLimitError } from '../api-error'
 import type { ApiErrorResponse } from '../api-error-response'
 import { ApiResponse } from '../api-response'
 import { defaultConfig, defaultHeaders } from '../default-config'
@@ -69,6 +69,12 @@ export abstract class ApiRequestBuilder<ResponseType> {
       headers: this.customRequestHeaders,
       body: this.requestBody
     })
+
+    if (response.status === 429) {
+      // Default to 5 minutes if no header response received
+      const rateLimitResetSeconds = Number.parseInt(response.headers.get('RateLimit-Reset') ?? '300')
+      throw new RateLimitError(rateLimitResetSeconds)
+    }
 
     if (response.status >= 400) {
       const backendError = await this.readApiErrorResponseFromBody(response)

--- a/frontend/src/api/common/api-response.ts
+++ b/frontend/src/api/common/api-response.ts
@@ -28,14 +28,6 @@ export class ApiResponse<ResponseType> {
     return this.response
   }
 
-  static isSuccessfulResponse(response: Response): boolean {
-    return response.status >= 400
-  }
-
-  isSuccessful(): boolean {
-    return ApiResponse.isSuccessfulResponse(this.response)
-  }
-
   /**
    * Returns the response as parsed JSON. An error will be thrown if the response is not JSON encoded.
    *

--- a/frontend/src/components/application-loader/application-loader-error.ts
+++ b/frontend/src/components/application-loader/application-loader-error.ts
@@ -3,11 +3,17 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { RateLimitError } from '../../api/common/api-error'
+
 /**
  * Custom {@link Error} class for the {@link ApplicationLoader}.
  */
 export class ApplicationLoaderError extends Error {
-  constructor(taskName: string) {
-    super(`The task ${taskName} failed`)
+  constructor(taskName: string, originalError: unknown) {
+    let message = `The task ${taskName} failed`
+    if (originalError instanceof RateLimitError) {
+      message += `: You are being rate limited. Please try again ${originalError.getResetIn()}`
+    }
+    super(message)
   }
 }

--- a/frontend/src/components/application-loader/application-loader.tsx
+++ b/frontend/src/components/application-loader/application-loader.tsx
@@ -28,7 +28,7 @@ export const ApplicationLoader: React.FC<PropsWithChildren> = ({ children }) => 
         await task.task()
       } catch (reason: unknown) {
         log.error('Error while initialising application', reason)
-        throw new ApplicationLoaderError(task.name)
+        throw new ApplicationLoaderError(task.name, reason)
       }
     }
   }, [])

--- a/frontend/src/components/application-loader/initializers/login-or-register-guest.ts
+++ b/frontend/src/components/application-loader/initializers/login-or-register-guest.ts
@@ -8,6 +8,7 @@ import { logInGuest, registerGuest } from '../../../api/auth/guest'
 import { store } from '../../../redux'
 import { fetchAndSetUser } from '../../login-page/utils/fetch-and-set-user'
 import { Logger } from '../../../utils/logger'
+import { RateLimitError } from '../../../api/common/api-error'
 
 const logger = new Logger('LoginOrRegisterGuest')
 
@@ -19,6 +20,7 @@ const logger = new Logger('LoginOrRegisterGuest')
  * The uuid is stored in local storage afterward.
  *
  * @param ignoreSavedUuid If true, the function will not check for a saved guest uuid in local storage
+ * @throws RateLimitError if the rate limit is exceeded back to the application-loader
  */
 export const loginOrRegisterGuest = async (ignoreSavedUuid?: boolean): Promise<void> => {
   const userState = store.getState().user
@@ -34,6 +36,9 @@ export const loginOrRegisterGuest = async (ignoreSavedUuid?: boolean): Promise<v
   logInGuest(guestUuid)
     .then(fetchAndSetUser)
     .catch((error: unknown) => {
+      if (error instanceof RateLimitError) {
+        throw error
+      }
       logger.error('Error logging in guest user', error)
       return loginOrRegisterGuest(true)
     })

--- a/frontend/src/components/explore-page/explore-notes-section/notes-list/notes-list.tsx
+++ b/frontend/src/components/explore-page/explore-notes-section/notes-list/notes-list.tsx
@@ -15,6 +15,7 @@ import { useUiNotifications } from '../../../notifications/ui-notification-bound
 import { useApplicationState } from '../../../../hooks/common/use-application-state'
 import equal from 'fast-deep-equal'
 import styles from './note-entry.module.css'
+import { RateLimitError } from '../../../../api/common/api-error'
 
 export interface NotesListProps {
   mode: Mode
@@ -33,7 +34,7 @@ export interface NotesListProps {
  */
 export const NotesList: React.FC<NotesListProps> = ({ mode, sort, searchFilter, typeFilter }) => {
   const [entries, setEntries] = useState<NoteExploreEntryInterface[]>([])
-  const { showErrorNotificationBuilder } = useUiNotifications()
+  const { showErrorNotificationBuilder, dispatchUiNotification } = useUiNotifications()
   const [moreDataAvailable, setMoreDataAvailable] = useState(true)
   const lastPage = useRef<number>(0)
   const lastFilters = useRef({})
@@ -58,9 +59,19 @@ export const NotesList: React.FC<NotesListProps> = ({ mode, sort, searchFilter, 
             setEntries((prev) => [...prev, ...data])
           }
         })
-        .catch(showErrorNotificationBuilder('explore.errorLoadingEntries'))
+        .catch((error: unknown) => {
+          if (error instanceof RateLimitError) {
+            dispatchUiNotification('errors.rateLimitExceeded.title', 'errors.rateLimitExceeded.description', {
+              contentI18nOptions: {
+                resetIn: error.getResetIn()
+              }
+            })
+            return
+          }
+          showErrorNotificationBuilder('explore.errorLoadingEntries')(error as Error)
+        })
     },
-    [mode, sort, searchFilter, typeFilter, showErrorNotificationBuilder]
+    [mode, sort, searchFilter, typeFilter, showErrorNotificationBuilder, dispatchUiNotification]
   )
 
   const updateExplorePage = useCallback(() => {

--- a/frontend/src/components/login-page/local-login/register/register-error.tsx
+++ b/frontend/src/components/login-page/local-login/register/register-error.tsx
@@ -6,29 +6,36 @@
 import { ErrorToI18nKeyMapper } from '../../../../api/common/error-to-i18n-key-mapper'
 import React, { useMemo } from 'react'
 import { Alert } from 'react-bootstrap'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
+import { RateLimitError } from '../../../../api/common/api-error'
 
 interface RegisterErrorProps {
   error?: Error
 }
 
 export const RegisterError: React.FC<RegisterErrorProps> = ({ error }) => {
-  useTranslation()
+  const { t } = useTranslation()
 
-  const errorI18nKey = useMemo(() => {
+  const errorMessage = useMemo(() => {
     if (!error) {
       return null
     }
-    return new ErrorToI18nKeyMapper(error, 'login.register.error')
+    if (error instanceof RateLimitError) {
+      return t('errors.rateLimitExceeded.description', {
+        resetIn: error.getResetIn()
+      })
+    }
+    const i18nKey = new ErrorToI18nKeyMapper(error, 'login.register.error')
       .withHttpCode(409, 'usernameExisting')
       .withBackendErrorName('FeatureDisabledError', 'registrationDisabled')
       .withBackendErrorName('PasswordTooWeakError', 'passwordTooWeak')
       .orFallbackI18nKey('other')
-  }, [error])
+    return t(i18nKey)
+  }, [error, t])
 
   return (
-    <Alert className='small' show={!!errorI18nKey} variant='danger'>
-      <Trans i18nKey={errorI18nKey ?? ''} />
+    <Alert className='small' show={!!errorMessage} variant='danger'>
+      {errorMessage}
     </Alert>
   )
 }

--- a/frontend/src/components/login-page/username-password-login.tsx
+++ b/frontend/src/components/login-page/username-password-login.tsx
@@ -13,6 +13,7 @@ import { UsernameField } from '../common/fields/username-field'
 import { PasswordField } from './password-field'
 import { Alert, Card, Form } from 'react-bootstrap'
 import { ActionButton } from '../common/action-button'
+import { RateLimitError } from '../../api/common/api-error'
 
 export interface UsernamePasswordLoginProps {
   authProviderIdentifier?: string
@@ -71,11 +72,21 @@ export const UsernamePasswordLogin: React.FC<UsernamePasswordLoginProps> = ({
             return fetchAndSetUser()
           }
         })
-        .catch((error: Error) => setError(errorMapping(error)))
+        .catch((error: Error) => {
+          if (error instanceof RateLimitError) {
+            setError(
+              t('errors.rateLimitExceeded.description', {
+                resetIn: error.getResetIn()
+              })
+            )
+          } else {
+            setError(errorMapping(error))
+          }
+        })
         .finally(() => setLoading(false))
       event.preventDefault()
     },
-    [username, password, authProviderIdentifier, router, doLogin, errorMapping]
+    [username, password, authProviderIdentifier, router, doLogin, errorMapping, t]
   )
 
   const onUsernameChange = useOnInputChange(setUsername)


### PR DESCRIPTION
### Component/Part
- backend -> security rate limiter
- frontend -> application loader

### Description
This PR fixes and improves the rate-limiting in a few points:
- exclude logout and monitoring from limits
- adapt rate limits for auth routes, to allow account switching without problems
- show rate limiting errors in the frontend, at least on app start and login for now

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6470
Fixes #6471 
Fixes #6472 
