### PR TITLE
Minor Typos in Configuration Documentation

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -6,14 +6,14 @@ Environment variables take precedence over configurations from the config files.
 our own options, but we also list node-specific options you can configure this way.
 
 - Environment variables are processed in [
-  `lib/config/environment.js`](https://github.com/hedgedoc/hedgedoc/tree/master/lib/config/environment.js) - so this is
-  the first place to look if anything is missing not obvious from this document. The default values are defined in [
+  `lib/config/environment.js`](https://github.com/hedgedoc/hedgedoc/tree/master/lib/config/environment.js) which makes it
+  the first place to look if anything is missing or not obvious from this document. The default values are defined in [
   `lib/config/default.js`](https://github.com/hedgedoc/hedgedoc/tree/master/lib/config/default.js), in case you wonder
   if you even need to override it.
 
 - The config file is processed in [
-  `lib/config/index.js`](https://github.com/hedgedoc/hedgedoc/tree/master/lib/config/index.js) - so this is the first
-  place to look if anything is missing not obvious from this document. The default values are defined in [
+  `lib/config/index.js`](https://github.com/hedgedoc/hedgedoc/tree/master/lib/config/index.js) which makes it
+  the first place to look if anything is missing or not obvious from this document. The default values are defined in [
   `lib/config/default.js`](https://github.com/hedgedoc/hedgedoc/tree/master/lib/config/default.js), in case you wonder
   if you even need to override it. To get started, it is a good idea to take the [
   `config.json.example`](https://github.com/hedgedoc/hedgedoc/tree/master/config.json.example) and copy it


### PR DESCRIPTION
### Component/Part
Documentation

### Description
This PR fixes some minor typos in the Configuration documentation to improve readability.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
None
