### PR TITLE
Do not strip KaTeX from TOC

### DIFF
--- a/commons/src/title-extraction/extract-first-heading.spec.ts
+++ b/commons/src/title-extraction/extract-first-heading.spec.ts
@@ -46,6 +46,17 @@ describe('extract first heading', () => {
       expect(extractFirstHeading(document)).toBe('Image Alt')
     })
 
+    it('ignores MathML duplicated by KaTeX', () => {
+      const headline = new Element(`h${headlineIndex}`, {}, [
+        new Element('span', { class: 'katex-mathml' }, [
+          new Element('math', {}, [new Element('mi', {}, [new Text('alpha')])]),
+        ]),
+        new Element('span', { class: 'katex-html', 'aria-hidden': 'true' }, [new Text('alpha')]),
+      ])
+      const document = new Document([headline])
+      expect(extractFirstHeading(document)).toBe('alpha')
+    })
+
     it('extracts only the first found headline', () => {
       const headline1 = new Element(`h${headlineIndex}`, {}, [new Text(`headline${headlineIndex}`)])
       const headline2 = new Element(`h${headlineIndex}`, {}, [new Text('headline1')])

--- a/commons/src/title-extraction/extract-first-heading.ts
+++ b/commons/src/title-extraction/extract-first-heading.ts
@@ -43,6 +43,8 @@ function extractInnerTextFromTag(node: Element): string {
     return ''
   } else if (node.name === 'img') {
     return findAttribute(node, 'alt')?.value ?? ''
+  } else if (node.name === 'math') {
+    return ''
   } else {
     return node.children.reduce((state, child) => {
       return state + extractInnerTextFromNode(child)

--- a/markdown-it-plugins/src/toc/index.test.ts
+++ b/markdown-it-plugins/src/toc/index.test.ts
@@ -183,4 +183,35 @@ describe('toc', () => {
     `),
     ).toMatchSnapshot()
   })
+
+  it('includes inline math in heading names', () => {
+    const callback = jest.fn()
+    const markdownIt = new MarkdownIt().use(toc, { callback })
+    markdownIt.inline.ruler.before('text', 'inlineMath', (state, silent) => {
+      if (state.src.slice(state.pos, state.pos + 8) !== '$\\alpha$') {
+        return false
+      }
+
+      if (!silent) {
+        const token = state.push('inline_math', '', 0)
+        token.content = '\\alpha'
+      }
+      state.pos += 8
+      return true
+    })
+
+    markdownIt.render('# $\\alpha$-foo')
+
+    expect(callback).toHaveBeenCalledWith({
+      children: [
+        {
+          children: [],
+          level: 1,
+          name: '\\alpha-foo',
+        },
+      ],
+      level: 0,
+      name: '',
+    })
+  })
 })

--- a/markdown-it-plugins/src/toc/toc-options.ts
+++ b/markdown-it-plugins/src/toc/toc-options.ts
@@ -37,6 +37,6 @@ export const defaultOptions: TocOptions = {
   linkClass: '',
   level: 1,
   listType: 'ol',
-  allowedTokenTypes: ['text', 'code_inline'],
+  allowedTokenTypes: ['text', 'code_inline', 'math', 'inline_math', 'display_math'],
   slugify: defaultSlugify,
 }


### PR DESCRIPTION
### Component/Part
renderer/ToC

### Description
The KaTeX renderer usually renders the raw KaTeX into MathML. This can not be properly displayed inside the toc and further makes problems when trying to render a fallback, because then parts could become duplicated. This commit fixes this by stripping MathML code completely for the title processing, leaving the raw KaTeX code intact. The only downside of this approach is that the surrounding '$' get lost, but this seems still better than nothing or duplicated content.

To test use a similar note content:

```markdown
# Test $\alpha \beta$ heading

123
```

Before this PR:
<img width="1770" height="247" alt="image" src="https://github.com/user-attachments/assets/a2f8551a-f9b5-4a89-ac49-2560764938ca" />

After this PR (note the TOC for difference):
<img width="1873" height="247" alt="image" src="https://github.com/user-attachments/assets/25295d0d-72c0-4963-b6cb-1cb4a0bf1e99" />



### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #2899 
