### PR TITLE
[HD1] add config option to open links in new tab

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -1,10 +1,6 @@
 module.exports = {
   serveLinkWarningPage: function (req, res) {
     let targetURL = typeof req.query.url === 'string' ? req.query.url : ''
-    let noteURL = typeof req.query.note === 'string' ? req.query.note : ''
-    if (noteURL !== '' && !/^[\w-]+$/.test(noteURL)) {
-      noteURL = ''
-    }
     let valid = false
     try {
       targetURL = decodeURIComponent(targetURL)
@@ -20,8 +16,8 @@ module.exports = {
     res.render('link.ejs', {
       title: 'External link',
       valid,
-      noteURL,
       targetURL,
+      cspNonce: res.locals.nonce,
       opengraph: []
     })
   }

--- a/locales/de.json
+++ b/locales/de.json
@@ -132,7 +132,7 @@
     "The content of that page is unrelated to HedgeDoc. Do not enter your HedgeDoc credentials there.": "Der Inhalt dieser Seite ist unabhängig von HedgeDoc. Dort keine HedgeDoc-Zugangsdaten eingeben.",
     "Do you want to continue?": "Fortfahren?",
     "Continue to external page": "Weiter zur externen Seite",
-    "Back to your note": "Zurück zur Notiz",
+    "Close": "Schließen",
     "Invalid link": "Ungültiger Link",
     "The provided link is not a valid URL.": "Die angegebene URL ist nicht gültig."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -132,7 +132,7 @@
     "Invalid link": "Invalid link",
     "Do you want to continue?": "Do you want to continue?",
     "Continue to external page": "Continue to external page",
-    "Back to your note": "Back to your note",
+    "Close": "Close",
     "The provided link is not a valid URL.": "The provided link is not a valid URL.",
     "The content of that page is unrelated to HedgeDoc. Do not enter your HedgeDoc credentials there.": "The content of that page is unrelated to HedgeDoc. Do not enter your HedgeDoc credentials there."
 }

--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -6,6 +6,10 @@
 
 - Automatically skip the login modal if no form-based login and exactly one external login provider is configured
 
+### Bugfixes
+
+- All links will be opened in new tabs instead of the same tab as the note. This was changed when the external link warning was implemented and now the old behavior is restored.
+
 ## <i class="fa fa-tag"></i> 1.11.1 <i class="fa fa-calendar-o"></i> 2026-07-24
 
 ### Security fixes

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -593,6 +593,7 @@ window.postProcess = postProcess
 // rewrite external links to go through the /_link warning page
 export function rewriteExternalLinks (view) {
   if (window.externalLinkWarning === false) {
+    view.find('a:not([href^="#"]):not([target])').attr('target', '_blank').attr('rel', 'noopener')
     return
   }
   const whitelist = window.externalLinkWhitelist || []
@@ -621,11 +622,18 @@ export function rewriteExternalLinks (view) {
       }
       return hostname === lowercaseDomain
     })) {
+      if (!anchor.attr('target')) {
+        anchor.attr('target', '_blank').attr('rel', 'noopener')
+      }
       return
     }
-    const noteURL = window.location.pathname.split('/').pop()
     const urlPath = window.urlpath ? `/${window.urlpath}` : ''
-    anchor.attr('href', `${window.location.origin}${urlPath}/_link?url=${encodeURIComponent(parsed.href)}&note=${noteURL}`)
+    const warningURL = `${window.location.origin}${urlPath}/_link?url=${encodeURIComponent(parsed.href)}`
+    anchor.attr('href', warningURL)
+    anchor.on('click', event => {
+      event.preventDefault()
+      window.open(warningURL, '_blank')
+    })
   })
 }
 window.rewriteExternalLinks = rewriteExternalLinks

--- a/public/views/link.ejs
+++ b/public/views/link.ejs
@@ -27,15 +27,18 @@
             <p><%= __('Do you want to continue?') %></p>
             <p>
                 <a class="btn btn-primary" href="<%- targetURL %>"><%= __('Continue to external page') %></a>
-                <a class="btn btn-default" href="<%- serverURL %>/<%- noteURL %>"><%= __('Back to your note') %></a>
+                <a class="btn btn-default" id="close-button"><%= __('Close') %></a>
             </p>
             <% } else { %>
             <p class="text-danger"><strong><%= __('The provided link is not a valid URL.') %></strong></p>
             <p>
-                <a class="btn btn-default" href="<%- serverURL %>/<%- noteURL %>"><%= __('Back to your note') %></a>
+                <a class="btn btn-default" id="close-button"><%= __('Close') %></a>
             </p>
             <% } %>
         </div>
     </div>
 </body>
+<script nonce="<%= cspNonce %>">
+    document.getElementById("close-button").addEventListener('click', _ => window.close())
+</script>
 </html>


### PR DESCRIPTION
### Component/Part
HD1 editor/renderer

### Description
The addition of external link warning has changed the behavior of opening links from opening in a new tab to opening in the same tab. This adds a new config option to open links in a new tab. 

When used in conjunction with external link warning, the warning page opens in a new tab with the `note` parameter being empty, which causes the "Back to your note" button to close the tab instead of directing back to the note. The new tab for the warning page is opened by a script in order to allow it to be closed by a script.

### Steps

- [x] Added implementation
- [x] Added / updated documentation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
