### PR TITLE
Update Arch Linux package link (community -> extra)

### DIFF
--- a/docs/content/setup/community.md
+++ b/docs/content/setup/community.md
@@ -85,7 +85,7 @@ The source code of the module can be found [here](https://git.selfprivacy.org/Se
 
 HedgeDoc is available in the Arch Linux _community_ repository.
 
-[Link to the package](https://archlinux.org/packages/community/any/hedgedoc/)
+[Link to the package](https://archlinux.org/packages/extra/any/hedgedoc/)
 
 ### FreeBSD
 


### PR DESCRIPTION
### Component/Part
Docs website

### Description
This PR updates to link to the arch linux package.

### Steps
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
None