### PR TITLE
ci: drop node 18

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['18', '20', '22', '24']
+        node: ['20', '22', '24']
     name: Node ${{ matrix.node }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Component/Part
ci
### Description
This PR removes node 18 from the ci.
Node 18 is deprecated and we already announce that HedgeDoc won't work with it anymore.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
<!-- e.g #123 -->
