### PR TITLE
fix(frontend): make password fields controlled inputs

### DIFF
--- a/frontend/src/components/common/fields/new-password-field.tsx
+++ b/frontend/src/components/common/fields/new-password-field.tsx
@@ -29,6 +29,7 @@ export const NewPasswordField: React.FC<CommonFieldProps> = ({ onChange, value, 
       <Form.Control
         type='password'
         size='sm'
+        value={value}
         isValid={isValid}
         isInvalid={hasError}
         onChange={onChange}

--- a/frontend/src/components/common/fields/password-again-field.tsx
+++ b/frontend/src/components/common/fields/password-again-field.tsx
@@ -39,6 +39,7 @@ export const PasswordAgainField: React.FC<PasswordAgainFieldProps> = ({
       <Form.Control
         type='password'
         size='sm'
+        value={value}
         isInvalid={isInvalid}
         isValid={isValid}
         onChange={onChange}


### PR DESCRIPTION
### Component/Part
frontend (common fields)

### Description
`NewPasswordField` and `PasswordAgainField` accept a `value` prop but never pass it to `Form.Control`, so the inputs are uncontrolled: programmatic resets (e.g. clearing the registration form after an error) leave stale text visible while the application state is already empty.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `develop` for 2.x