### PR TITLE
fix(frontend): cap websocket reconnect timeout and reset state on url change

### DIFF
--- a/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-realtime-connection.ts
+++ b/frontend/src/components/editor-page/editor-pane/hooks/yjs/use-realtime-connection.ts
@@ -46,7 +46,7 @@ export const useRealtimeConnection = (): MessageTransporter => {
             reconnectCount.current += 1
             establishWebsocketConnection()
           },
-          Math.max(timeout, WEBSOCKET_RECONNECT_MAX_DURATION)
+          Math.min(timeout, WEBSOCKET_RECONNECT_MAX_DURATION)
         )
       })
       socket.addEventListener('open', () => {
@@ -56,6 +56,13 @@ export const useRealtimeConnection = (): MessageTransporter => {
   }, [messageTransporter, websocketUrl])
 
   const isConnected = useApplicationState((state) => state.realtimeStatus.isConnected)
+
+  useEffect(() => {
+    // When websocketUrl changes (e.g. switching notes), reset connection state
+    // so the connection effect below can establish a fresh connection.
+    reconnectCount.current = 0
+    disconnectReason.current = undefined
+  }, [websocketUrl])
 
   useEffect(() => {
     if (


### PR DESCRIPTION
### Component/Part
frontend (realtime connection)

### Description
Two small fixes in `useRealtimeConnection`:

1. The reconnect backoff uses `Math.max(timeout, WEBSOCKET_RECONNECT_MAX_DURATION)` — so every retry waits **at least** the maximum duration instead of being capped at it. Changed to `Math.min`.
2. When `websocketUrl` changes (e.g. switching notes), the reconnect counter and disconnect reason now reset so a fresh connection can be established instead of inheriting the previous note's terminal state.

Found while running this code in production on a HedgeDoc 2 fork (nodebook.co.in).

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `develop` for 2.x