### PR TITLE
fix(frontend): footnote backrefs correctly return

### DIFF
--- a/frontend/src/components/markdown-renderer/extensions/link-replacer/jump-anchor.tsx
+++ b/frontend/src/components/markdown-renderer/extensions/link-replacer/jump-anchor.tsx
@@ -27,14 +27,6 @@ export const JumpAnchor: React.FC<JumpAnchorProps> = ({ jumpTargetId, children, 
         type: CommunicationMessageType.SET_URL_HASH,
         hash: jumpTargetId
       })
-      const intoViewElement = document.getElementById(jumpTargetId)
-      const scrollElement = document.querySelector('[data-scroll-element]')
-      if (!intoViewElement || !scrollElement) {
-        return
-      }
-      //It would be much easier to use scrollIntoView here but since the code mirror also uses smooth scroll and bugs like
-      // https://stackoverflow.com/a/63563437/13103995 exist, we must use scrollTo.
-      scrollElement.scrollTo({ behavior: 'smooth', top: intoViewElement.offsetTop })
       event.preventDefault()
     },
     [iframeCommunicator, jumpTargetId]

--- a/frontend/src/components/render-page/render-page-content.tsx
+++ b/frontend/src/components/render-page/render-page-content.tsx
@@ -95,15 +95,19 @@ export const RenderPageContent: React.FC = () => {
         const scrollToElement = (): boolean => {
           const targetElement = document.getElementById(elementId)
           const scrollElement = document.querySelector('[data-scroll-element]')
-          if (targetElement && scrollElement) {
-            sendScrolling.current = true
-            communicator.sendMessageToOtherSide({
-              type: CommunicationMessageType.ENABLE_RENDERER_SCROLL_SOURCE
-            })
-            scrollElement.scrollTo({ behavior: 'smooth', top: targetElement.offsetTop })
-            return true
+          if (!targetElement || !scrollElement) {
+            return false
           }
-          return false
+          sendScrolling.current = true
+          let top = targetElement.offsetTop
+          if (targetElement.parentElement?.className === 'footnote-ref') {
+            top = targetElement.parentElement.offsetTop
+          }
+          communicator.sendMessageToOtherSide({
+            type: CommunicationMessageType.ENABLE_RENDERER_SCROLL_SOURCE
+          })
+          scrollElement.scrollTo({ behavior: 'smooth', top: top })
+          return true
         }
 
         // On initial page load on slower computers, the markdown might not have rendered yet.


### PR DESCRIPTION
### Component/Part
frontend

### Description
This PR fixes the footnote backref links

The problem was that we intended to scroll to the topOffset of the linked item,
but the backrefs link to an a-tag in sup-tag. The a-tag has topOffset of 0 and so we scroll to the very top.
To fix this we now check if any link links to something in a sup-tag with className footnote-ref and use the offset of that parent element instead.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
#6477 
