### PR TITLE
fix(frontend): change z-index of explore search bar

### DIFF
--- a/frontend/src/components/explore-page/explore-notes-section/explore-notes-section.module.css
+++ b/frontend/src/components/explore-page/explore-notes-section/explore-notes-section.module.css
@@ -6,7 +6,7 @@
 
 .filter-and-nav-box {
   position: sticky;
-  z-index: 1020;
+  z-index: 999;
   top: 0;
   padding-block-end: 0.25rem;
   background-color: var(--bs-body-bg);


### PR DESCRIPTION
### Component/Part
frontend

### Description

The search bar was in front of the menu and that looked wrong.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)

Fixes #6601
