### PR TITLE
refactor(frontend): remove revision revert button

### DIFF
--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/revisions-sidebar-entry/revisions-modal/revision-modal-footer.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/revisions-sidebar-entry/revisions-modal/revision-modal-footer.tsx
@@ -40,12 +40,6 @@ export const RevisionModalFooter: React.FC<RevisionModalFooterProps> = ({
   const noteAlias = useApplicationState((state) => state.noteDetails?.primaryAlias)
   const { showErrorNotificationBuilder } = useUiNotifications()
 
-  const onRevertToRevision = useCallback(() => {
-    // TODO Websocket message handler missing
-    //  see https://github.com/hedgedoc/hedgedoc/issues/1984
-    window.alert('Not yet implemented. Requires websocket.')
-  }, [])
-
   const onDownloadRevision = useCallback(() => {
     if (selectedRevisionId === undefined || noteAlias === undefined) {
       return
@@ -73,13 +67,6 @@ export const RevisionModalFooter: React.FC<RevisionModalFooterProps> = ({
         {...cypressId('revision.modal.delete.button')}
         disabled={disableDeleteRevisions}>
         <Trans i18nKey={'editor.modal.deleteRevision.button'} />
-      </Button>
-      <Button
-        variant='danger'
-        disabled={selectedRevisionId === undefined}
-        onClick={onRevertToRevision}
-        {...cypressId('revision.modal.revert.button')}>
-        <Trans i18nKey={'editor.modal.revision.revertButton'} />
       </Button>
       <Button
         variant='primary'


### PR DESCRIPTION
### Component/Part
frontend

### Description
This PR removes the revision revert button

We did not implement this functionality yet and won't for some time so in order for HedgeDoc 2 to become release ready, this button will be removed.


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [s] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6478