### PR TITLE
update docs/content/setup/manual-setup.md: node 18 -> 20

### DIFF
--- a/docs/content/setup/manual-setup.md
+++ b/docs/content/setup/manual-setup.md
@@ -1,7 +1,7 @@
 # Manual Installation
 
 !!! info "Requirements on your server"
-    - Node.js 18 or later
+    - Node.js 20 or later
       We recommend to run HedgeDoc with the latest LTS release of Node.js.
     - Database (PostgreSQL, MySQL, MariaDB, SQLite)  
       The database must use charset `utf8`. This is typically the default in PostgreSQL and SQLite.  


### PR DESCRIPTION
I noticed that the changelog 1.10.1 2025-02-02 deprecates Node 18 and says that future releases will require Node 20. 

<https://github.com/hedgedoc/hedgedoc/blob/c02dc05beccafd9a9e25cd48f0db398c3176c16a/public/docs/release-notes.md#-1101--2025-02-02>

This PR just updates the documentation to reflect that. :-) 


### Component/Part

Documentation

### Description
This PR updates `docs/content/setup/manual-setup.md` to reference node 20 instead of 18.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

none
