### PR TITLE
Restructure revision cleanup to avoid SQL errors and data loss

### DIFF
--- a/backend/src/revisions/revisions.service.spec.ts
+++ b/backend/src/revisions/revisions.service.spec.ts
@@ -563,10 +563,10 @@ describe('RevisionsService', () => {
       mockSelect(
         tracker,
         [
-          FieldNameRevision.uuid,
+          `${TableRevision}"."${FieldNameRevision.uuid}`,
           `${TableRevision}"."${FieldNameRevision.noteId}`,
-          FieldNameRevision.content,
-          FieldNameAlias.alias,
+          `${TableRevision}"."${FieldNameRevision.content}`,
+          `${TableAlias}"."${FieldNameAlias.alias}`,
         ],
         TableRevision,
         [FieldNameRevision.noteId, FieldNameAlias.isPrimary],

--- a/backend/src/revisions/revisions.service.spec.ts
+++ b/backend/src/revisions/revisions.service.spec.ts
@@ -6,13 +6,11 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, jest } from '@jest/globals';
 import type { SpyInstance } from 'jest-mock';
 import {
-  FieldNameAlias,
   FieldNameAuthorshipInfo,
   FieldNameRevision,
   FieldNameRevisionTag,
   FieldNameUser,
   NoteType,
-  TableAlias,
   TableAuthorshipInfo,
   TableRevision,
   TableRevisionTag,
@@ -29,8 +27,14 @@ import { AliasService } from '../alias/alias.service';
 import appConfigMock from '../config/mock/app.config.mock';
 import { createDefaultMockNoteConfig, registerNoteConfig } from '../config/mock/note.config.mock';
 import { NoteConfig } from '../config/note.config';
-import { expectBindings } from '../database/mock/expect-bindings';
-import { mockDelete, mockInsert, mockSelect, mockUpdate } from '../database/mock/mock-queries';
+import { expectBindings, IS_FIRST } from '../database/mock/expect-bindings';
+import {
+  mockDelete,
+  mockInsert,
+  mockQuery,
+  mockSelect,
+  mockUpdate,
+} from '../database/mock/mock-queries';
 import { mockKnexDb } from '../database/mock/provider';
 import { GenericDBError, NotInDBError } from '../errors/errors';
 import { LoggerModule } from '../logger/logger.module';
@@ -502,36 +506,14 @@ describe('RevisionsService', () => {
   });
 
   describe('removeOldRevisions', () => {
-    const now = 1758653425;
     let expectedDateTime: string;
+    let spyOnGetPrimaryAlias: SpyInstance<typeof aliasService.getPrimaryAliasByNoteId>;
+
     beforeEach(() => {
       jest.useFakeTimers();
-      jest.setSystemTime(now);
+      jest.setSystemTime(new Date(2026, 7, 8, 21, 10, 0));
       noteConfig.revisionRetentionDays = 1;
       expectedDateTime = dateTimeToDB(getCurrentDateTime().minus({ days: 1 }));
-    });
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-    it("doesn't run if revisionRetentionDays is set to <= 0", async () => {
-      noteConfig.revisionRetentionDays = 0;
-      await service.removeOldRevisions();
-      expectBindings(tracker, 'delete', [[]], false, true);
-    });
-    it("doesn't update if no revisions were removed", async () => {
-      mockDelete(tracker, TableRevision, [FieldNameRevision.createdAt], []);
-      mockSelect(
-        tracker,
-        [FieldNameRevision.noteId],
-        TableRevision,
-        [FieldNameRevision.createdAt],
-        [],
-      );
-      await service.removeOldRevisions();
-      expectBindings(tracker, 'delete', [[expectedDateTime]]);
-      expectBindings(tracker, 'select', [[expectedDateTime]]);
-    });
-    it('updates notes if revisions were deleted', async () => {
       // The typecast is required since jest does not see all signatures of the mocked function
       // and assumes using the first signature, which is wrong here and leads to a type error
       (
@@ -539,61 +521,134 @@ describe('RevisionsService', () => {
           (a: string, b: string, c: string) => string
         >
       ).mockImplementation((a, b, c) => `${mockPatch}\n${a}\n${b}\n${c}`);
-      mockDelete(
+      spyOnGetPrimaryAlias = jest
+        .spyOn(aliasService, 'getPrimaryAliasByNoteId')
+        .mockResolvedValue(mockPrimaryAlias);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("doesn't run if revisionRetentionDays is set to <= 0", async () => {
+      noteConfig.revisionRetentionDays = 0;
+      await service.removeOldRevisions();
+      expectBindings(tracker, 'select', [[]], false, true);
+    });
+
+    it("doesn't do any work if no old revisions exist", async () => {
+      mockQuery(
+        'select',
         tracker,
-        TableRevision,
-        [FieldNameRevision.createdAt],
-        [
-          {
-            [FieldNameRevision.noteId]: mockNoteId,
-          },
-        ],
+        /select "note_id", count\("uuid"\) as "count" from "revision" where "created_at" < .* group by "note_id"/,
+        [],
+      );
+      await service.removeOldRevisions();
+      expect(spyOnGetPrimaryAlias).not.toHaveBeenCalled();
+      expectBindings(tracker, 'select', [[expectedDateTime]]);
+    });
+
+    it('skips noteIds that only have a single old revision and no newer revision (category 3a)', async () => {
+      mockQuery(
+        'select',
+        tracker,
+        /select "note_id", count\("uuid"\) as "count" from "revision" where "created_at" < .* group by "note_id"/,
+        [{ note_id: mockNoteId, count: '1' }],
+      );
+      mockQuery(
+        'select',
+        tracker,
+        /select "note_id", count\("uuid"\) as "count" from "revision" where "note_id" in .* and "created_at" >= .* group by "note_id"/,
+        [],
+      );
+      await service.removeOldRevisions();
+      expect(spyOnGetPrimaryAlias).not.toHaveBeenCalled();
+      expectBindings(tracker, 'select', [[expectedDateTime], [mockNoteId, expectedDateTime]]);
+    });
+
+    it('handles category 3b noteIds by keeping the newest revision and deleting the rest', async () => {
+      mockQuery(
+        'select',
+        tracker,
+        /select "note_id", count\("uuid"\) as "count" from "revision" where "created_at" < .* group by "note_id"/,
+        [{ note_id: mockNoteId, count: '2' }],
+      );
+      mockQuery(
+        'select',
+        tracker,
+        /select "note_id", count\("uuid"\) as "count" from "revision" where "note_id" in .* and "created_at" >= .* group by "note_id"/,
+        [],
       );
       mockSelect(
         tracker,
-        [FieldNameRevision.noteId],
+        [FieldNameRevision.uuid, FieldNameRevision.content],
         TableRevision,
-        [FieldNameRevision.createdAt],
-        [
-          {
-            [FieldNameRevision.noteId]: mockNoteId,
-          },
-        ],
-      );
-      mockSelect(
-        tracker,
-        [
-          `${TableRevision}"."${FieldNameRevision.uuid}`,
-          `${TableRevision}"."${FieldNameRevision.noteId}`,
-          `${TableRevision}"."${FieldNameRevision.content}`,
-          `${TableAlias}"."${FieldNameAlias.alias}`,
-        ],
-        TableRevision,
-        [FieldNameRevision.noteId, FieldNameAlias.isPrimary],
+        FieldNameRevision.noteId,
         [
           {
             [FieldNameRevision.uuid]: mockRevisionUuid1,
-            [`${TableRevision}.${FieldNameRevision.noteId}`]: mockNoteId,
             [FieldNameRevision.content]: mockContent1,
-            [FieldNameAlias.alias]: mockPrimaryAlias,
-          },
-        ],
-        [
-          {
-            joinTable: TableAlias,
-            keyLeft: FieldNameAlias.noteId,
-            keyRight: FieldNameRevision.noteId,
           },
         ],
       );
       mockUpdate(tracker, TableRevision, [FieldNameRevision.patch], FieldNameRevision.uuid, 1);
+      mockDelete(tracker, TableRevision, [FieldNameRevision.noteId, FieldNameRevision.uuid], 1);
       await service.removeOldRevisions();
-
-      expectBindings(tracker, 'delete', [[expectedDateTime]]);
-      expectBindings(tracker, 'select', [[expectedDateTime], [mockNoteId, true]]);
+      expect(spyOnGetPrimaryAlias).toHaveBeenCalledTimes(1);
+      expect(spyOnGetPrimaryAlias).toHaveBeenCalledWith(mockNoteId, expect.anything());
+      expect(tracker.history.select).toHaveLength(3);
+      expect(tracker.history.select[0].bindings).toEqual([expectedDateTime]);
+      expect(tracker.history.select[1].bindings).toEqual([mockNoteId, expectedDateTime]);
+      expect(tracker.history.select[2].bindings).toEqual([mockNoteId, IS_FIRST]);
       expectBindings(tracker, 'update', [
         [`${mockPatch}\n${mockPrimaryAlias}\n\n${mockContent1}`, mockRevisionUuid1],
       ]);
+      expectBindings(tracker, 'delete', [[mockNoteId, mockRevisionUuid1]]);
+    });
+
+    it('handles category 3c noteIds by keeping the oldest revision within the retention period', async () => {
+      mockQuery(
+        'select',
+        tracker,
+        /select "note_id", count\("uuid"\) as "count" from "revision" where "created_at" < .* group by "note_id"/,
+        [{ note_id: mockNoteId, count: '1' }],
+      );
+      mockQuery(
+        'select',
+        tracker,
+        /select "note_id", count\("uuid"\) as "count" from "revision" where "note_id" in .* and "created_at" >= .* group by "note_id"/,
+        [{ note_id: mockNoteId, count: '2' }],
+      );
+      mockSelect(
+        tracker,
+        [FieldNameRevision.uuid, FieldNameRevision.content],
+        TableRevision,
+        [FieldNameRevision.noteId, FieldNameRevision.createdAt],
+        [
+          {
+            [FieldNameRevision.uuid]: mockRevisionUuid1,
+            [FieldNameRevision.content]: mockContent1,
+          },
+        ],
+      );
+      mockUpdate(tracker, TableRevision, [FieldNameRevision.patch], FieldNameRevision.uuid, 1);
+      mockDelete(
+        tracker,
+        TableRevision,
+        [FieldNameRevision.noteId, FieldNameRevision.createdAt],
+        1,
+      );
+      await service.removeOldRevisions();
+      expect(spyOnGetPrimaryAlias).toHaveBeenCalledTimes(1);
+      expect(spyOnGetPrimaryAlias).toHaveBeenCalledWith(mockNoteId, expect.anything());
+      expect(tracker.history.select).toHaveLength(3);
+      expect(tracker.history.select[0].bindings).toEqual([expectedDateTime]);
+      expect(tracker.history.select[1].bindings).toEqual([mockNoteId, expectedDateTime]);
+      expect(tracker.history.select[2].bindings).toEqual([mockNoteId, expectedDateTime, IS_FIRST]);
+      expectBindings(tracker, 'update', [
+        [`${mockPatch}\n${mockPrimaryAlias}\n\n${mockContent1}`, mockRevisionUuid1],
+      ]);
+      expectBindings(tracker, 'delete', [[mockNoteId, expectedDateTime]]);
     });
   });
 });

--- a/backend/src/revisions/revisions.service.ts
+++ b/backend/src/revisions/revisions.service.ts
@@ -479,16 +479,16 @@ export class RevisionsService {
           `${TableRevision}.${FieldNameRevision.noteId}`,
         )
         .select(
-          FieldNameRevision.uuid,
+          `${TableRevision}.${FieldNameRevision.uuid}`,
           `${TableRevision}.${FieldNameRevision.noteId}`,
-          FieldNameRevision.content,
-          FieldNameAlias.alias,
+          `${TableRevision}.${FieldNameRevision.content}`,
+          `${TableAlias}.${FieldNameAlias.alias}`,
         )
-        .whereIn(FieldNameRevision.noteId, uniqueNoteIds)
-        .andWhere(FieldNameAlias.isPrimary, true)
+        .whereIn(`${TableRevision}.${FieldNameRevision.noteId}`, uniqueNoteIds)
+        .andWhere(`${TableAlias}.${FieldNameAlias.isPrimary}`, true)
         .orderBy([
-          { column: FieldNameRevision.noteId },
-          { column: FieldNameRevision.createdAt, order: 'ASC' },
+          { column: `${TableRevision}.${FieldNameRevision.noteId}` },
+          { column: `${TableRevision}.${FieldNameRevision.createdAt}`, order: 'ASC' },
         ]);
 
       let lastNoteId = -1;

--- a/backend/src/revisions/revisions.service.ts
+++ b/backend/src/revisions/revisions.service.ts
@@ -5,7 +5,6 @@
  */
 import {
   AuthorshipInfo,
-  FieldNameAlias,
   FieldNameAuthorshipInfo,
   FieldNameNote,
   FieldNameRevision,
@@ -14,7 +13,6 @@ import {
   Note,
   Revision,
   RevisionTag,
-  TableAlias,
   TableAuthorshipInfo,
   TableRevision,
   TableRevisionTag,
@@ -41,6 +39,11 @@ import {
   getCurrentDateTime,
 } from '../utils/datetime';
 import { extractRevisionMetadataFromContent } from './utils/extract-revision-metadata-from-content';
+
+interface NoteRevisionCountDbResult {
+  [FieldNameRevision.noteId]: number;
+  count: string;
+}
 
 interface RevisionUserInfo {
   users: {
@@ -438,86 +441,140 @@ export class RevisionsService {
 
   /**
    * Deletes old revisions except the latest one if the clean-up is enabled
+   *
+   * This follows the following algorithm:
+   * 1. Count all revisions older than revisionRetentionDays -> SQL should return map (noteId, revisionCount)
+   * 2. Count all revisions exactly as old as revisionRetentionDays or newer for all noteIds found in step 1 -> SQL should return map (noteId, revisionCount)
+   * 3. Sort noteIds in 3 categories:
+   *    a) noteId has only one revision older than revisionRetentionDays and no newer revision
+   *    b) noteId has multiple revisions older than revisionRetentionDays and no newer revision
+   *    c) noteId has at least one newer revision
+   * 4. Skip all noteIds from category 3a -> these may not be deleted to avoid data-loss
+   * 5. Loop over all noteIds from category 3b and do:
+   *    1. Find newest revision and update `patch` to diff between empty string and `content`
+   *    2. Delete all revisions for this noteId except the newest revision
+   * 6. Loop over all noteIds from category 3c and do:
+   *    1. Find oldest revision that is either exactly as old as or newer than revisionRetentionDays
+   *    2. Update that revision's `patch` to the diff between empty string and `content`
+   *    3. Delete all revisions for this noteId older than revisionRetentionDays
    */
   async removeOldRevisions(): Promise<void> {
-    const currentTime = getCurrentDateTime();
     const revisionRetentionDays: number = this.noteConfig.revisionRetentionDays;
     if (revisionRetentionDays <= 0) {
       return;
     }
+
+    const currentTime = getCurrentDateTime();
     const oldestRevisionToKeepTime = currentTime.minus({
       days: revisionRetentionDays,
     });
     const oldestRevisionToKeepDBTime = dateTimeToDB(oldestRevisionToKeepTime);
+
     await this.knex.transaction(async (transaction) => {
-      // Delete old revisions
-      const noteIdsWhereRevisionsWillBeDeleted = await transaction(TableRevision)
+      // 1. Count all revisions older than revisionRetentionDays -> SQL should return map (noteId, revisionCount)
+      const oldRevisionCountDbResult = (await transaction(TableRevision)
         .select(FieldNameRevision.noteId)
-        .where(FieldNameRevision.createdAt, '<=', oldestRevisionToKeepDBTime);
+        .count(`${FieldNameRevision.uuid} as count`)
+        .where(FieldNameRevision.createdAt, '<', oldestRevisionToKeepDBTime)
+        .groupBy(FieldNameRevision.noteId)) as NoteRevisionCountDbResult[];
 
-      await transaction(TableRevision)
-        .where(FieldNameRevision.createdAt, '<=', oldestRevisionToKeepDBTime)
-        .delete();
-
-      this.logger.log(
-        `${noteIdsWhereRevisionsWillBeDeleted.length} old revisions were removed from the DB`,
-        'removeOldRevisions',
+      const oldRevisionsCount = new Map<number, number>(
+        oldRevisionCountDbResult.map((entry) => [entry.note_id, Number(entry.count)]),
       );
 
-      if (noteIdsWhereRevisionsWillBeDeleted.length === 0) {
+      if (oldRevisionsCount.size === 0) {
+        this.logger.debug('No old revisions found for removal', 'removeOldRevisions');
         return;
       }
 
-      const uniqueNoteIds = Array.from(
-        new Set(noteIdsWhereRevisionsWillBeDeleted.map((entry) => entry[FieldNameRevision.noteId])),
+      const oldNoteIds = [...oldRevisionsCount.keys()];
+
+      // 2. Count all revisions exactly as old as revisionRetentionDays or newer for all noteIds found in step 1
+      const newRevisionsCountDbResult = (await transaction(TableRevision)
+        .select(FieldNameRevision.noteId)
+        .count(`${FieldNameRevision.uuid} as count`)
+        .whereIn(FieldNameRevision.noteId, oldNoteIds)
+        .andWhere(FieldNameRevision.createdAt, '>=', oldestRevisionToKeepDBTime)
+        .groupBy(FieldNameRevision.noteId)) as NoteRevisionCountDbResult[];
+      const newRevisionsCount = new Map<number, number>(
+        newRevisionsCountDbResult.map((entry) => [entry.note_id, Number(entry.count)]),
       );
 
-      const revisionsToUpdate = await transaction(TableRevision)
-        .join(
-          TableAlias,
-          `${TableAlias}.${FieldNameAlias.noteId}`,
-          `${TableRevision}.${FieldNameRevision.noteId}`,
-        )
-        .select(
-          `${TableRevision}.${FieldNameRevision.uuid}`,
-          `${TableRevision}.${FieldNameRevision.noteId}`,
-          `${TableRevision}.${FieldNameRevision.content}`,
-          `${TableAlias}.${FieldNameAlias.alias}`,
-        )
-        .whereIn(`${TableRevision}.${FieldNameRevision.noteId}`, uniqueNoteIds)
-        .andWhere(`${TableAlias}.${FieldNameAlias.isPrimary}`, true)
-        .orderBy([
-          { column: `${TableRevision}.${FieldNameRevision.noteId}` },
-          { column: `${TableRevision}.${FieldNameRevision.createdAt}`, order: 'ASC' },
-        ]);
+      // 3. Sort noteIds in 3 categories
+      const notesWithOnlyOneRevision: number[] = [];
+      const notesWithMultipleOldRevisionsButNoNewOnes: number[] = [];
+      const notesWithNewRevisions: number[] = [];
 
-      let lastNoteId = -1;
-      let lastContent = '';
-
-      for (const revisionToUpdate of revisionsToUpdate) {
-        const id = revisionToUpdate[FieldNameRevision.uuid];
-        const noteId = revisionToUpdate[FieldNameRevision.noteId];
-        const primaryAlias = revisionToUpdate[FieldNameAlias.alias];
-        const content = revisionToUpdate[FieldNameRevision.content];
-
-        let newPatch = '';
-        if (noteId !== lastNoteId) {
-          newPatch = createPatch(
-            primaryAlias,
-            '', // There is no older Revision
-            content,
-          );
-        } else {
-          newPatch = createPatch(primaryAlias, lastContent, content);
+      for (const [noteId, oldCount] of oldRevisionsCount) {
+        const newCount = newRevisionsCount.get(noteId) ?? 0;
+        if (newCount === 0 && oldCount === 1) {
+          // a) noteId has only one revision older than revisionRetentionDays and no newer revision
+          notesWithOnlyOneRevision.push(noteId);
+        } else if (newCount === 0 && oldCount > 1) {
+          // b) noteId has multiple revisions older than revisionRetentionDays and no newer revision
+          notesWithMultipleOldRevisionsButNoNewOnes.push(noteId);
+        } else if (newCount > 0) {
+          // c) noteId has at least one newer revision
+          notesWithNewRevisions.push(noteId);
         }
+      }
 
+      // 5. Loop over all noteIds from category 3b
+      for (const noteId of notesWithMultipleOldRevisionsButNoNewOnes) {
+        // 5.1. Find newest revision
+        const newestRevision = await transaction(TableRevision)
+          .select(FieldNameRevision.uuid, FieldNameRevision.content)
+          .where(FieldNameRevision.noteId, noteId)
+          .orderBy(FieldNameRevision.createdAt, 'desc')
+          .first();
+        if (newestRevision === undefined) {
+          continue;
+        }
+        const primaryAlias = await this.aliasService.getPrimaryAliasByNoteId(noteId, transaction);
+        const newPatch = createPatch(primaryAlias, '', newestRevision[FieldNameRevision.content]);
         await transaction(TableRevision)
           .update(FieldNameRevision.patch, newPatch)
-          .where(FieldNameRevision.uuid, id);
-
-        lastNoteId = noteId;
-        lastContent = content;
+          .where(FieldNameRevision.uuid, newestRevision[FieldNameRevision.uuid]);
+        // 5.2. Delete all revisions for this noteId except the newest revision
+        await transaction(TableRevision)
+          .where(FieldNameRevision.noteId, noteId)
+          .andWhere(FieldNameRevision.uuid, '!=', newestRevision[FieldNameRevision.uuid])
+          .delete();
       }
+
+      // 6. Loop over all noteIds from category 3c
+      for (const noteId of notesWithNewRevisions) {
+        // 6.1. Find oldest revision that is either exactly as old as or newer than revisionRetentionDays
+        const oldestKeptRevision = await transaction(TableRevision)
+          .select(FieldNameRevision.uuid, FieldNameRevision.content)
+          .where(FieldNameRevision.noteId, noteId)
+          .andWhere(FieldNameRevision.createdAt, '>=', oldestRevisionToKeepDBTime)
+          .orderBy(FieldNameRevision.createdAt, 'asc')
+          .first();
+        if (oldestKeptRevision === undefined) {
+          continue;
+        }
+        const primaryAlias = await this.aliasService.getPrimaryAliasByNoteId(noteId, transaction);
+        // 6.2. Update that revision's `patch` to the diff between empty string and `content`
+        const newPatch = createPatch(
+          primaryAlias,
+          '',
+          oldestKeptRevision[FieldNameRevision.content],
+        );
+        await transaction(TableRevision)
+          .update(FieldNameRevision.patch, newPatch)
+          .where(FieldNameRevision.uuid, oldestKeptRevision[FieldNameRevision.uuid]);
+        // 6.3. Delete all revisions for this noteId older than revisionRetentionDays
+        await transaction(TableRevision)
+          .where(FieldNameRevision.noteId, noteId)
+          .andWhere(FieldNameRevision.createdAt, '<', oldestRevisionToKeepDBTime)
+          .delete();
+      }
+
+      this.logger.debug(
+        `Removed old revisions from ${notesWithMultipleOldRevisionsButNoNewOnes.length + notesWithNewRevisions.length} notes (skipped ${notesWithOnlyOneRevision.length} notes with only one revision)`,
+        'removeOldRevisions',
+      );
     });
   }
 }


### PR DESCRIPTION
### Component/Part
backend -> periodic revision cleanup (disabled by default)

### Description
The generated SQL from Knex contained ambigous column names, resulting in failure in the real-world since these queries were rejected by the SQLite library. This PR fixes the problem by properly making all column names explicit.

During this change we detected, that the current algorithm may produce data loss (for notes with only one old revision, this can be deleted, thus removing the content of the note).
This PR restructures the algorithm to avoid this behaviour.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6487 
