### PR TITLE
refactor: anchor links

### DIFF
--- a/frontend/global-styles/markdown-tweaks.scss
+++ b/frontend/global-styles/markdown-tweaks.scss
@@ -43,8 +43,12 @@
 
   h1, h2, h3, h4, h5, h6 {
     .heading-anchor {
+      color: var(--bs-heading-color);
+      position: absolute;
+      text-decoration: none;
+      border-bottom: none;
       user-select: none;
-      font-size: 0.75em;
+      font-size: 0.7em;
       margin-top: 0.25em;
       opacity: 0.3;
       transition: opacity 0.1s;
@@ -53,6 +57,26 @@
         opacity: 1;
       }
     }
+  }
+
+  h1 .heading-anchor {
+    left: -1rem;
+  }
+
+  h2 .heading-anchor {
+    left: -.85rem;
+  }
+
+  h3 .heading-anchor {
+    left: -.75rem;
+  }
+
+  h4 .heading-anchor {
+    left: -.65rem;
+  }
+
+  h5 .heading-anchor , h6 .heading-anchor {
+    left: -.55rem;
   }
 
   blockquote .blockquote-extra {

--- a/frontend/src/components/render-page/renderers/document/markdown-document.module.scss
+++ b/frontend/src/components/render-page/renderers/document/markdown-document.module.scss
@@ -20,7 +20,8 @@
   }
 
   .content {
-    padding-left: 10px;
+    padding-top: 1rem;
+    padding-left: 2rem;
     padding-right: 10px;
     flex: 0 0 900px;
     max-width: 100%;

--- a/frontend/src/extensions/essential-app-extensions/headline-anchors/headline-anchors-markdown-renderer-extension.ts
+++ b/frontend/src/extensions/essential-app-extensions/headline-anchors/headline-anchors-markdown-renderer-extension.ts
@@ -14,8 +14,8 @@ export class HeadlineAnchorsMarkdownRendererExtension extends MarkdownRendererEx
   public configureMarkdownIt(markdownIt: MarkdownIt): void {
     anchor(markdownIt, {
       permalink: anchor.permalink.ariaHidden({
-        symbol: '🔗',
-        class: 'heading-anchor text-dark',
+        symbol: '¶',
+        class: 'heading-anchor',
         renderHref: (slug: string): string => `#${slug}`,
         placement: 'before'
       })


### PR DESCRIPTION
### Component/Part
renderer

### Description
This PR refactors the link anchor.

Instead of the link emoji the paragraph symbol ¶ is used to indicate link anchors. The link anchor is moved before the line to resemble HedgeDoc 1 more closely.
This PR also increases the padding of the whole content to look better and be more readable


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
