### PR TITLE
Update Mastodon logo colour

### DIFF
--- a/docs/content/theme/styles/hedgedoc-custom.css
+++ b/docs/content/theme/styles/hedgedoc-custom.css
@@ -55,7 +55,7 @@
 }
 
 .mastodon {
-  color: #2b90d9;
+  color: #6364FF;
 }
 
 [data-md-color-scheme="slate"] .light-mode-only {


### PR DESCRIPTION
Minor update to switch the colour of the Mastodon logo in the docs to the post-2022 branding.

### Component/Part
Docs

### Description
This simply switches the Mastodon logo from blue to purple.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
n/a
