### PR TITLE
fix(frontend): redirect user to DEFAULT_FALLBACK_URL when permissions update fails

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -616,6 +616,10 @@
     "noteDeleted": {
       "title": "Note '{{noteTitle}}' deleted",
       "text": "You were redirected to the explore page, because the note you just edited was deleted."
+    },
+    "notePermissionsRevoked": {
+      "title": "Access permission for note was revoked",
+      "text": "You were redirected to the explore page, because the permissions for the note you just edited were revoked."
     }
   },
   "realtime": {

--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-on-note-deleted.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-on-note-deleted.ts
@@ -10,6 +10,7 @@ import { MessageType } from '@hedgedoc/commons'
 import type { Listener } from 'eventemitter2'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect } from 'react'
+import { DEFAULT_FALLBACK_URL } from '../../../../login-page/utils/use-get-post-login-redirect-url'
 
 /**
  * Hook that redirects the user to the history page and displays a notification when the note is deleted.
@@ -27,7 +28,7 @@ export const useOnNoteDeleted = (websocketConnection: MessageTransporter): void 
         noteTitle
       }
     })
-    router.push('/explore/my')
+    router.push(DEFAULT_FALLBACK_URL)
   }, [router, noteTitle, dispatchUiNotification])
 
   useEffect(() => {

--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-on-permissions-updated.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-on-permissions-updated.ts
@@ -9,6 +9,11 @@ import type { MessageTransporter } from '@hedgedoc/commons'
 import { MessageType } from '@hedgedoc/commons'
 import type { Listener } from 'eventemitter2'
 import { useEffect } from 'react'
+import { Logger } from '../../../../../utils/logger'
+import { DEFAULT_FALLBACK_URL } from '../../../../login-page/utils/use-get-post-login-redirect-url'
+import { useRouter } from 'next/navigation'
+
+const logger = new Logger('useOnPermissionsUpdated')
 
 /**
  * Hook that updates the permissions state in the redux if the server announced an update of the note permissions.
@@ -17,14 +22,18 @@ import { useEffect } from 'react'
  */
 export const useOnPermissionsUpdated = (websocketConnection: MessageTransporter): void => {
   const { showErrorNotificationBuilder } = useUiNotifications()
+  const router = useRouter()
 
   useEffect(() => {
     const listener = websocketConnection.on(
       MessageType.PERMISSIONS_UPDATED,
       () => {
-        updateNotePermissions().catch(
-          showErrorNotificationBuilder('common.errorWhileLoading', { name: 'note permission update' })
-        )
+        updateNotePermissions().catch(() => {
+          logger.error(
+            `Got an error while updating note permissions after receiving ${MessageType.PERMISSIONS_UPDATED}. Returning the user to explore page`
+          )
+          router.replace(DEFAULT_FALLBACK_URL)
+        })
       },
       {
         objectify: true
@@ -33,5 +42,5 @@ export const useOnPermissionsUpdated = (websocketConnection: MessageTransporter)
     return () => {
       listener.off()
     }
-  }, [showErrorNotificationBuilder, websocketConnection])
+  }, [showErrorNotificationBuilder, websocketConnection, router])
 }

--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-on-permissions-updated.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-on-permissions-updated.ts
@@ -12,6 +12,7 @@ import { useEffect } from 'react'
 import { Logger } from '../../../../../utils/logger'
 import { DEFAULT_FALLBACK_URL } from '../../../../login-page/utils/use-get-post-login-redirect-url'
 import { useRouter } from 'next/navigation'
+import { ApiError } from '../../../../../api/common/api-error'
 
 const logger = new Logger('useOnPermissionsUpdated')
 
@@ -21,18 +22,26 @@ const logger = new Logger('useOnPermissionsUpdated')
  * @param websocketConnection The websocket connection that emits the permissions changed event
  */
 export const useOnPermissionsUpdated = (websocketConnection: MessageTransporter): void => {
-  const { showErrorNotificationBuilder } = useUiNotifications()
+  const { showErrorNotificationBuilder, dispatchUiNotification } = useUiNotifications()
   const router = useRouter()
 
   useEffect(() => {
     const listener = websocketConnection.on(
       MessageType.PERMISSIONS_UPDATED,
       () => {
-        updateNotePermissions().catch(() => {
-          logger.error(
-            `Got an error while updating note permissions after receiving ${MessageType.PERMISSIONS_UPDATED}. Returning the user to explore page`
-          )
-          router.replace(DEFAULT_FALLBACK_URL)
+        updateNotePermissions().catch((error: unknown) => {
+          if (error instanceof ApiError && error.statusCode === 403) {
+            logger.error(
+              `Got an error while updating note permissions after receiving ${MessageType.PERMISSIONS_UPDATED}. Returning the user to explore page`
+            )
+            dispatchUiNotification(
+              'notifications.notePermissionsRevoked.title',
+              'notifications.notePermissionsRevoked.text',
+              {}
+            )
+            return router.replace(DEFAULT_FALLBACK_URL)
+          }
+          showErrorNotificationBuilder('common.errorWhileLoading', { name: 'note permission update' })
         })
       },
       {
@@ -42,5 +51,5 @@ export const useOnPermissionsUpdated = (websocketConnection: MessageTransporter)
     return () => {
       listener.off()
     }
-  }, [showErrorNotificationBuilder, websocketConnection, router])
+  }, [showErrorNotificationBuilder, dispatchUiNotification, websocketConnection, router])
 }

--- a/frontend/src/components/login-page/utils/use-get-post-login-redirect-url.ts
+++ b/frontend/src/components/login-page/utils/use-get-post-login-redirect-url.ts
@@ -5,13 +5,13 @@
  */
 import { useSingleStringUrlParameter } from '../../../hooks/common/use-single-string-url-parameter'
 
-const defaultFallback = '/explore/my'
+export const DEFAULT_FALLBACK_URL = '/explore/my'
 
 /**
  * Returns the URL that the user should be redirected to after logging in.
  * If no parameter has been provided or if the URL is not relative, then "/explore/my" will be used.
  */
 export const useGetPostLoginRedirectUrl = (): string => {
-  const redirectBackUrl = useSingleStringUrlParameter('redirectBackTo', defaultFallback)
-  return redirectBackUrl.startsWith('/') && !redirectBackUrl.startsWith('//') ? redirectBackUrl : defaultFallback
+  const redirectBackUrl = useSingleStringUrlParameter('redirectBackTo', DEFAULT_FALLBACK_URL)
+  return redirectBackUrl.startsWith('/') && !redirectBackUrl.startsWith('//') ? redirectBackUrl : DEFAULT_FALLBACK_URL
 }


### PR DESCRIPTION
### Description
This PR redirects the user to DEFAULT_FALLBACK_URL when permissions update fails after PERMISSIONS_UPDATED message

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6475 