### PR TITLE
Add unstyled HTML export

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -337,7 +337,7 @@
           "public": "Public"
         }
       },
-      "rawHtml": "Raw HTML",
+      "unstyled-html": "Unstyled HTML",
       "markdown-file": "Markdown file",
       "print": "Print"
     },

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-unstyled-html-sidebar-entry/export-unstyled-html-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-unstyled-html-sidebar-entry/export-unstyled-html-sidebar-entry.tsx
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, { useCallback, useMemo } from 'react'
+import { Trans } from 'react-i18next'
+import { useEditorToRendererCommunicator } from '../../../../../render-context/editor-to-renderer-communicator-context-provider'
+import { useEditorReceiveHandler } from '../../../../../../render-page/window-post-message-communicator/hooks/use-editor-receive-handler'
+import { CommunicationMessageType } from '../../../../../../render-page/window-post-message-communicator/rendering-message'
+import { useApplicationState } from '../../../../../../../hooks/common/use-application-state'
+import { FiletypeHtml as IconFiletypeHtml } from 'react-bootstrap-icons'
+import { useNoteFilename } from '../../../../../../../hooks/common/use-note-filename'
+import { download } from '../../../../../../common/download/download'
+import { SidebarButton } from '../../../../sidebar-button/sidebar-button'
+import { useBaseUrl } from '../../../../../../../hooks/common/use-base-url'
+
+/**
+ * Editor sidebar entry for exporting the unstyled HTML content into a local file.
+ * This works by sending a request to the iframe for retrieving and processing
+ * the content and downloading the returned HTML.
+ */
+export const ExportUnstyledHtmlSidebarEntry: React.FC = () => {
+  const baseUrl = useBaseUrl()
+  const primaryAlias = useApplicationState((state) => state.noteDetails.primaryAlias)
+  const fileName = useNoteFilename('html')
+  const editorToRendererCommunicator = useEditorToRendererCommunicator()
+
+  useEditorReceiveHandler(
+    CommunicationMessageType.EXPORT_HTML_RESPONSE,
+    useMemo(
+      () =>
+        ({ html }) =>
+          download(html, fileName, 'text/html'),
+      [fileName]
+    )
+  )
+
+  const rendererReady = useApplicationState((state) => state.rendererStatus.rendererReady)
+  const onClick = useCallback(() => {
+    if (rendererReady) {
+      editorToRendererCommunicator.sendMessageToOtherSide({
+        type: CommunicationMessageType.EXPORT_HTML_REQUEST,
+        noteUrl: `${baseUrl}n/${primaryAlias}`
+      })
+    }
+  }, [editorToRendererCommunicator, rendererReady, baseUrl, primaryAlias])
+
+  return (
+    <SidebarButton onClick={onClick} icon={IconFiletypeHtml}>
+      <Trans i18nKey={'editor.export.unstyled-html'} />
+    </SidebarButton>
+  )
+}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/export-sidebar-menu.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/export-sidebar-menu.tsx
@@ -10,17 +10,14 @@ import type { SpecificSidebarMenuProps } from '../../types'
 import { DocumentSidebarMenuSelection } from '../../types'
 import { ExportMarkdownSidebarEntry } from './entries/export-markdown-sidebar-entry'
 import React, { Fragment, useCallback } from 'react'
-import {
-  ArrowLeft as IconArrowLeft,
-  CloudDownload as IconCloudDownload,
-  FileCode as IconFileCode
-} from 'react-bootstrap-icons'
+import { ArrowLeft as IconArrowLeft, CloudDownload as IconCloudDownload } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
 import { concatCssClasses } from '../../../../../utils/concat-css-classes'
 import styles from '../../sidebar-button/sidebar-button.module.scss'
 import { ExportGistSidebarEntry } from './entries/export-gist-sidebar-entry/export-gist-sidebar-entry'
 import { ExportGitlabSnippetSidebarEntry } from './entries/export-gitlab-snippet-sidebar-entry/export-gitlab-snippet-sidebar-entry'
 import { ExportPrintSidebarEntry } from './entries/export-print-sidebar-entry'
+import { ExportUnstyledHtmlSidebarEntry } from './entries/export-unstyled-html-sidebar-entry/export-unstyled-html-sidebar-entry'
 
 /**
  * Renders the export menu for the sidebar.
@@ -56,16 +53,10 @@ export const ExportSidebarMenu: React.FC<SpecificSidebarMenuProps> = ({
       <SidebarMenu expand={expand}>
         <ExportPrintSidebarEntry />
         <ExportMarkdownSidebarEntry />
-        <SidebarButton icon={IconFileCode} disabled={true}>
-          HTML
-        </SidebarButton>
+        <ExportUnstyledHtmlSidebarEntry />
 
         <ExportGistSidebarEntry />
         <ExportGitlabSnippetSidebarEntry />
-
-        <SidebarButton icon={IconFileCode} disabled={true}>
-          <Trans i18nKey='editor.export.rawHtml' />
-        </SidebarButton>
       </SidebarMenu>
     </Fragment>
   )

--- a/frontend/src/components/render-page/hooks/use-on-html-export-request.ts
+++ b/frontend/src/components/render-page/hooks/use-on-html-export-request.ts
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { CommunicationMessageType } from '../window-post-message-communicator/rendering-message'
+import { useRendererReceiveHandler } from '../window-post-message-communicator/hooks/use-renderer-receive-handler'
+import { useMemo } from 'react'
+import clickShieldCss from '../../markdown-renderer/replace-components/click-shield/click-shield.module.scss'
+import highlightedCodeCss from '../../common/highlighted-code/highlighted-code.module.scss'
+import copyButtonCss from '../../common/copyable/copy-to-clipboard-button/style.module.scss'
+import type { RendererToEditorCommunicator } from '../window-post-message-communicator/renderer-to-editor-communicator'
+
+/**
+ * Builds a hook that grabs and transforms the markdown HTML content for sending it back to the iframe host
+ * for downloading. The transformations include removing click shields, interactive buttons and invalid links.
+ *
+ * @param communicator The iframe communicator to use for receiving events on
+ */
+export const useOnHtmlExportRequest = (communicator: RendererToEditorCommunicator) => {
+  useRendererReceiveHandler(
+    CommunicationMessageType.EXPORT_HTML_REQUEST,
+    useMemo(
+      () =>
+        ({ noteUrl }) => {
+          const documentContainer = document.querySelector('.markdown-body')
+          if (!documentContainer) {
+            return
+          }
+          const downloadElement = document.createElement('div')
+          downloadElement.innerHTML = documentContainer.innerHTML
+          ;[
+            ...downloadElement.querySelectorAll(`.${clickShieldCss['click-shield']}`),
+            ...downloadElement.querySelectorAll(`.${copyButtonCss['copy-button']}`),
+            ...downloadElement.querySelectorAll(`.${highlightedCodeCss['linenumber']}`)
+          ].forEach((element) => element.remove())
+          console.debug('Note URL to replace: ', noteUrl)
+          downloadElement.querySelectorAll('a[href]').forEach((element) => {
+            const href = element.getAttribute('href')
+            if (!href || !href.startsWith(noteUrl)) {
+              return
+            }
+            element.setAttribute('href', href.replace(noteUrl, ''))
+          })
+          const finalHtml = downloadElement.innerHTML
+          communicator.sendMessageToOtherSide({
+            type: CommunicationMessageType.EXPORT_HTML_RESPONSE,
+            html: finalHtml
+          })
+        },
+      [communicator]
+    )
+  )
+}

--- a/frontend/src/components/render-page/render-page-content.tsx
+++ b/frontend/src/components/render-page/render-page-content.tsx
@@ -20,6 +20,7 @@ import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useSt
 import { setPrintMode } from '../../redux/print-mode/methods'
 import { usePrintSelfKeyboardShortcut } from '../editor-page/hooks/use-print-keyboard-shortcut'
 import { useApplicationState } from '../../hooks/common/use-application-state'
+import { useOnHtmlExportRequest } from './hooks/use-on-html-export-request'
 
 /**
  * Wraps the markdown rendering in an iframe.
@@ -83,6 +84,8 @@ export const RenderPageContent: React.FC = () => {
       })
     }, [communicator])
   )
+
+  useOnHtmlExportRequest(communicator)
 
   useRendererReceiveHandler(
     CommunicationMessageType.SET_PRINT_MODE,

--- a/frontend/src/components/render-page/window-post-message-communicator/rendering-message.ts
+++ b/frontend/src/components/render-page/window-post-message-communicator/rendering-message.ts
@@ -23,7 +23,9 @@ export enum CommunicationMessageType {
   EXTENSION_EVENT = 'EXTENSION_EVENT',
   SET_PRINT_MODE = 'SET_PRINT_MODE',
   SCROLL_TO_ELEMENT = 'SCROLL_TO_ELEMENT',
-  SET_URL_HASH = 'SET_URL_HASH'
+  SET_URL_HASH = 'SET_URL_HASH',
+  EXPORT_HTML_REQUEST = 'EXPORT_HTML_REQUEST',
+  EXPORT_HTML_RESPONSE = 'EXPORT_HTML_RESPONSE'
 }
 
 export interface NoPayloadMessage<TYPE extends CommunicationMessageType> {
@@ -105,6 +107,16 @@ export interface SetUrlHashMessage {
   hash: string
 }
 
+export interface ExportHtmlRequestMessage {
+  type: CommunicationMessageType.EXPORT_HTML_REQUEST
+  noteUrl: string
+}
+
+export interface ExportHtmlResponseMessage {
+  type: CommunicationMessageType.EXPORT_HTML_RESPONSE
+  html: string
+}
+
 export type CommunicationMessages =
   | NoPayloadMessage<CommunicationMessageType.RENDERER_READY>
   | NoPayloadMessage<CommunicationMessageType.ENABLE_RENDERER_SCROLL_SOURCE>
@@ -122,6 +134,8 @@ export type CommunicationMessages =
   | SetPrintModeConfigurationMessage
   | ScrollToElementMessage
   | SetUrlHashMessage
+  | ExportHtmlRequestMessage
+  | ExportHtmlResponseMessage
 
 export type EditorToRendererMessageType =
   | CommunicationMessageType.SET_MARKDOWN_CONTENT
@@ -133,6 +147,7 @@ export type EditorToRendererMessageType =
   | CommunicationMessageType.DISABLE_RENDERER_SCROLL_SOURCE
   | CommunicationMessageType.SET_PRINT_MODE
   | CommunicationMessageType.SCROLL_TO_ELEMENT
+  | CommunicationMessageType.EXPORT_HTML_REQUEST
 
 export type RendererToEditorMessageType =
   | CommunicationMessageType.RENDERER_READY
@@ -143,6 +158,7 @@ export type RendererToEditorMessageType =
   | CommunicationMessageType.IMAGE_UPLOAD
   | CommunicationMessageType.EXTENSION_EVENT
   | CommunicationMessageType.SET_URL_HASH
+  | CommunicationMessageType.EXPORT_HTML_RESPONSE
 
 export enum RendererType {
   DOCUMENT = 'document',

--- a/frontend/src/hooks/common/use-note-filename.tsx
+++ b/frontend/src/hooks/common/use-note-filename.tsx
@@ -11,9 +11,11 @@ import sanitize from 'sanitize-filename'
  * Returns a sanitized filename for the current note based on the title.
  * When no title is provided, the filename will be "untitled".
  *
+ * @param extension The file extension to use, defaults to md
+ *
  * @return The sanitized filename
  */
-export const useNoteFilename = (): string => {
+export const useNoteFilename = (extension: string = 'md'): string => {
   const title = useNoteTitle()
-  return useMemo(() => `${sanitize(title)}.md`, [title])
+  return useMemo(() => `${sanitize(title)}.${extension}`, [title, extension])
 }


### PR DESCRIPTION
### Component/Part
import/export

### Description
This PR adds the unstyled HTML export - in HD1 known as "Raw HTML". It includes the renderer output without further styles or external embeddings and can be used for example for pasting it into your own HTML-based CMS or publishiing it with your own CSS.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
part of #6482 
part of #2889 
