### PR TITLE
fix(editor): restore native browser zoom keyboard shortcuts

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -7,6 +7,11 @@
 - Added external link whitelist setting (`externalLinkWhitelist` in config.json or `CMD_EXTERNAL_LINK_WHITELIST`) to skip warning page for certain domains
 - Enabled `.webp` for file uploads (for all backends but `imgur`, since it does not support it)
 
+### Bugfixes
+
+- Restore native browser zoom-in keyboard shortcuts in the editor ([#6244](https://github.com/hedgedoc/hedgedoc/issues/6244))
+
+
 ## <i class="fa fa-tag"></i> 1.11.0 <i class="fa fa-calendar-o"></i> 2026-06-18
 
 ### Security fixes

--- a/public/js/lib/editor/index.js
+++ b/public/js/lib/editor/index.js
@@ -197,15 +197,6 @@ export default class Editor {
       'Shift-Ctrl-6': cm => {
         utils.wrapTextWith(this.editor, cm, '^')
       },
-      'Ctrl-+': cm => {
-        utils.wrapTextWith(this.editor, cm, '+')
-      },
-      'Shift-Ctrl-=': cm => {
-        utils.wrapTextWith(this.editor, cm, '+')
-      },
-      'Ctrl-=': cm => {
-        utils.wrapTextWith(this.editor, cm, '=')
-      },
       'Shift-Ctrl-Backspace': cm => {
         utils.wrapTextWith(this.editor, cm, 'Backspace')
       }


### PR DESCRIPTION
### Component/Part
Frontend (Editor)

### Description
This PR resolves an accessibility issue where the browser's native zoom-in keyboard shortcuts (`Ctrl`+`+` / `Ctrl`+`=`) are intercepted by the CodeMirror editor to wrap selected text in `+`/`=` characters, preventing users from zooming the page back in.

Since `Ctrl`+`-` (zoom out) is not intercepted, users who zoom out are locked into a zoomed-out state unless they manually use browser menus.

By removing the custom keybindings for `Ctrl-+`, `Shift-Ctrl-=`, and `Ctrl-=`, we allow the native browser zoom-in events to bubble up as expected.

### Steps
- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Fixes #6244