### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ HedgeDoc lets you create real-time collaborative markdown notes.
 - ℹ️ Read all about HedgeDoc and the history of the project on [our website](https://hedgedoc.org)
 - 🧪 Try out HedgeDoc with the [demo instance][hedgedoc-demo]. Check out the [features page][hedgedoc-demo-features]!
 - 💽 Install HedgeDoc yourself using the [install guide](https://docs.hedgedoc.org/setup/getting-started/)
+- ☁️ Prefer a managed instance? [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/hedgedoc)
 - ❓ Questions? Join our [Matrix chat][matrix.org-url] or the [community forums][hedgedoc-community]
 - 💬 Stay up to date by subscribing to the [release feed][github-release-feed]
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added HedgeDoc to our marketplace, so this PR adds a small managed-hosting link under Getting Started (links to https://zenith.hosting/host/hedgedoc).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting