### PR TITLE
docs: change mastodon color to brand purple

### DIFF
--- a/docs/content/theme/styles/hedgedoc-custom.css
+++ b/docs/content/theme/styles/hedgedoc-custom.css
@@ -50,7 +50,7 @@
 }
 
 .mastodon {
-  color: #2b90d9;
+  color: #6364FF;
 }
 
 [data-md-color-scheme="slate"] .light-mode-only {


### PR DESCRIPTION
Update Mastodon logo colour to correct branding

### Component/Part
Docs

### Description
This PR changes the colour of the Mastodon logo used in the docs to match the post-2022 Mastodon Brand Guidelines.

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
