### PR TITLE
Allow opening links to PDFs from the renderer sandbox

### DIFF
--- a/frontend/src/components/common/renderer-iframe/renderer-iframe.spec.tsx
+++ b/frontend/src/components/common/renderer-iframe/renderer-iframe.spec.tsx
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { RendererType } from '../../render-page/window-post-message-communicator/rendering-message'
+import { render, screen } from '@testing-library/react'
+import { RendererIframe } from './renderer-iframe'
+
+jest.mock('../../editor-page/render-context/editor-to-renderer-communicator-context-provider', () => ({
+  useEditorToRendererCommunicator: () => ({
+    enableCommunication: jest.fn(),
+    getUuid: () => 'test-uuid',
+    sendMessageToOtherSide: jest.fn(),
+    setMessageTarget: jest.fn(),
+    unsetMessageTarget: jest.fn()
+  })
+}))
+
+jest.mock('../../markdown-renderer/hooks/use-extension-event-emitter', () => ({
+  useExtensionEventEmitter: () => undefined
+}))
+
+jest.mock('../../render-page/window-post-message-communicator/hooks/use-editor-receive-handler', () => ({
+  useEditorReceiveHandler: jest.fn()
+}))
+
+jest.mock('./hooks/use-effect-on-render-type-change', () => ({
+  useEffectOnRenderTypeChange: jest.fn()
+}))
+
+jest.mock('./hooks/use-force-render-page-url-on-iframe-load-callback', () => ({
+  useForceRenderPageUrlOnIframeLoadCallback: () => jest.fn()
+}))
+
+jest.mock('./hooks/use-send-additional-configuration-to-renderer', () => ({
+  useSendAdditionalConfigurationToRenderer: jest.fn()
+}))
+
+jest.mock('./hooks/use-send-fragment-to-renderer', () => ({
+  useSendFragmentToRenderer: jest.fn()
+}))
+
+jest.mock('./hooks/use-send-markdown-to-renderer', () => ({
+  useSendMarkdownToRenderer: jest.fn()
+}))
+
+jest.mock('./hooks/use-send-scroll-state', () => ({
+  useSendScrollState: jest.fn()
+}))
+
+describe('RendererIframe', () => {
+  it('includes security sandboxing attributes for the iframe', () => {
+    render(<RendererIframe markdownContentLines={[]} rendererType={RendererType.DOCUMENT} />)
+
+    const expectedArguments = [
+      'allow-downloads',
+      'allow-same-origin',
+      'allow-scripts',
+      'allow-popups',
+      'allow-popups-to-escape-sandbox',
+      'allow-modals'
+    ]
+    const renderer = screen.getByTitle('render')
+    for (const argument of expectedArguments) {
+      expect(renderer).toHaveAttribute('sandbox', expect.stringContaining(argument))
+    }
+  })
+})

--- a/frontend/src/components/common/renderer-iframe/renderer-iframe.tsx
+++ b/frontend/src/components/common/renderer-iframe/renderer-iframe.tsx
@@ -186,7 +186,10 @@ export const RendererIframe: React.FC<RendererIframeProps> = ({
         title='render'
         {...(isTestMode
           ? {}
-          : { sandbox: 'allow-downloads allow-same-origin allow-scripts allow-popups allow-modals' })}
+          : {
+              sandbox:
+                'allow-downloads allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-modals'
+            })}
         allowFullScreen={true}
         ref={frameReference}
         referrerPolicy={'no-referrer'}


### PR DESCRIPTION
### Component/Part
renderer

### Description
Apparently, opening a link from a sandboxed iframe enabled the sandbox mode for the opened new tab as well. For most pages, this is not a problem since these pages don't depend on anything special. However when clicking a link to a PDF file, Chromium- based browsers don't open the tab, since the built-in PDF viewer is not compatible with the sandboxing.
The attribute `allow-popups-to-escape-sandbox` allows pages opened from the sandbox into a new tab to be not sandboxed. Since we don't have opener access there, this is no risk to HedgeDoc and can safely be enabled and therefore fix PDF links.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5841 
