### PR TITLE
fix(frontend): set note title from server when title state from markdown is empty string

### DIFF
--- a/frontend/src/redux/note-details/build-state-from-updated-markdown-content.ts
+++ b/frontend/src/redux/note-details/build-state-from-updated-markdown-content.ts
@@ -61,7 +61,7 @@ const buildStateFromMarkdownContentAndLines = (
       },
       startOfContentLineOffset: 0,
       rawFrontmatter: '',
-      title: generateNoteTitle(initialState.frontmatter, () => state.firstHeading),
+      title: state.title || generateNoteTitle(initialState.frontmatter, () => state.firstHeading),
       frontmatter: initialState.frontmatter
     }
   }
@@ -102,7 +102,7 @@ const buildStateFromFrontmatter = (
 ) => {
   return {
     ...state,
-    title: generateNoteTitle(noteFrontmatter, () => state.firstHeading),
+    title: state.title || generateNoteTitle(noteFrontmatter, () => state.firstHeading),
     rawFrontmatter: frontmatterExtraction.rawText,
     frontmatter: noteFrontmatter,
     startOfContentLineOffset: frontmatterExtraction.lineOffset

--- a/frontend/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.ts
+++ b/frontend/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.ts
@@ -17,8 +17,7 @@ import type { NoteInterface } from '@hedgedoc/commons'
  */
 export const buildStateFromServerInterface = (dto: NoteInterface): NoteDetails => {
   const newState = convertNoteInterfaceToNoteDetails(dto)
-  const rebuiltState = buildStateFromUpdatedMarkdownContent(newState, newState.markdownContent.plain)
-  return rebuiltState.title === "" ? { ...rebuiltState, title: dto.metadata.title } : rebuiltState
+  return buildStateFromUpdatedMarkdownContent(newState, newState.markdownContent.plain)
 }
 
 /**

--- a/frontend/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.ts
+++ b/frontend/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.ts
@@ -17,7 +17,8 @@ import type { NoteInterface } from '@hedgedoc/commons'
  */
 export const buildStateFromServerInterface = (dto: NoteInterface): NoteDetails => {
   const newState = convertNoteInterfaceToNoteDetails(dto)
-  return buildStateFromUpdatedMarkdownContent(newState, newState.markdownContent.plain)
+  const rebuiltState = buildStateFromUpdatedMarkdownContent(newState, newState.markdownContent.plain)
+  return rebuiltState.title === "" ? { ...rebuiltState, title: dto.metadata.title } : rebuiltState
 }
 
 /**


### PR DESCRIPTION
### Component/Part
Frontend

### Description
This PR fixes an issue I observed where occasionally both the app bar and title bar of browser tabs were displaying as "Untitled" for a note that has an h1 tag.

This happens because `buildStateFromServerInterface` sets the title from the server response and then immediately calls `buildStateFromUpdatedMarkdownContent`. This recomputes the title from `state.firstHeading` which is `undefined` while the note is loading and results in the title being set to `''`. The only way for the correct title to be displayed after this occurs is for the `HeadlineExtracted` event to restore it. To avoid this the server-provided `dbo.metadata.title` is used when the recomputed title is empty.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `develop` for 2.x

### Related Issue(s)
I did not find any related issues.
