### PR TITLE
feat(frontend): add nodeBook knowledge-graph extension

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -953,6 +953,44 @@
         "description": "Set a equals sign after the language to show line numbers. You can specify a start line number after the equal sign or a plus to continue the line numbers from the last code block.",
         "example": "```markdown=12\nline1\n```\n```markdown=+\nline2\n```\n```markdown=\nline3\n```"
       }
+    },
+    "nodeBook": {
+      "title": "nodeBook",
+      "conceptMap": {
+        "title": "Concept Map",
+        "description": "Create knowledge graphs by declaring nodes with `# Name [Type]` headings, adding attributes with `name: value;` (the `has` prefix is optional), and connecting nodes with `<relation> Target;` edges. Use `<relation> N Target;` for weighted edges — the number displays as a circled digit on the arc. Prefix a relation or an attribute with `!` to assert it does NOT hold (e.g. `!<has> external ear;` or `!color: green;`) — negated relations are drawn as a dashed red barred edge, and negated attributes appear struck through.",
+        "example": "```nodeBook\n# Earth [Planet]\ndiameter: 12742 *km*;\nstate: \"solid\";\n!color: green;\n<orbits> Sun;\n<has satellite> Moon;\n!<has satellite> Ring;\n\n# Sun [Star]\nspectral type: \"G2V\";\n\n# Moon [Satellite]\ndiameter: 3474 *km*;\n```"
+      },
+      "petriNet": {
+        "title": "Petri Net",
+        "description": "Model processes with `[Transition]` nodes. Connect inputs with `<has prior_state>` and outputs with `<has post_state>`. Arc weights specify how many tokens are consumed or produced per firing (e.g. `<has prior_state> 6 CO2;` needs 6 tokens). Click enabled (green) transitions to simulate. A deadlock banner appears when no transition can fire.",
+        "example": "```nodeBook\n# Photosynthesis [Transition]\n<has prior_state> 6 CO2;\n<has prior_state> 6 H2O;\n<has prior_state> Sunlight;\n<has post_state> Glucose;\n<has post_state> 6 O2;\n\n# CO2 [Molecule]\n# H2O [Molecule]\n# Sunlight [Energy]\n# Glucose [Molecule]\n# O2 [Molecule]\n```"
+      },
+      "accounting": {
+        "title": "Double-Entry Accounting",
+        "description": "Model accounting transactions as Petri net transitions using `[Transaction]` nodes. Use `<debit>` and `<credit>` relations to move value between accounts. Declare accounts with `[Asset]`, `[Liability]`, `[Equity]`, `[Revenue]`, or `[Expense]` types and set initial balances with `balance: amount;`. Add `currency: EUR;` at the top to set the currency (supports USD, EUR, GBP, INR, JPY, PHP, and more). Click transactions to simulate — disabled when source accounts have insufficient balance.",
+        "example": "```nodeBook\ncurrency: INR;\n\n# Cash [Asset]\nbalance: 50000;\n\n# Buy Inventory [Transaction]\ndate: 2026-01-15;\n<debit> 25000 Inventory;\n<credit> 25000 Cash;\n```"
+      },
+      "mindMap": {
+        "title": "Mind Map",
+        "description": "Create hierarchical mind maps with a `# Root <relation>` heading followed by indented list items. Each indentation level defines a deeper branch. The relation label is used for all edges in the tree.",
+        "example": "```nodeBook\n# Science <branches into>\n- Physics\n  - Mechanics\n  - Thermodynamics\n- Chemistry\n  - Organic\n  - Inorganic\n- Biology\n  - Botany\n  - Zoology\n```"
+      },
+      "morphs": {
+        "title": "Polymorphic Nodes",
+        "description": "Add `## Morph Name` sub-headings under a `#` node to define polymorphic states. Each morph can have its own attributes and relations. Click a node in the graph to switch between its morphs using the state selector.",
+        "example": "```nodeBook\n# Water [Molecule]\nmolecular formula: \"H2O\";\nstate: \"liquid\";\n\n## Ice\nstate: \"solid\";\ntemperature: 0 *Celsius*;\n\n## Steam\nstate: \"gas\";\ntemperature: 100 *Celsius*;\n```"
+      },
+      "negation": {
+        "title": "Negation",
+        "description": "Prefix a relation or an attribute line with `!` to assert it does NOT hold — an explicit negative fact, distinct from simply leaving it out. Use `!<relation> Target;` to negate a relation and `!name: value;` to negate an attribute (the optional `has` prefix and modifiers like units still work). Negated relations render as a dashed red barred edge; negated attributes appear struck through with a `not` tag. Negated facts are excluded from inference and inheritance.",
+        "example": "```nodeBook\n# Snake [Animal]\n!<has> external ear;\n!color: green;\n\n# Pig [Animal]\n!<has> scales;\n\n# Penguin [Bird]\n!<can> fly;\nhabitat: \"Antarctica\";\n```"
+      }
+    },
+    "nodeBook-schema": {
+      "title": "nodeBook Schema",
+      "description": "Define custom node types, relation types, and attribute types in a `nodeBook-schema` code block. These schemas enable validation of your knowledge graphs via the Validate button.",
+      "example": "```nodeBook-schema\nnodeType: Planet, A celestial body, parent: Object\nrelationType: orbits, One body orbits another, domain: Planet, range: Star\nattributeType: diameter, float, Size measurement, unit: km, domain: Planet\nattributeType: mass, float, Mass of the object, unit: kg, domain: Planet\n```"
     }
   },
   "print": {

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -59,6 +59,16 @@ const svgrConfig = {
 /** @type {import('next').NextConfig} */
 const rawNextConfig = {
   webpack: (config) => {
+    // tau-prolog (a dependency of @nodebook/core, used for graph inference)
+    // optionally requires 'fs' and 'readline-sync' (which needs
+    // 'child_process') for file-based consult and REPL input. Neither is used
+    // in the browser, so provide empty modules.
+    config.resolve.fallback = {
+      ...config.resolve.fallback,
+      fs: false,
+      child_process: false
+    }
+
     config.module.rules.push({
       test: /\.svg$/i,
       issuer: /\.[jt]sx?$/,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "@hedgedoc/html-to-react": "workspace:html-to-react",
     "@hedgedoc/markdown-it-plugins": "workspace:markdown-it-plugins",
     "@mrdrogdrog/optional": "1.2.1",
+    "@nodebook/react": "^0.2.0",
     "@orama/orama": "3.1.18",
     "@react-hook/resize-observer": "2.0.2",
     "@redux-devtools/core": "4.1.1",

--- a/frontend/src/components/common/highlighted-code/preconfigured-highlight-js.ts
+++ b/frontend/src/components/common/highlighted-code/preconfigured-highlight-js.ts
@@ -386,4 +386,8 @@ hljs.registerLanguage('xquery', xquery)
 hljs.registerLanguage('zephir', zephir)
 hljs.registerLanguage('wasmn', wasm)
 
+import cnl from '../../../extensions/external-lib-app-extensions/nodebook/nodebook-hljs-language'
+hljs.registerLanguage('cnl', cnl)
+hljs.registerLanguage('nodeBook', cnl)
+
 export default hljs

--- a/frontend/src/extensions/external-lib-app-extensions/external-lib-app-extensions.ts
+++ b/frontend/src/extensions/external-lib-app-extensions/external-lib-app-extensions.ts
@@ -11,6 +11,7 @@ import { GistAppExtension } from './gist/gist-app-extension'
 import { GraphvizAppExtension } from './graphviz/graphviz-app-extension'
 import { KatexAppExtension } from './katex/katex-app-extension'
 import { MermaidAppExtension } from './mermaid/mermaid-app-extension'
+import { NodeBookAppExtension } from './nodebook/nodebook-app-extension'
 import { PlantumlAppExtension } from './plantuml/plantuml-app-extension'
 import { VegaLiteAppExtension } from './vega-lite/vega-lite-app-extension'
 import { VimeoAppExtension } from './vimeo/vimeo-app-extension'
@@ -27,6 +28,7 @@ export const externalLibAppExtensions: AppExtension[] = [
   new KatexAppExtension(),
   new AsciinemaAppExtension(),
   new MermaidAppExtension(),
+  new NodeBookAppExtension(),
   new PlantumlAppExtension(),
   new VegaLiteAppExtension(),
   new VimeoAppExtension(),

--- a/frontend/src/extensions/external-lib-app-extensions/nodebook/README.md
+++ b/frontend/src/extensions/external-lib-app-extensions/nodebook/README.md
@@ -1,0 +1,187 @@
+<!--
+SPDX-FileCopyrightText: 2025 The HedgeDoc developers (see AUTHORS file)
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+# nodeBook Extension
+
+The nodeBook extension for HedgeDoc renders **Controlled Natural Language (CNL)** knowledge graphs inline within markdown documents. Users write structured text inside ` ```nodeBook ` code fences and see an interactive graph visualization powered by Cytoscape.js.
+
+## Quick Start
+
+Write a nodeBook block in any HedgeDoc note:
+
+````
+```nodeBook
+# Socrates [individual]
+<member_of> Greek;
+
+# Greek [class]
+<is_a> Human;
+
+# Human [class]
+<is_a> Mortal;
+
+# Mortal [class]
+```
+````
+
+This renders a directed graph with four nodes and three labeled edges, laid out automatically with the dagre algorithm.
+
+## CNL Syntax
+
+### Nodes
+
+```
+# NodeName                        → individual (default)
+# NodeName [Type]                 → typed node (class, Event, Transition, etc.)
+# **adjective** NodeName [Type]   → node with adjective
+# *quantifier* NodeName [Type]    → node with quantifier
+```
+
+### Relations
+
+```
+<relation_name> Target;           → directed edge to Target
+<relation_name> N Target;         → weighted edge (N = number)
+<debit> Cash;                     → alias: mapped to <has post_state>
+<credit> Revenue;                 → alias: mapped to <has prior_state>
+```
+
+### Attributes
+
+```
+attribute: value;                 → basic attribute
+has attribute: value;             → "has" prefix is optional
+attribute: value *unit*;          → with unit
+attribute {abbr}: value;          → with abbreviation
+attribute: value ++adverb++;      → with adverb
+attribute: value [modality];      → with modality qualifier
+```
+
+### Morphs (Polymorphic States)
+
+```
+# Water [class]
+state: liquid;
+
+## frozen
+temperature: 0 *Celsius*;
+
+## boiling
+temperature: 100 *Celsius*;
+<produces> Steam;
+```
+
+Morphs define alternate states for a node. Each morph has its own attributes and relations. The UI provides radio buttons to switch between morphs.
+
+### Mindmap Blocks
+
+```
+# Topic <has part>
+- Subtopic A
+  - Detail A1
+  - Detail A2
+- Subtopic B
+```
+
+A heading with `<relation>` followed by indented list items creates a hierarchical mindmap structure.
+
+### Transitions
+
+Nodes typed `[Transition]` get a "Simulate" button. Define inputs/outputs with `<has prior_state>` and `<has post_state>` relations.
+
+### Queries
+
+```
+<relation> what;                  → What is this node related to via <relation>?
+who <relation> Target;            → Who has <relation> to Target? (graph-level)
+attribute: what;                  → What is the value of this attribute?
+what: value;                      → What node has this attribute value? (graph-level)
+<how> Target;                     → How does this node relate to Target?
+?- relation(X, Y, is_a).         → Raw Prolog query
+```
+
+### Graph-Level Directives
+
+```
+currency: USD;                    → Set graph currency
+expression: a + b * c;           → Add math expression
+```
+
+````
+```graph-description
+Description of the entire graph.
+```
+````
+
+### Schema Blocks
+
+Custom type schemas can be defined in ` ```nodeBook-schema ` fences:
+
+````
+```nodeBook-schema
+nodeType: Planet, A celestial body, parent:Celestial
+relationType: orbits, domain:Planet, range:Star, transitive:false
+attributeType: radius, float, unit:km
+```
+````
+
+## Architecture
+
+The extension follows HedgeDoc's extension architecture:
+
+```
+CNL Text (code fence)
+  ↓  getOperationsFromCnl()
+CnlOperation[]
+  ↓  operationsToGraph()        ← 3-pass: nodes → morphs → relations/attributes
+CnlGraphData
+  ↓  validateOperations()       ← advisory warnings
+  ↓  TransitiveClosureEngine    ← infer transitive edges + membership inheritance
+  ↓  PrologInferenceEngine      ← (async) Prolog-based inference + user queries
+Rendered Graph (Cytoscape.js)
+```
+
+### Key Modules
+
+| Module                      | Purpose                                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `cnl-parser.ts`             | Parses CNL text into an array of operations (addNode, addRelation, addAttribute, addMorph, etc.) |
+| `operations-to-graph.ts`    | Converts operations into a `CnlGraphData` structure via 3-pass processing                        |
+| `validate-operations.ts`    | Validates operations against schemas; produces advisory warnings                                 |
+| `morph-registry.ts`         | O(1) lookup registry for morph→relation/attribute mappings                                       |
+| `schema-parser.ts`          | Parses `nodeBook-schema` code blocks into structured type definitions                            |
+| `schema-store.ts`           | Merges user schemas with built-in defaults at runtime                                            |
+| `inference-engine.ts`       | Derives implicit edges via transitive closure (BFS) and membership inheritance                   |
+| `prolog-bridge.ts`          | Tau Prolog integration for full inference and user queries (lazy-loaded)                         |
+| `nodebook-evaluator.ts`     | Math expression evaluator using math.js (lazy-loaded)                                            |
+| `equation-to-pn.ts`         | Converts math expressions to Petri net graph operations                                          |
+| `compute-nodebook-score.ts` | Scores a knowledge graph across 9 categories (max 100 points)                                    |
+| `nodebook-graph.tsx`        | React component: renders Cytoscape.js graph with morph switching, transitions, and export        |
+
+### Design Decisions
+
+- **Deterministic IDs**: FNV-1a hash for node/edge IDs (no timestamps or randomness)
+- **Client-side only**: All parsing, inference, and rendering happens in the browser; no backend needed
+- **Lazy loading**: Heavy dependencies (Tau Prolog, math.js) loaded via dynamic `import()` with webpack code splitting
+- **Singularization**: Node names are singularized so "humans", "Human", and "Humans" all resolve to the same node ID
+
+## Testing
+
+247 unit tests across 7 test files. All are pure-function tests requiring no mocking.
+
+```bash
+yarn workspace @hedgedoc/frontend jest --testPathPattern='nodebook.*spec'
+```
+
+See [TESTING.md](TESTING.md) for the full testing guide, manual test checklists, sample CNL blocks, and the detailed requirements specification derived from the test suite.
+
+## Dependencies
+
+Added to `frontend/package.json`:
+
+- `cytoscape` — graph rendering
+- `cytoscape-dagre` — hierarchical layout algorithm
+- `cytoscape-svg` — SVG export

--- a/frontend/src/extensions/external-lib-app-extensions/nodebook/cnl-insert-handler.tsx
+++ b/frontend/src/extensions/external-lib-app-extensions/nodebook/cnl-insert-handler.tsx
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useChangeEditorContentCallback } from '../../../components/editor-page/change-content-context/use-change-editor-content-callback'
+import type React from 'react'
+import { useCallback, useEffect } from 'react'
+
+interface CnlInsertMessage {
+  type: 'nodebook-insert-cnl'
+  cnlLines: string[]
+}
+
+/**
+ * Listens for 'nodebook-insert-cnl' postMessages from the renderer iframe
+ * and inserts CNL lines into a nodeBook code fence in the editor.
+ */
+export const CnlInsertHandler: React.FC = () => {
+  const changeEditorContent = useChangeEditorContentCallback()
+
+  const handleMessage = useCallback(
+    (event: MessageEvent) => {
+      const data = event.data as CnlInsertMessage
+      if (data?.type !== 'nodebook-insert-cnl' || !Array.isArray(data.cnlLines)) {
+        return
+      }
+      if (!changeEditorContent) {
+        return
+      }
+
+      const cnlLines = data.cnlLines
+      changeEditorContent(({ markdownContent }) => {
+        const insertResult = findInsertPosition(markdownContent, cnlLines)
+        return [insertResult.edits, undefined]
+      })
+    },
+    [changeEditorContent]
+  )
+
+  useEffect(() => {
+    window.addEventListener('message', handleMessage)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [handleMessage])
+
+  return null
+}
+
+/**
+ * Finds the right position to insert CNL lines:
+ * 1. Look for an existing ```nodeBook fence after the last ```nodeBook-analyze fence
+ * 2. If found, append lines before the closing ```
+ * 3. If not found, create a new ```nodeBook fence after the analyze block
+ */
+function findInsertPosition(
+  markdownContent: string,
+  cnlLines: string[]
+): { edits: Array<{ from: number; to: number; insert: string }> } {
+  const lines = markdownContent.split('\n')
+  let lastAnalyzeEnd = -1
+  let nextNodeBookFenceEnd = -1
+
+  // Find the last ```nodeBook-analyze closing fence
+  let inAnalyze = false
+  let charOffset = 0
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const trimmed = line.trimStart()
+    if (trimmed.startsWith('```nodeBook-analyze')) {
+      inAnalyze = true
+    } else if (inAnalyze && trimmed === '```') {
+      lastAnalyzeEnd = charOffset + line.length
+      inAnalyze = false
+    }
+    charOffset += line.length + 1 // +1 for newline
+  }
+
+  if (lastAnalyzeEnd === -1) {
+    // No analyze block found — append at end
+    const insert = '\n\n```nodeBook\n' + cnlLines.join('\n') + '\n```\n'
+    return {
+      edits: [{ from: markdownContent.length, to: markdownContent.length, insert }]
+    }
+  }
+
+  // Look for a ```nodeBook fence after the analyze block
+  charOffset = 0
+  let inNodeBook = false
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const trimmed = line.trimStart()
+    if (charOffset >= lastAnalyzeEnd) {
+      if (!inNodeBook && trimmed.startsWith('```nodeBook') && !trimmed.startsWith('```nodeBook-')) {
+        inNodeBook = true
+      } else if (inNodeBook && trimmed === '```') {
+        nextNodeBookFenceEnd = charOffset
+        break
+      }
+    }
+    charOffset += line.length + 1
+  }
+
+  if (nextNodeBookFenceEnd !== -1) {
+    // Append before the closing ``` of the existing nodeBook fence
+    const insert = cnlLines.join('\n') + '\n'
+    return {
+      edits: [{ from: nextNodeBookFenceEnd, to: nextNodeBookFenceEnd, insert }]
+    }
+  }
+
+  // No nodeBook fence after analyze — create one
+  const insert = '\n\n```nodeBook\n' + cnlLines.join('\n') + '\n```\n'
+  return {
+    edits: [{ from: lastAnalyzeEnd, to: lastAnalyzeEnd, insert }]
+  }
+}

--- a/frontend/src/extensions/external-lib-app-extensions/nodebook/nodebook-app-extension.ts
+++ b/frontend/src/extensions/external-lib-app-extensions/nodebook/nodebook-app-extension.ts
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2025 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import type { CheatsheetExtension } from '../../../components/cheatsheet/cheatsheet-extension'
+import {
+  basicCompletion,
+  codeFenceRegex
+} from '../../../components/editor-page/editor-pane/autocompletions/basic-completion'
+import type { MarkdownRendererExtension } from '../../../components/markdown-renderer/extensions/_base-classes/markdown-renderer-extension'
+import { AppExtension } from '../../_base-classes/app-extension'
+import { buildNodeBookInBlockCompletions } from '@nodebook/react'
+import { CnlInsertHandler } from './cnl-insert-handler'
+import { NodeBookMarkdownExtension } from './nodebook-markdown-extension'
+import type { CompletionSource } from '@codemirror/autocomplete'
+import type React from 'react'
+
+/**
+ * Adds support for nodeBook knowledge graph rendering to the markdown renderer.
+ * Users write CNL (Controlled Natural Language) inside a nodeBook code fence,
+ * and HedgeDoc renders an interactive knowledge graph inline.
+ */
+export class NodeBookAppExtension extends AppExtension {
+  buildMarkdownRendererExtensions(): MarkdownRendererExtension[] {
+    return [new NodeBookMarkdownExtension()]
+  }
+
+  buildEditorExtensionComponent(): React.FC {
+    return CnlInsertHandler
+  }
+
+  buildCheatsheetExtensions(): CheatsheetExtension[] {
+    return [
+      {
+        i18nKey: 'nodeBook',
+        categoryI18nKey: 'charts',
+        topics: [
+          { i18nKey: 'conceptMap' },
+          { i18nKey: 'petriNet' },
+          { i18nKey: 'accounting' },
+          { i18nKey: 'mindMap' },
+          { i18nKey: 'morphs' },
+          { i18nKey: 'negation' },
+          { i18nKey: 'queries' }
+        ]
+      },
+      { i18nKey: 'nodeBook-schema', categoryI18nKey: 'charts' },
+      { i18nKey: 'nodeBook-analyze', categoryI18nKey: 'charts' }
+    ]
+  }
+
+  buildAutocompletion(): CompletionSource[] {
+    return [
+      ...buildNodeBookInBlockCompletions(),
+      basicCompletion(codeFenceRegex, '```nodeBook\n# Node Name [Type]\nattribute: value;\n<relation> Target;\n```'),
+      basicCompletion(
+        codeFenceRegex,
+        '```nodeBook\n# Process [Transition]\n<has prior_state> 2 Input;\n<has post_state> Output;\n```'
+      ),
+      basicCompletion(
+        codeFenceRegex,
+        '```nodeBook\n# Cash [Asset]\nbalance: 10000;\n\n# Buy Inventory [Transaction]\ndate: 2026-01-15;\n<debit> 5000 Inventory;\n<credit> 5000 Cash;\n```'
+      ),
+      basicCompletion(
+        codeFenceRegex,
+        '```nodeBook\n# Central Topic <relation>\n- Branch 1\n  - Sub-branch 1\n  - Sub-branch 2\n- Branch 2\n```'
+      ),
+      basicCompletion(
+        codeFenceRegex,
+        '```nodeBook\n# Socrates [individual]\n<member_of> Greek;\n<member_of> what;\n\n# Greek [class]\n<is_a> Human;\n\n# Human [class]\n<is_a> Mortal;\n\n# Mortal [class]\n\nwho <is_a> Mortal;\n```'
+      ),
+      basicCompletion(
+        codeFenceRegex,
+        '```nodeBook-schema\nnodeType: Planet, A celestial body, parent: Object\nrelationType: orbits, One body orbits another, domain: Planet, range: Star\nattributeType: diameter, float, Size measurement, unit: km, domain: Planet\n```'
+      ),
+      basicCompletion(
+        codeFenceRegex,
+        '```nodeBook-analyze\nPaste a paragraph from your textbook here. Select annotation categories\nfrom the toolbar to see which parts of the text map to graph elements\nlike nodes, relations, adjectives, and more.\n```'
+      )
+    ]
+  }
+}

--- a/frontend/src/extensions/external-lib-app-extensions/nodebook/nodebook-codemirror-language.ts
+++ b/frontend/src/extensions/external-lib-app-extensions/nodebook/nodebook-codemirror-language.ts
@@ -1,0 +1,207 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import {
+  HighlightStyle,
+  LanguageDescription,
+  LanguageSupport,
+  StreamLanguage,
+  syntaxHighlighting,
+  type StringStream,
+  type StreamParser
+} from '@codemirror/language'
+import { Tag } from '@lezer/highlight'
+
+interface CnlState {
+  inDescription: boolean
+}
+
+function startState(): CnlState {
+  return { inDescription: false }
+}
+
+function copyState(state: CnlState): CnlState {
+  return { inDescription: state.inDescription }
+}
+
+/** Custom tags so our HighlightStyle only targets CNL tokens. */
+const cnlTag = {
+  heading: Tag.define(),
+  keyword: Tag.define(),
+  typeName: Tag.define(),
+  propertyName: Tag.define(),
+  string: Tag.define(),
+  number: Tag.define(),
+  meta: Tag.define(),
+  comment: Tag.define(),
+  emphasis: Tag.define(),
+  punctuation: Tag.define()
+}
+
+function token(stream: StringStream, state: CnlState): string | null {
+  // Inside ```description block
+  if (state.inDescription) {
+    if (stream.match(/^```/)) {
+      state.inDescription = false
+      return 'comment'
+    }
+    stream.skipToEnd()
+    return 'comment'
+  }
+
+  // Start of ```description block
+  if (stream.match(/^```description/)) {
+    state.inDescription = true
+    return 'comment'
+  }
+
+  // Start of line checks
+  if (stream.sol()) {
+    // Prolog query: ?- goal.
+    if (stream.match(/^\s*\?-/)) {
+      stream.skipToEnd()
+      return 'meta'
+    }
+
+    // Wh-word query line
+    if (stream.match(/^\s*(?:what|who|where|when|how)\b/i)) {
+      stream.skipToEnd()
+      return 'meta'
+    }
+
+    // Directive: expression: or currency:
+    if (stream.match(/^\s*(?:expression|currency)\s*:/)) {
+      stream.skipToEnd()
+      return 'meta'
+    }
+
+    // H2 morph heading: ## morph name
+    if (stream.match(/^\s*##\s+.*/)) {
+      return 'heading'
+    }
+
+    // H1 heading: # Node Name [Type]
+    if (stream.match(/^\s*#\s+/)) {
+      stream.skipToEnd()
+      return 'heading'
+    }
+  }
+
+  // Bold: **adjective**
+  if (stream.match(/^\*\*[^*]+\*\*/)) {
+    return 'emphasis'
+  }
+
+  // Relation: <relation name>, optionally negated with a leading ! (e.g. !<has> ear;)
+  if (stream.match(/^!\s*<[^>]+>/) || stream.match(/^<[^>]+>/)) {
+    return 'keyword'
+  }
+
+  // Type bracket: [Type]
+  if (stream.match(/^\[[^\]]+\]/)) {
+    return 'typeName'
+  }
+
+  // Unit: *unit* (single asterisks, not double)
+  if (stream.peek() === '*' && !stream.match(/^\*\*/, false)) {
+    stream.next()
+    if (stream.skipTo('*')) {
+      stream.next()
+      return 'meta'
+    }
+    return null
+  }
+
+  // Number
+  if (stream.match(/^\d+(?:\.\d+)?/)) {
+    return 'number'
+  }
+
+  // Semicolon
+  if (stream.peek() === ';') {
+    stream.next()
+    return 'punctuation'
+  }
+
+  // Attribute key: look for "word:" or "has word:" patterns at line start
+  if (stream.sol() || stream.pos === 0) {
+    if (stream.match(/^(?:has\s+)?[\w][\w\s]*?(?=:)/)) {
+      return 'propertyName'
+    }
+  }
+
+  // Colon after property name
+  if (stream.peek() === ':') {
+    stream.next()
+    return 'punctuation'
+  }
+
+  stream.next()
+  return null
+}
+
+const cnlParser: StreamParser<CnlState> = {
+  startState,
+  copyState,
+  token,
+  tokenTable: {
+    heading: cnlTag.heading,
+    keyword: cnlTag.keyword,
+    typeName: cnlTag.typeName,
+    propertyName: cnlTag.propertyName,
+    string: cnlTag.string,
+    number: cnlTag.number,
+    meta: cnlTag.meta,
+    comment: cnlTag.comment,
+    emphasis: cnlTag.emphasis,
+    punctuation: cnlTag.punctuation
+  }
+}
+
+const cnlStreamLanguage = StreamLanguage.define(cnlParser)
+
+/**
+ * GitHub Light theme — matches highlight.js github.css used in rendered view.
+ */
+const cnlLightStyle = HighlightStyle.define(
+  [
+    { tag: cnlTag.heading, color: '#005cc5', fontWeight: 'bold' },
+    { tag: cnlTag.keyword, color: '#d73a49' },
+    { tag: cnlTag.typeName, color: '#d73a49' },
+    { tag: cnlTag.propertyName, color: '#005cc5' },
+    { tag: cnlTag.string, color: '#032f62' },
+    { tag: cnlTag.number, color: '#005cc5' },
+    { tag: cnlTag.meta, color: '#005cc5' },
+    { tag: cnlTag.comment, color: '#6a737d', fontStyle: 'italic' },
+    { tag: cnlTag.emphasis, fontWeight: 'bold' },
+    { tag: cnlTag.punctuation, color: '#24292e' }
+  ],
+  { themeType: 'light' }
+)
+
+/**
+ * GitHub Dark theme — matches highlight.js github-dark.css used in rendered view.
+ */
+const cnlDarkStyle = HighlightStyle.define(
+  [
+    { tag: cnlTag.heading, color: '#1f6feb', fontWeight: 'bold' },
+    { tag: cnlTag.keyword, color: '#ff7b72' },
+    { tag: cnlTag.typeName, color: '#ff7b72' },
+    { tag: cnlTag.propertyName, color: '#79c0ff' },
+    { tag: cnlTag.string, color: '#a5d6ff' },
+    { tag: cnlTag.number, color: '#79c0ff' },
+    { tag: cnlTag.meta, color: '#79c0ff' },
+    { tag: cnlTag.comment, color: '#8b949e', fontStyle: 'italic' },
+    { tag: cnlTag.emphasis, fontWeight: 'bold' },
+    { tag: cnlTag.punctuation, color: '#c9d1d9' }
+  ],
+  { themeType: 'dark' }
+)
+
+export const cnlLanguageDescription = LanguageDescription.of({
+  name: 'nodeBook',
+  alias: ['cnl'],
+  support: new LanguageSupport(cnlStreamLanguage, [syntaxHighlighting(cnlLightStyle), syntaxHighlighting(cnlDarkStyle)])
+})

--- a/frontend/src/extensions/external-lib-app-extensions/nodebook/nodebook-hljs-language.ts
+++ b/frontend/src/extensions/external-lib-app-extensions/nodebook/nodebook-hljs-language.ts
@@ -1,0 +1,179 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import type { HLJSApi, Language } from 'highlight.js'
+
+/**
+ * highlight.js language definition for CNL (Controlled Natural Language)
+ * used in nodeBook code fences.
+ */
+export default function cnlLanguage(_hljs: HLJSApi): Language {
+  return {
+    name: 'cnl',
+    aliases: ['nodeBook'],
+    case_insensitive: false,
+    contains: [
+      // Description blocks: ```description ... ```
+      {
+        className: 'comment',
+        begin: /```description/,
+        end: /```/,
+        relevance: 10
+      },
+      // Prolog queries: ?- goal.
+      {
+        className: 'meta',
+        begin: /^\s*\?-/,
+        end: /$/,
+        contains: [
+          {
+            className: 'keyword',
+            begin: /\b(?:what|who|where|when|how)\b/i
+          },
+          {
+            className: 'number',
+            begin: /\b\d+(?:\.\d+)?\b/
+          }
+        ],
+        relevance: 10
+      },
+      // Wh-word queries (standalone lines starting with wh-word)
+      {
+        className: 'meta',
+        begin: /^\s*(?:what|who|where|when|how)\b/i,
+        end: /$/,
+        contains: [
+          {
+            className: 'keyword',
+            begin: /\b(?:what|who|where|when|how)\b/i
+          },
+          {
+            className: 'string',
+            begin: /<[^>]+>/
+          },
+          {
+            className: 'number',
+            begin: /\b\d+(?:\.\d+)?\b/
+          }
+        ],
+        relevance: 5
+      },
+      // H1 heading: # Node Name [Type]
+      {
+        className: 'section',
+        begin: /^\s*#\s+/,
+        end: /$/,
+        contains: [
+          {
+            className: 'type',
+            begin: /\[/,
+            end: /\]/
+          },
+          // Bold adjective in heading
+          {
+            className: 'strong',
+            begin: /\*\*/,
+            end: /\*\*/
+          },
+          // Quantifier in heading
+          {
+            className: 'meta',
+            begin: /(?<!\*)\*(?!\*)/,
+            end: /\*(?!\*)/
+          }
+        ],
+        relevance: 10
+      },
+      // H2 morph heading: ## morph name
+      {
+        className: 'section',
+        begin: /^\s*##\s+/,
+        end: /$/,
+        relevance: 10
+      },
+      // Directives: expression: or currency:
+      {
+        className: 'meta',
+        begin: /^\s*(?:expression|currency)\s*:/,
+        end: /$/,
+        relevance: 5
+      },
+      // Relation: <relation name> Target;  (optionally negated with a leading !)
+      {
+        className: 'keyword',
+        begin: /!?\s*<[^>]+>/,
+        relevance: 5
+      },
+      // Attribute line: key: value;
+      {
+        begin: /^\s*(?:has\s+)?[\w][\w\s]*?(?=:)/,
+        end: /;|$/,
+        contains: [
+          {
+            className: 'attr',
+            begin: /^\s*(?:has\s+)?[\w][\w\s]*?(?=:)/,
+            relevance: 0
+          },
+          {
+            className: 'punctuation',
+            begin: /:/
+          },
+          {
+            className: 'number',
+            begin: /\b\d+(?:\.\d+)?\b/
+          },
+          // Unit: *unit*
+          {
+            className: 'meta',
+            begin: /(?<!\*)\*(?!\*)/,
+            end: /\*(?!\*)/
+          },
+          // Bold inside value
+          {
+            className: 'strong',
+            begin: /\*\*/,
+            end: /\*\*/
+          },
+          {
+            className: 'string',
+            begin: /(?<=:\s*)/,
+            end: /(?=;|$)/,
+            contains: [
+              {
+                className: 'number',
+                begin: /\b\d+(?:\.\d+)?\b/
+              },
+              {
+                className: 'meta',
+                begin: /(?<!\*)\*(?!\*)/,
+                end: /\*(?!\*)/
+              }
+            ]
+          }
+        ],
+        relevance: 3
+      },
+      // Semicolons
+      {
+        className: 'punctuation',
+        begin: /;/,
+        relevance: 0
+      },
+      // Numbers (standalone)
+      {
+        className: 'number',
+        begin: /\b\d+(?:\.\d+)?\b/,
+        relevance: 0
+      },
+      // Bold adjective: **adjective**
+      {
+        className: 'strong',
+        begin: /\*\*/,
+        end: /\*\*/,
+        relevance: 0
+      }
+    ]
+  }
+}

--- a/frontend/src/extensions/external-lib-app-extensions/nodebook/nodebook-markdown-extension.ts
+++ b/frontend/src/extensions/external-lib-app-extensions/nodebook/nodebook-markdown-extension.ts
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2025 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { CodeBlockMarkdownRendererExtension } from '../../../components/markdown-renderer/extensions/_base-classes/code-block-markdown-extension/code-block-markdown-renderer-extension'
+import { parseCodeBlockParameters } from '../../../components/markdown-renderer/extensions/_base-classes/code-block-markdown-extension/code-block-parameters'
+import { CodeBlockComponentReplacer } from '../../../components/markdown-renderer/replace-components/code-block-component-replacer'
+import { NodeBookGraph, NodeBookSchemaDisplay } from '@nodebook/react'
+import '@nodebook/react/styles.css'
+import type { SchemaParseResult } from '@nodebook/core'
+import { parseSchemaBlock, mergeSchemaResults, setUserSchemas } from '@nodebook/core'
+import type MarkdownIt from 'markdown-it'
+
+const schemaExtractRuleName = 'nodebook-schema-extract'
+
+/**
+ * Adds support for rendering nodeBook knowledge graphs and schema definitions.
+ */
+export class NodeBookMarkdownExtension extends CodeBlockMarkdownRendererExtension {
+  public buildReplacers(): CodeBlockComponentReplacer[] {
+    return [
+      new CodeBlockComponentReplacer(NodeBookGraph, 'nodeBook'),
+      new CodeBlockComponentReplacer(NodeBookSchemaDisplay, 'nodeBook-schema')
+    ]
+  }
+
+  public configureMarkdownIt(markdownIt: MarkdownIt): void {
+    super.configureMarkdownIt(markdownIt)
+
+    if (markdownIt.core.ruler.getRules(schemaExtractRuleName).length === 0) {
+      markdownIt.core.ruler.push(schemaExtractRuleName, (state) => {
+        const results: SchemaParseResult[] = []
+
+        for (const token of state.tokens) {
+          if (token.type !== 'fence') continue
+          const { language } = parseCodeBlockParameters(token.info)
+          if (language !== 'nodeBook-schema') continue
+          results.push(parseSchemaBlock(token.content))
+        }
+
+        if (results.length > 0) {
+          const merged = mergeSchemaResults(results)
+          setUserSchemas(merged.schemas)
+        } else {
+          setUserSchemas(null)
+        }
+      })
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1712,6 +1712,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.25.7":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.26.0":
   version: 7.26.7
   resolution: "@babel/runtime@npm:7.26.7"
@@ -2983,6 +2990,7 @@ __metadata:
     "@hedgedoc/markdown-it-plugins": "workspace:markdown-it-plugins"
     "@mrdrogdrog/optional": "npm:1.2.1"
     "@next/bundle-analyzer": "npm:14.2.35"
+    "@nodebook/react": "npm:^0.2.0"
     "@orama/orama": "npm:3.1.18"
     "@react-hook/resize-observer": "npm:2.0.2"
     "@redux-devtools/core": "npm:4.1.1"
@@ -4619,6 +4627,37 @@ __metadata:
     "@node-rs/argon2-win32-x64-msvc":
       optional: true
   checksum: 10c0/0513244f8b820cd38e3b3dc8ad4dbee2f2ada3ba37714c3975dbf801df26ab906b420fb769c171fee0ac06caff9e0471c827e18876f55568ea234b9b48e6da53
+  languageName: node
+  linkType: hard
+
+"@nodebook/core@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@nodebook/core@npm:0.3.0"
+  dependencies:
+    compromise: "npm:^14.14.3"
+    mathjs: "npm:^13.2.2"
+    tau-prolog: "npm:^0.3.4"
+  checksum: 10c0/18fbef59687c4857610c0a9c382fb7bc42e9581517ffefae44eb7d8cfe90d2ff2422f7a9793631112488475f8f9b7247019b88b961f78962a77db217405dabb2
+  languageName: node
+  linkType: hard
+
+"@nodebook/react@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@nodebook/react@npm:0.2.0"
+  dependencies:
+    "@nodebook/core": "npm:0.3.0"
+    cytoscape: "npm:^3.30.4"
+    cytoscape-elk: "npm:^2.2.0"
+    cytoscape-svg: "npm:^0.4.0"
+    react-bootstrap-icons: "npm:^1.11.6"
+    react-use: "npm:^17.6.0"
+  peerDependencies:
+    "@codemirror/autocomplete": ^6.0.0
+    "@codemirror/language": ^6.0.0
+    "@lezer/highlight": ^1.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 10c0/6711e40434dcea02f9aaa1e2fe1d283f2fd770de9c78dc60c0cd3a5961144fb21ae17afe55c08dad8908051000ccd245aabcbb960de63d7bd7e33d0a692123eb
   languageName: node
   linkType: hard
 
@@ -6261,6 +6300,13 @@ __metadata:
   version: 2.2.7
   resolution: "@types/js-cookie@npm:2.2.7"
   checksum: 10c0/29196c6829982b5efa79117122a7d62cf4bc2f6397ce8eac1539319ff5dce3b44b2d86f2ac064f2ed3488fb24439358f24af6914fde5c5c4bab9a85728a13a6f
+  languageName: node
+  linkType: hard
+
+"@types/js-cookie@npm:^3.0.0":
+  version: 3.0.6
+  resolution: "@types/js-cookie@npm:3.0.6"
+  checksum: 10c0/173afaf5ea9d86c22395b9d2a00b6adb0006dcfef165d6dcb0395cdc32f5a5dcf9c3c60f97194119963a15849b8f85121e1ae730b03e40bc0c29b84396ba22f9
   languageName: node
   linkType: hard
 
@@ -8244,10 +8290,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"complex.js@npm:^2.2.5":
+  version: 2.4.3
+  resolution: "complex.js@npm:2.4.3"
+  checksum: 10c0/c61b225c4c2925c922ebaf2c4c6d7d0c2f9cebf4fb5eb8dce231aea7508f15db0920b52107279fdd9947b54a0320eae2911d430a421c2db8d0d24df6c2cb2cf8
+  languageName: node
+  linkType: hard
+
 "component-emitter@npm:^1.3.0":
   version: 1.3.1
   resolution: "component-emitter@npm:1.3.1"
   checksum: 10c0/e4900b1b790b5e76b8d71b328da41482118c0f3523a516a41be598dc2785a07fd721098d9bf6e22d89b19f4fa4e1025160dc00317ea111633a3e4f75c2b86032
+  languageName: node
+  linkType: hard
+
+"compromise@npm:^14.14.3":
+  version: 14.16.0
+  resolution: "compromise@npm:14.16.0"
+  dependencies:
+    efrt: "npm:2.7.0"
+    grad-school: "npm:0.0.5"
+    suffix-thumb: "npm:5.0.2"
+  checksum: 10c0/24ce6c87726175efdde8a33e45937b99098c03ef0467f3afb1c1c4e48b8f5c47c4dc2e09127168fa0c858d77ddd0e00543486a764e717135d5b3059155ad0a59
   languageName: node
   linkType: hard
 
@@ -8696,6 +8760,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cytoscape-elk@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "cytoscape-elk@npm:2.3.0"
+  dependencies:
+    elkjs: "npm:^0.9.3"
+  peerDependencies:
+    cytoscape: ^3.2.0
+  checksum: 10c0/7ddf3138aaefdd5c54aacabad2c19743a80e8a3beb2a0423a77c2febf69dd5559c68d753fd96a0e240c8b2e7f5843bd87036dc126a4b5f9b24259e62aee86c4e
+  languageName: node
+  linkType: hard
+
 "cytoscape-fcose@npm:^2.2.0":
   version: 2.2.0
   resolution: "cytoscape-fcose@npm:2.2.0"
@@ -8707,10 +8782,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cytoscape-svg@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "cytoscape-svg@npm:0.4.0"
+  peerDependencies:
+    cytoscape: ^3.2.0
+  checksum: 10c0/4c9a098464af489019371055dcaed0df5bef3f124eb72c548b292f898ff55ebe752d9c1154c152718f335062e721e4fb1a82c4921f327013127eda47f2d17dca
+  languageName: node
+  linkType: hard
+
 "cytoscape@npm:^3.29.3":
   version: 3.33.1
   resolution: "cytoscape@npm:3.33.1"
   checksum: 10c0/dffcf5f74df4d91517c4faf394df880d8283ce76edef19edba0c762941cf4f18daf7c4c955ec50c794f476ace39ad4394f8c98483222bd2682e1fd206e976411
+  languageName: node
+  linkType: hard
+
+"cytoscape@npm:^3.30.4":
+  version: 3.34.0
+  resolution: "cytoscape@npm:3.34.0"
+  checksum: 10c0/cb17b3dcacb9492f058cff653debf7b5a713e7532a9866cc72ae79d207757e8a9b68430874fe986f2a6404a8161b4fb5c1a2f1ca9ac5b1a21e316f57ed9d1243
   languageName: node
   linkType: hard
 
@@ -9225,6 +9316,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decimal.js@npm:^10.4.3":
+  version: 10.6.0
+  resolution: "decimal.js@npm:10.6.0"
+  checksum: 10c0/07d69fbcc54167a340d2d97de95f546f9ff1f69d2b45a02fd7a5292412df3cd9eb7e23065e532a318f5474a2e1bccf8392fdf0443ef467f97f3bf8cb0477e5aa
+  languageName: node
+  linkType: hard
+
 "decode-named-character-reference@npm:^1.0.0":
   version: 1.2.0
   resolution: "decode-named-character-reference@npm:1.2.0"
@@ -9606,6 +9704,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"efrt@npm:2.7.0":
+  version: 2.7.0
+  resolution: "efrt@npm:2.7.0"
+  checksum: 10c0/c8f8e838e6e4efae7105a8349db2c9d7ad7a14a69982628c740fdaf7658c44866a6b988a6c9abda8d2f0f9ccbfe943ec38e35a6355873f9b7cb58ae87575f355
+  languageName: node
+  linkType: hard
+
 "electron-to-chromium@npm:^1.4.668":
   version: 1.4.689
   resolution: "electron-to-chromium@npm:1.4.689"
@@ -9617,6 +9722,13 @@ __metadata:
   version: 1.5.91
   resolution: "electron-to-chromium@npm:1.5.91"
   checksum: 10c0/1c2f1210a1e526a0a139d8b783a71ee47cfd5db3ab888105b063c3c536d2d6a5de739dec30c137faeb3af8276bf26b4cadc05948aa7c51e6d1a628e9313c6b8a
+  languageName: node
+  linkType: hard
+
+"elkjs@npm:^0.9.3":
+  version: 0.9.3
+  resolution: "elkjs@npm:0.9.3"
+  checksum: 10c0/caf544ff4fce8442d1d3dd6dface176c9b2fe26fc1e34f56122828e6eef7d2d7fe70d3202f9f3ecf0feb6287d4c8430949f483e63e450a7454bb39ccffab3808
   languageName: node
   linkType: hard
 
@@ -9971,6 +10083,13 @@ __metadata:
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 10c0/524c739d776b36c3d29fa08a22e03e8824e3b2fd57500e5e44ecf3cc4707c34c60f9ca0781c0e33d191f2991161504c295e98f68c78fe7baa6e57081ec6ac0a3
+  languageName: node
+  linkType: hard
+
+"escape-latex@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "escape-latex@npm:1.2.0"
+  checksum: 10c0/b77ea1594a38625295793a61105222c283c1792d1b2511bbfd6338cf02cc427dcabce7e7c1e22ec2f5c40baf3eaf2eeaf229a62dbbb74c6e69bb4a4209f2544f
   languageName: node
   linkType: hard
 
@@ -10690,6 +10809,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fraction.js@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "fraction.js@npm:4.3.7"
+  checksum: 10c0/df291391beea9ab4c263487ffd9d17fed162dbb736982dee1379b2a8cc94e4e24e46ed508c6d278aded9080ba51872f1bc5f3a5fd8d7c74e5f105b508ac28711
+  languageName: node
+  linkType: hard
+
 "fs-constants@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
@@ -11068,6 +11194,13 @@ __metadata:
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
+  languageName: node
+  linkType: hard
+
+"grad-school@npm:0.0.5":
+  version: 0.0.5
+  resolution: "grad-school@npm:0.0.5"
+  checksum: 10c0/c7b8a4681efe00d279ec3d24b4570492891c7b33ae0c6d038b762888fb3348082bb366c402b892c6f04b3345a9ee2f0f03c835738480331c068f336974f11732
   languageName: node
   linkType: hard
 
@@ -11936,6 +12069,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"javascript-natural-sort@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "javascript-natural-sort@npm:0.7.1"
+  checksum: 10c0/340f8ffc5d30fb516e06dc540e8fa9e0b93c865cf49d791fed3eac3bdc5fc71f0066fc81d44ec1433edc87caecaf9f13eec4a1fce8c5beafc709a71eaedae6fe
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-changed-files@npm:29.7.0"
@@ -12432,6 +12572,13 @@ __metadata:
   version: 2.2.1
   resolution: "js-cookie@npm:2.2.1"
   checksum: 10c0/ee67fc0f8495d0800b851910b5eb5bf49d3033adff6493d55b5c097ca6da46f7fe666b10e2ecb13cfcaf5b88d71c205ce00a7e646de791689bfd053bbb36a376
+  languageName: node
+  linkType: hard
+
+"js-cookie@npm:^3.0.0":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
   languageName: node
   linkType: hard
 
@@ -13334,6 +13481,25 @@ __metadata:
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
   checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
+  languageName: node
+  linkType: hard
+
+"mathjs@npm:^13.2.2":
+  version: 13.2.3
+  resolution: "mathjs@npm:13.2.3"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.7"
+    complex.js: "npm:^2.2.5"
+    decimal.js: "npm:^10.4.3"
+    escape-latex: "npm:^1.2.0"
+    fraction.js: "npm:^4.3.7"
+    javascript-natural-sort: "npm:^0.7.1"
+    seedrandom: "npm:^3.0.5"
+    tiny-emitter: "npm:^2.1.0"
+    typed-function: "npm:^4.2.1"
+  bin:
+    mathjs: bin/cli.js
+  checksum: 10c0/a8c160931e926a65e59b983f285672ce3797682d703074670e39c11b36a15ceec01e2044de1ef5929227695da21ed2e401ef715c333d564eebff4aaa5c9c48cf
   languageName: node
   linkType: hard
 
@@ -15447,7 +15613,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-bootstrap-icons@npm:1.11.6":
+"react-bootstrap-icons@npm:1.11.6, react-bootstrap-icons@npm:^1.11.6":
   version: 1.11.6
   resolution: "react-bootstrap-icons@npm:1.11.6"
   dependencies:
@@ -15709,6 +15875,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-use@npm:^17.6.0":
+  version: 17.6.1
+  resolution: "react-use@npm:17.6.1"
+  dependencies:
+    "@types/js-cookie": "npm:^3.0.0"
+    "@xobotyi/scrollbar-width": "npm:^1.9.5"
+    copy-to-clipboard: "npm:^3.3.1"
+    fast-deep-equal: "npm:^3.1.3"
+    fast-shallow-equal: "npm:^1.0.0"
+    js-cookie: "npm:^3.0.0"
+    nano-css: "npm:^5.6.2"
+    react-universal-interface: "npm:^0.6.2"
+    resize-observer-polyfill: "npm:^1.5.1"
+    screenfull: "npm:^5.1.0"
+    set-harmonic-interval: "npm:^1.0.1"
+    throttle-debounce: "npm:^3.0.1"
+    ts-easing: "npm:^0.2.0"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 10c0/8b3babd9f7db14624e172d22c2fb30f091d785e97d0aed84e47e52a3ca8dbdc0c094ab797bbd0e754ff2f92be82357c7a46e08dbc85244edfefa21475f760cdf
+  languageName: node
+  linkType: hard
+
 "react@npm:18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
@@ -15751,6 +15942,13 @@ __metadata:
   dependencies:
     picomatch: "npm:^2.2.1"
   checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
+  languageName: node
+  linkType: hard
+
+"readline-sync@npm:1.4.9":
+  version: 1.4.9
+  resolution: "readline-sync@npm:1.4.9"
+  checksum: 10c0/0b013fe85c45fa25c341ab510ac05450f3339fcca031cafaaf19f5d1ef28467663d5d3fa1873dc5e100c42534150d9bcba0e4055a08a949f4d56010efe184aa1
   languageName: node
   linkType: hard
 
@@ -16242,6 +16440,13 @@ __metadata:
   version: 4.1.0
   resolution: "secure-json-parse@npm:4.1.0"
   checksum: 10c0/52b3f8125ea974db1333a5b63e6a1df550c36c0d5f9a263911d6732812bd02e938b30be324dcbbb9da3ef9bf5a84849e0dd911f56544003d3c09e8eee12504de
+  languageName: node
+  linkType: hard
+
+"seedrandom@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "seedrandom@npm:3.0.5"
+  checksum: 10c0/929752ac098ff4990b3f8e0ac39136534916e72879d6eb625230141d20db26e2f44c4d03d153d457682e8cbaab0fb7d58a1e7267a157cf23fd8cf34e25044e88
   languageName: node
   linkType: hard
 
@@ -16977,6 +17182,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"suffix-thumb@npm:5.0.2":
+  version: 5.0.2
+  resolution: "suffix-thumb@npm:5.0.2"
+  checksum: 10c0/21013f81dbcca00db2081c69571b652ad23820735b4a9717ef138fc74cd12f1ead37304441698c6b562ba8e56222ed2b1a7ef8cfb89aa116f4684c1097c43bb6
+  languageName: node
+  linkType: hard
+
 "superagent@npm:^8.1.2":
   version: 8.1.2
   resolution: "superagent@npm:8.1.2"
@@ -17139,6 +17351,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tau-prolog@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "tau-prolog@npm:0.3.4"
+  dependencies:
+    readline-sync: "npm:1.4.9"
+  checksum: 10c0/f9384bfb9d946bdc905042b642e783a3cc112910eda5cce30ece32ac59dbdcf8db407c119dda69494306eb8a5e1befd855c87ebb4510d90b1fe3ade1ffe0bd9c
+  languageName: node
+  linkType: hard
+
 "terser-webpack-plugin@npm:^5.3.10":
   version: 5.3.10
   resolution: "terser-webpack-plugin@npm:5.3.10"
@@ -17246,6 +17467,13 @@ __metadata:
     es5-ext: "npm:~0.10.46"
     next-tick: "npm:1"
   checksum: 10c0/fc43c6a01f52875e57d301ae9ec47b3021c6d9b96de5bc6e4e5fc4a3d2b25ebaab69faf6fe85520efbef0ad784537748f88f7efd7b6b2bf0a177c8bc7a66ca7c
+  languageName: node
+  linkType: hard
+
+"tiny-emitter@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "tiny-emitter@npm:2.1.0"
+  checksum: 10c0/459c0bd6e636e80909898220eb390e1cba2b15c430b7b06cec6ac29d87acd29ef618b9b32532283af749f5d37af3534d0e3bde29fdf6bcefbf122784333c953d
   languageName: node
   linkType: hard
 
@@ -17739,6 +17967,13 @@ __metadata:
   version: 2.7.2
   resolution: "type@npm:2.7.2"
   checksum: 10c0/84c2382788fe24e0bc3d64c0c181820048f672b0f06316aa9c7bdb373f8a09f8b5404f4e856bc4539fb931f2f08f2adc4c53f6c08c9c0314505d70c29a1289e1
+  languageName: node
+  linkType: hard
+
+"typed-function@npm:^4.2.1":
+  version: 4.2.2
+  resolution: "typed-function@npm:4.2.2"
+  checksum: 10c0/92f2acc7e6d94431f4b37c2219d131cc90c1f43c19c097b7e337408cfd91336e481680d3362e30b5616318272950480ba670572b4585e8c690ca509d65c97554
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
frontend (external-lib app extensions)

### Description
This PR proposes **nodeBook** as a new external-lib app extension, following the exact pattern of mermaid, KaTeX, graphviz, and the other bundled renderers: a thin `AppExtension` over the published npm packages [`@nodebook/react`](https://www.npmjs.com/package/@nodebook/react) / [`@nodebook/core`](https://www.npmjs.com/package/@nodebook/core) (AGPL-3.0, same license as HedgeDoc).

nodeBook renders **Controlled Natural Language** written in ```nodeBook code fences as interactive knowledge graphs. In one readable notation, note authors get:

- **simple mindmaps** and **concept maps with named, directed edges**;
- **schema definitions** (```nodeBook-schema fences) that turn a note into a tiny **queryable graph database** with typed nodes, relations, and attributes;
- **inference** (transitive closure, inverse/symmetric relations, membership inheritance) powered by the tau-prolog library, including wh-word queries;
- **process representation** with basic Petri-net logic — token simulation for chemical reactions, biological pathways, and system descriptions;
- **basic mathematical equation parsing** and evaluation (mathjs) through Function transitions;
- a **basic ledger mode for personal accounting** via transaction nodes with debit/credit arcs;
- **interactive rendering, SVG/PNG export, pan/zoom/drag** via Cytoscape.js;
- a **graph-analytics scoring engine** in `@nodebook/core` reporting the richness of the graphs in a note (9-category rubric; surfaced in a sidebar panel we kept out of this PR to minimize the diff — happy to follow up).

Syntax reference: https://github.com/gnowgi/hedgedoc-nb/blob/main/docs/nodebook-cnl-spec.md • Live guided tutorial: https://nodebook.co.in/n/tutorial

**Why it may fit HedgeDoc:** the packages are maintained and released independently (the same engine ships as a [Logseq marketplace plugin](https://github.com/logseq/marketplace/pull/881) and an Obsidian plugin), so HedgeDoc carries only glue: two registration lines, fence replacers, cheatsheet entries with autocompletion, a CodeMirror language, and hljs highlighting for CNL. The only config change is a webpack `resolve.fallback` for tau-prolog's runtime-guarded optional `fs`/`child_process` requires.

The extension originated as a fork (nodebook.co.in runs it in production for teaching use); we extracted everything into packages precisely so it could be offered upstream. Opened as a **draft** to gauge maintainer interest before polishing — very happy to adjust scope, naming, or approach to whatever fits the project.

### Steps

- [x] Added implementation
- [ ] Added / updated tests
- [x] Added / updated documentation (cheatsheet entries; extension README)
- [ ] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `develop` for 2.x