### PR TITLE
Renderer-communicator fixes

### DIFF
--- a/frontend/src/components/common/renderer-iframe/renderer-iframe.spec.tsx
+++ b/frontend/src/components/common/renderer-iframe/renderer-iframe.spec.tsx
@@ -7,13 +7,16 @@ import { RendererType } from '../../render-page/window-post-message-communicator
 import { render, screen } from '@testing-library/react'
 import { RendererIframe } from './renderer-iframe'
 
+const unsetMessageTarget = jest.fn()
+
 jest.mock('../../editor-page/render-context/editor-to-renderer-communicator-context-provider', () => ({
   useEditorToRendererCommunicator: () => ({
     enableCommunication: jest.fn(),
     getUuid: () => 'test-uuid',
+    isCommunicationEnabled: () => false,
     sendMessageToOtherSide: jest.fn(),
     setMessageTarget: jest.fn(),
-    unsetMessageTarget: jest.fn()
+    unsetMessageTarget
   })
 }))
 
@@ -50,6 +53,8 @@ jest.mock('./hooks/use-send-scroll-state', () => ({
 }))
 
 describe('RendererIframe', () => {
+  beforeEach(() => unsetMessageTarget.mockClear())
+
   it('includes security sandboxing attributes for the iframe', () => {
     render(<RendererIframe markdownContentLines={[]} rendererType={RendererType.DOCUMENT} />)
 
@@ -65,5 +70,21 @@ describe('RendererIframe', () => {
     for (const argument of expectedArguments) {
       expect(renderer).toHaveAttribute('sandbox', expect.stringContaining(argument))
     }
+  })
+
+  it('clears the global renderer status and message target when unmounted', () => {
+    const onRendererStatusChange = jest.fn()
+    const { unmount } = render(
+      <RendererIframe
+        markdownContentLines={[]}
+        rendererType={RendererType.DOCUMENT}
+        onRendererStatusChange={onRendererStatusChange}
+      />
+    )
+
+    unmount()
+
+    expect(unsetMessageTarget).toHaveBeenCalled()
+    expect(onRendererStatusChange).toHaveBeenLastCalledWith(false)
   })
 })

--- a/frontend/src/components/common/renderer-iframe/renderer-iframe.tsx
+++ b/frontend/src/components/common/renderer-iframe/renderer-iframe.tsx
@@ -86,9 +86,10 @@ export const RendererIframe: React.FC<RendererIframeProps> = ({
   useEffect(
     () => () => {
       log.debug('Component ended')
-      setRendererReady(false)
+      iframeCommunicator.unsetMessageTarget()
+      onRendererStatusChange?.(false)
     },
-    [iframeCommunicator, log]
+    [iframeCommunicator, log, onRendererStatusChange]
   )
 
   useEffect(() => {

--- a/frontend/src/components/editor-page/editor-page-content.tsx
+++ b/frontend/src/components/editor-page/editor-page-content.tsx
@@ -18,7 +18,7 @@ import { PrintWarning } from './print-warning/print-warning'
 import React, { useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import './print.scss'
-import { usePrintKeyboardShortcut } from './hooks/use-print-keyboard-shortcut'
+import { usePrintIframeKeyboardShortcut } from './hooks/use-print-keyboard-shortcut'
 import { NoteType } from '@hedgedoc/commons'
 import { useApplicationState } from '../../hooks/common/use-application-state'
 import { buildCursorLineScrollState } from './synced-scroll/cursor-line-scroll-state'
@@ -33,7 +33,7 @@ export enum ScrollSource {
  */
 export const EditorPageContent: React.FC = () => {
   useTranslation()
-  usePrintKeyboardShortcut()
+  usePrintIframeKeyboardShortcut()
 
   const scrollSource = useRef<ScrollSource>(ScrollSource.EDITOR)
   const [editorScrollState, onMarkdownRendererScroll] = useScrollState(scrollSource, ScrollSource.EDITOR)

--- a/frontend/src/components/editor-page/hooks/use-print-keyboard-shortcut.spec.ts
+++ b/frontend/src/components/editor-page/hooks/use-print-keyboard-shortcut.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { fireEvent, renderHook } from '@testing-library/react'
+import { usePrintIframeKeyboardShortcut, usePrintSelfKeyboardShortcut } from './use-print-keyboard-shortcut'
+
+const printIframe = jest.fn()
+const printSelf = jest.fn()
+
+jest.mock('../utils/print-iframe', () => ({
+  usePrintIframe: () => printIframe,
+  usePrintSelf: () => printSelf
+}))
+
+describe('usePrintKeyboardShortcut', () => {
+  beforeEach(() => {
+    printIframe.mockClear()
+    printSelf.mockClear()
+  })
+
+  it('prints the renderer iframe when the print shortcut is pressed', () => {
+    renderHook(() => usePrintIframeKeyboardShortcut())
+
+    fireEvent.keyDown(window, { ctrlKey: true, key: 'p' })
+
+    expect(printIframe).toHaveBeenCalledTimes(1)
+    expect(printSelf).not.toHaveBeenCalled()
+  })
+
+  it('prints the current window when the print shortcut is pressed in the renderer iframe', () => {
+    renderHook(() => usePrintSelfKeyboardShortcut())
+
+    fireEvent.keyDown(window, { ctrlKey: true, key: 'p' })
+
+    expect(printSelf).toHaveBeenCalledTimes(1)
+    expect(printIframe).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/editor-page/hooks/use-print-keyboard-shortcut.ts
+++ b/frontend/src/components/editor-page/hooks/use-print-keyboard-shortcut.ts
@@ -4,26 +4,33 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { usePrintIframe, usePrintSelf } from '../utils/print-iframe'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect } from 'react'
 
 /**
  * Hook to listen for the print keyboard shortcut and print the content of the renderer iframe.
  */
-export const usePrintKeyboardShortcut = (): void => {
-  const isIframe = useMemo(() => window.top !== window.self, [])
+export const usePrintIframeKeyboardShortcut = (): void => {
+  const printIframe = usePrintIframe()
+  usePrintShortcut(printIframe)
+}
 
+/**
+ * Hook to listen for the print keyboard shortcut and print the renderer content from within the iframe.
+ */
+export const usePrintSelfKeyboardShortcut = (): void => {
+  const printSelf = usePrintSelf()
+  usePrintShortcut(printSelf)
+}
+
+const usePrintShortcut = (print: () => void): void => {
   const handlePrint = useCallback(
     (event: KeyboardEvent): void => {
       if (event.key === 'p' && (event.ctrlKey || event.metaKey)) {
         event.preventDefault()
-        if (isIframe) {
-          usePrintSelf()()
-        } else {
-          usePrintIframe()()
-        }
+        print()
       }
     },
-    [isIframe]
+    [print]
   )
 
   useEffect(() => {

--- a/frontend/src/components/render-page/render-page-content.tsx
+++ b/frontend/src/components/render-page/render-page-content.tsx
@@ -18,7 +18,7 @@ import type { RevealOptions } from 'reveal.js'
 import { EventEmitter2 } from 'eventemitter2'
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { setPrintMode } from '../../redux/print-mode/methods'
-import { usePrintKeyboardShortcut } from '../editor-page/hooks/use-print-keyboard-shortcut'
+import { usePrintSelfKeyboardShortcut } from '../editor-page/hooks/use-print-keyboard-shortcut'
 
 /**
  * Wraps the markdown rendering in an iframe.
@@ -127,7 +127,7 @@ export const RenderPageContent: React.FC = () => {
     )
   )
 
-  usePrintKeyboardShortcut()
+  usePrintSelfKeyboardShortcut()
 
   const onMakeScrollSource = useCallback(() => {
     sendScrolling.current = true

--- a/frontend/src/components/render-page/window-post-message-communicator/hooks/use-send-to-renderer.ts
+++ b/frontend/src/components/render-page/window-post-message-communicator/hooks/use-send-to-renderer.ts
@@ -21,7 +21,7 @@ export const useSendToRenderer = (
   const iframeCommunicator = useEditorToRendererCommunicator()
 
   useEffect(() => {
-    if (message && rendererReady) {
+    if (message && rendererReady && iframeCommunicator.isCommunicationEnabled()) {
       iframeCommunicator.sendMessageToOtherSide(message)
     }
   }, [iframeCommunicator, message, rendererReady])

--- a/frontend/src/redux/print-mode/slice.ts
+++ b/frontend/src/redux/print-mode/slice.ts
@@ -11,9 +11,7 @@ const printModeSlice = createSlice({
   name: 'printMode',
   initialState,
   reducers: {
-    setPrintMode: (state, action: PayloadAction<boolean>) => {
-      state = action.payload
-    }
+    setPrintMode: (_state, action: PayloadAction<boolean>) => action.payload
   }
 })
 


### PR DESCRIPTION
### Component/Part
editor

### Description
When the renderer communicator is not properly cleaned-up by marking it as having disabled communication, it fails on reloading notes with required communication as for example slides.
Furthermore, there was an error with the printing hooks. Due to React's rule of hooks, hooks can't call other hooks and therefore the actual print hooks were never called when pressing the Ctrl-P shortcut.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none