### PR TITLE
fix(revision): correct unpatching coordinates and whitelist details tag

### DIFF
--- a/lib/workers/dmpWorker.js
+++ b/lib/workers/dmpWorker.js
@@ -97,8 +97,17 @@ function getRevision (revisions, count) {
     }
     // swap DIFF_INSERT and DIFF_DELETE to achieve unpatching
     for (let i = 0, l = applyPatches.length; i < l; i++) {
-      for (let j = 0, m = applyPatches[i].diffs.length; j < m; j++) {
-        const diff = applyPatches[i].diffs[j]
+      const patch = applyPatches[i]
+      const tempStart = patch.start1
+      patch.start1 = patch.start2
+      patch.start2 = tempStart
+
+      const tempLength = patch.length1
+      patch.length1 = patch.length2
+      patch.length2 = tempLength
+
+      for (let j = 0, m = patch.diffs.length; j < m; j++) {
+        const diff = patch.diffs[j]
         if (diff[0] === DiffMatchPatch.DIFF_INSERT) {
           diff[0] = DiffMatchPatch.DIFF_DELETE
         } else if (diff[0] === DiffMatchPatch.DIFF_DELETE) {
@@ -145,3 +154,8 @@ process.on('uncaughtException', function (err) {
   logger.error('Process will exit now.')
   process.exit(1)
 })
+
+module.exports = {
+  createPatch,
+  getRevision
+}

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -10,7 +10,8 @@
 ### Bugfixes
 
 - Restore native browser zoom-in keyboard shortcuts in the editor ([#6244](https://github.com/hedgedoc/hedgedoc/issues/6244))
-
+- Fix revision history corruption during backward patch application (unpatching) ([#6513](https://github.com/hedgedoc/hedgedoc/issues/6513))
+- Add HTML `<details>` tag to the client-side XSS filter whitelist ([#6513](https://github.com/hedgedoc/hedgedoc/issues/6513))
 
 ## <i class="fa fa-tag"></i> 1.11.0 <i class="fa fa-calendar-o"></i> 2026-06-18
 

--- a/public/js/render.js
+++ b/public/js/render.js
@@ -24,6 +24,8 @@ whiteList.kbd = []
 whiteList.iframe = ['allowfullscreen', 'name', 'referrerpolicy', 'src', 'width', 'height']
 // allow summary tag
 whiteList.summary = []
+// allow details tag
+whiteList.details = ['open']
 // allow ruby tag
 whiteList.ruby = []
 // allow rp tag for ruby

--- a/test/revision.js
+++ b/test/revision.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const assert = require('assert')
+const dmpWorker = require('../lib/workers/dmpWorker')
+
+describe('Note Revision DMP Worker', function () {
+  it('correctly reconstructs revision history backwards (unpatching)', function () {
+    const text1 = 'Hello, this is a beautiful world!'
+    const text2 = 'Hello, this is a wonderful and beautiful new world!'
+    const text3 = 'Hello, this is a wonderful and beautiful new world! And it is nice.'
+    const text4 = 'Hello, this is a wonderful and beautiful new world! And it is nice. Indeed.'
+    const text5 = 'Hello, this is a wonderful and beautiful new world! And it is nice. Indeed. Bye!'
+
+    const patch4 = dmpWorker.createPatch(text4, text5)
+    const patch3 = dmpWorker.createPatch(text3, text4)
+    const patch2 = dmpWorker.createPatch(text2, text3)
+    const patch1 = dmpWorker.createPatch(text1, text2)
+
+    const revisions = [
+      { content: text5, patch: patch4 },
+      { content: null, patch: patch3 },
+      { content: null, patch: patch2 },
+      { content: null, patch: patch1 },
+      { content: null, lastContent: text1, patch: null }
+    ]
+
+    // Retrieve revision 2 (should return text4 by inverting patch4)
+    const result2 = dmpWorker.getRevision(revisions, 2)
+    assert.strictEqual(result2.content, text4)
+
+    // Retrieve revision 3 (should return text3 by inverting patch4 and patch3)
+    const result3 = dmpWorker.getRevision(revisions, 3)
+    assert.strictEqual(result3.content, text3)
+  })
+
+  it('handles failing patch application and shifts coordinates correctly', function () {
+    const text1 = 'Part 1: Hello. Part 2: World. Part 3: Bye.'
+    const text2 = 'Part 1: Hello. Part 2: Wonderful World. Part 3: Bye.'
+    const text3 = 'Part 1: Hello. Part 2: Wonderful World. Part 3: See ya.'
+    const text4 = 'Part 1: Hello. Part 2: Wonderful World. Part 3: See ya. Extra.'
+    const text5 = 'Part 1: Hello. Part 2: Wonderful World. Part 3: See ya. Extra. Final.'
+
+    const patch4 = dmpWorker.createPatch(text4, text5)
+    const patch3 = dmpWorker.createPatch(text3, text4)
+    const patch2 = dmpWorker.createPatch(text2, text3)
+    const patch1 = dmpWorker.createPatch(text1, text2)
+
+    const revisions = [
+      { content: text5, patch: patch4 },
+      { content: null, patch: patch3 },
+      { content: null, patch: patch2 },
+      { content: null, patch: patch1 },
+      { content: null, lastContent: text1, patch: null }
+    ]
+
+    revisions[0].content = 'Part 1: Hello. Part 2: Wonderful World. Part 3: Completely different.'
+
+    const result = dmpWorker.getRevision(revisions, 3)
+    assert.ok(result.content.includes('Completely different.'))
+  })
+})


### PR DESCRIPTION
### Component/Part
Backend Worker / Frontend Render System

### Description
This PR fixes the revision history corruption bug that occurs during backward patch reconstruction (unpatching). It also adds the HTML `<details>` tag to the custom XSS whitelist to prevent it from being rendered as escaped HTML in the frontend.

Specifically:
- In `lib/workers/dmpWorker.js`, during unpatching, the patch coordinates (`start1`, `start2`) and lengths (`length1`, `length2`) are now swapped alongside the `DIFF_INSERT` / `DIFF_DELETE` operations. This aligns coordinates mathematically in Google's Diff-Match-Patch library when moving backward.
- In `public/js/render.js`, `<details>` is added to the custom XSS filter whitelist so it displays properly along with `<summary>`.
- In `test/revision.js`, unit tests are added to verify the correctness of the `getRevision` unpatching coordinates/offsets.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/master/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Fixes #6513
