### PR TITLE
[HD1] Fix slide preview of nested list items

### DIFF
--- a/public/css/slide-preview.css
+++ b/public/css/slide-preview.css
@@ -44,10 +44,6 @@
   overflow: hidden;
 }
 
-.markdown-body.slides section[data-markdown] > ul {
-  display: inline-block;
-}
-
 .markdown-body.slides > section > section + section::after {
   content: '';
   position: absolute;
@@ -61,7 +57,8 @@
   display: none;
 }
 
-.markdown-body.slides ul, .markdown-body.slides ol {
+.markdown-body.slides section[data-markdown] > div:first-child > ul,
+.markdown-body.slides section[data-markdown] > div:first-child > ol {
   display: inline-block;
   text-align: left;
   margin: 0 0 0 1em;

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -18,6 +18,7 @@
 ### Bugfixes
 
 - Restore native browser zoom-in keyboard shortcuts in the editor ([#6244](https://github.com/hedgedoc/hedgedoc/issues/6244))
+- Nested list items render properly again in the preview pane for slides ([#6080](https://github.com/hedgedoc/hedgedoc/issues/6080))
 
 ## <i class="fa fa-tag"></i> 1.11.0 <i class="fa fa-calendar-o"></i> 2026-06-18
 


### PR DESCRIPTION
### Component/Part
editor -> slide preview

### Description
This PR fixes the displaying of (nested) list items in the preview pane of the editor. Previously, list items were all treated as inline blocks and therefore nested list items were placed next to the previous item instead of below it. Now they align properly as expected.

Can be tested with the following content as done in the original issue:

```markdown
---
type: slide
---

- first
    - second 1
    - second 2

```

<img width="1156" height="649" alt="image" src="https://github.com/user-attachments/assets/2b317f23-cab1-46fc-b408-06eb8c0b35be" />


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
Fixes #6080 
