### PR TITLE
[HD1] feat: add 'image/webp' to allowed upload MIME types

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -193,7 +193,8 @@ switch (config.imageUploadType) {
       'image/jpeg',
       'image/png',
       'image/gif',
-      'image/svg+xml'
+      'image/svg+xml',
+      'image/webp'
     ]
 }
 

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Added external link whitelist setting (`externalLinkWhitelist` in config.json or `CMD_EXTERNAL_LINK_WHITELIST`) to skip warning page for certain domains
+- Enabled `.webp` for file uploads (for all backends but `imgur`, since it does not support it)
 
 ## <i class="fa fa-tag"></i> 1.11.0 <i class="fa fa-calendar-o"></i> 2026-06-18
 


### PR DESCRIPTION
### Component/Part
HD1 Image upload (config)

### Description
This PR adds `image/webp` to the list of allowed upload MIME types. Previously WebP images were rejected with a "file type is not allowed" error on upload. WebP is now accepted for the default provider (filesystem, s3, minio, azure, lutim), so WebP images can be uploaded and embedded into notes. `imgur` does not support webp and webp is therefore not enabled.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
