### PR TITLE
Adjust TOC colors for accessability

### DIFF
--- a/frontend/src/components/editor-page/table-of-contents/table-of-contents.module.scss
+++ b/frontend/src/components/editor-page/table-of-contents/table-of-contents.module.scss
@@ -43,7 +43,7 @@
     font-size: 0.9em;
 
     a {
-      color: #767676;
+      color: var(--bs-secondary-color);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: pre;
@@ -54,7 +54,7 @@
       a {
         margin-top: 2px;
         margin-bottom: 2px;
-        color: #000000;
+        color: var(--bs-emphasis-color);
         font-weight: bold;
       }
     }


### PR DESCRIPTION
### Component/Part
editor -> TOC (table of contents)

### Description
Previously the hardcoded colors only made a contrast of 3.39 to the background. Furthermore changing the overall theme variables wouldn't change the colors for the table-of-contents as well. This commit changes that to use the theme variables, therefore ensuring better maintainability and contrast (now 7.29)

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
part of #6032 
