### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/docs/content/setup/community.md
+++ b/docs/content/setup/community.md
@@ -65,6 +65,12 @@ using the button below. This will run the official Docker image from [quay.io](h
 
 [![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=hedgedoc)
 
+### Zenith
+
+[Zenith](https://zenith.hosting/) offers one-click managed hosting for open source apps. Deploy a fully managed HedgeDoc instance in minutes using the button below.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/hedgedoc)
+
 ### SelfPrivacy
 
 HedgeDoc is available as a 1-click install on [SelfPrivacy](https://selfprivacy.org/). SelfPrivacy app allows you to set up self-hosted services on your automatically configured and managed NixOS-based server. Because HedgeDoc is officialy supported by SelfPrivacy, all you need to do is add it from the Services catalog on the Services page.


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added HedgeDoc to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the One-click Installer section (links to https://zenith.hosting/host/hedgedoc).

thanks @ErikMichelson for pointing me to the right page. we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting