### PR TITLE
fix(ci): include node version in yarn cache

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -23,7 +23,7 @@ runs:
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-master
+        key: ${{ runner.os }}-node${{ inputs.NODEJS_VERSION }}-yarn-master
 
     - name: Set up NodeJS
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
### Component/Part
CI cache

### Description
The dependency set may differ between node versions. This fixed caching makes it harder for version-specific deps and might introduce bugs therefore. We now include the node version in the cache key.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
