### PR TITLE
fix(realtime): pass yjs state as Uint8Array instead of ArrayBuffer

### DIFF
--- a/backend/src/realtime/realtime-note/realtime-note-store.spec.ts
+++ b/backend/src/realtime/realtime-note/realtime-note-store.spec.ts
@@ -43,7 +43,7 @@ describe('RealtimeNoteStore', () => {
   it("can create a new realtime note with a yjs state if it doesn't exist yet", () => {
     const initialYjsState = [0];
     expect(
-      realtimeNoteStore.create(mockedNoteId, mockedContent, new Uint8Array(initialYjsState).buffer),
+      realtimeNoteStore.create(mockedNoteId, mockedContent, new Uint8Array(initialYjsState)),
     ).toBe(mockedRealtimeNote);
     expect(realtimeNoteConstructorSpy).toHaveBeenCalledWith(
       mockedNoteId,

--- a/backend/src/realtime/realtime-note/realtime-note-store.ts
+++ b/backend/src/realtime/realtime-note/realtime-note-store.ts
@@ -27,7 +27,7 @@ export class RealtimeNoteStore {
   public create(
     noteId: number,
     initialTextContent: string,
-    initialYjsState?: ArrayBuffer,
+    initialYjsState?: Uint8Array,
   ): RealtimeNote {
     if (this.noteIdToRealtimeNote.has(noteId)) {
       throw new Error(`Realtime note for note ${noteId} already exists.`);

--- a/backend/src/realtime/realtime-note/realtime-note.service.spec.ts
+++ b/backend/src/realtime/realtime-note/realtime-note.service.spec.ts
@@ -204,7 +204,7 @@ describe('RealtimeNoteService', () => {
     expect(realtimeNoteStore.create).toHaveBeenCalledWith(
       mockedNoteId,
       mockedContent,
-      mockedYjsStateBuffer,
+      Buffer.from(mockedYjsStateBuffer),
     );
     expect(setIntervalSpy).not.toHaveBeenCalled();
   });

--- a/backend/src/realtime/realtime-note/realtime-note.service.ts
+++ b/backend/src/realtime/realtime-note/realtime-note.service.ts
@@ -85,7 +85,7 @@ export class RealtimeNoteService implements BeforeApplicationShutdown {
     const realtimeNote = this.realtimeNoteStore.create(
       noteId,
       lastRevision[FieldNameRevision.content],
-      lastRevision[FieldNameRevision.yjsStateVector]?.buffer ?? undefined,
+      lastRevision[FieldNameRevision.yjsStateVector] ?? undefined,
     );
     realtimeNote.on('beforeDestroy', () => {
       this.saveRealtimeNote(realtimeNote);


### PR DESCRIPTION
### Component/Part
backend (realtime)

### Description
`RealtimeNoteService` passes `lastRevision.yjsStateVector.buffer` into `RealtimeNoteStore.create`. Using `.buffer` hands over the raw `ArrayBuffer` and discards the `Uint8Array` view's `byteOffset`/`byteLength` — for a `Buffer` sliced out of a larger allocation (as node-postgres commonly returns), that corrupts the initial yjs state loaded into a realtime note. This types `create()` as `Uint8Array` and passes the view through unchanged; specs updated accordingly.

Found while running this code in production on a HedgeDoc 2 fork (nodebook.co.in).

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `develop` for 2.x