### PR TITLE
docs(security): add notice about HD2-preview exemption

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,12 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 Only the latest release of HedgeDoc is supported. We don't have the
 ressources to maintain multiple versions.
 
+We currently do not accept vulnerability reports for preview releases
+of the upcoming HedgeDoc 2.0. This version is still work-in-progress
+with several (security) features missing. Production usage is not yet
+recommended.  
+Security reports for preview releases of HedgeDoc 2.0 will be closed.
+
 ## Reporting a Vulnerability
 
 Please go to ["Issues" > "New" > "Report a security vulnerability"][report]. This


### PR DESCRIPTION
### Component/Part
Docs -> SECURITY.md

### Description
This PR adds a section to the SECURITY.md about preview builds of HD2.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
several ones
