### PR TITLE
fix(externalLinks): make external link warning work with subpaths

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -6,6 +6,7 @@
 
 - Added external link whitelist setting (`externalLinkWhitelist` in config.json or `CMD_EXTERNAL_LINK_WHITELIST`) to skip warning page for certain domains
 - Added external link warning setting (`externalLinkWarning` in config.json or `CMD_EXTERNAL_LINK_WARNING`) to disable the external link warning page entirely
+- Fixed external link warning for subpath instances
 - Enabled `.webp` for file uploads (for all backends but `imgur`, since it does not support it)
 
 ### Bugfixes

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -624,7 +624,8 @@ export function rewriteExternalLinks (view) {
       return
     }
     const noteURL = window.location.pathname.split('/').pop()
-    anchor.attr('href', `${window.location.origin}/_link?url=${encodeURIComponent(parsed.href)}&note=${noteURL}`)
+    const urlPath = window.urlpath ? `/${window.urlpath}` : ''
+    anchor.attr('href', `${window.location.origin}${urlPath}/_link?url=${encodeURIComponent(parsed.href)}&note=${noteURL}`)
   })
 }
 window.rewriteExternalLinks = rewriteExternalLinks


### PR DESCRIPTION
### Component/Part
link rewirte for external link warning 

### Description
When the instance is hosted on a subpath, the links got wrongly rewritten. This pull reuqest fixes this problem.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6577
