### PR TITLE
docs(oidc): update Authelia configuration for v4.38+ compatibility

### DIFF
--- a/docs/content/guides/auth/authelia.md
+++ b/docs/content/guides/auth/authelia.md
@@ -8,9 +8,10 @@ Also this guides assumes you run HedgeDoc via a [Docker container](../../setup/d
 ## Steps
 
 1. Set up the necessary OpenID Connect parameters in your Authelia `configuration.yml` as explained in the [documentation](https://www.authelia.com/configuration/identity-providers/openid-connect/provider/).
-   Make sure to generate safe secrets (such as `LENGTH=64; tr -cd '[:alnum:]' < /dev/urandom | fold -w "${LENGTH}" | head -n 1 | tr -d '\n' ; echo`)
 
-2. A completed `identity_providers` section of the configuration may look like the following (the chosen Client ID shouldn't actually be this guessable for safety reasons):
+2. Make sure to generate safe secrets (such as `LENGTH=64; tr -cd '[:alnum:]' < /dev/urandom | fold -w "${LENGTH}" | head -n 1 | tr -d '\n' ; echo`)
+
+3. A completed `identity_providers` section of the configuration may look like the following (the chosen Client ID shouldn't actually be this guessable for safety reasons):
 ```yaml
 identity_providers:
   oidc:
@@ -62,9 +63,9 @@ identity_providers:
 ```
 (Note: As of Authelia v4.38.0+, issuer_private_key was deprecated and replaced by jwks. The configuration above uses Authelia's templating engine to securely load the private key and HMAC secret from external Docker secrets files, avoiding plaintext keys in your YAML).
 
-1. Restart Authelia to apply to new configuration and check for any errors in the log.
+4. Restart Authelia to apply to new configuration and check for any errors in the log.
 
-2. In the `docker-compose.yml` of HedgeDoc add the following environment variables (you can choose different attributes for e.g. the display name - all available attributes you can find in the [scope definitions](https://www.authelia.com/docs/configuration/identity-providers/oidc.html#scope-definitions)):
+5. In the `docker-compose.yml` of HedgeDoc add the following environment variables (you can choose different attributes for e.g. the display name - all available attributes you can find in the [scope definitions](https://www.authelia.com/docs/configuration/identity-providers/oidc.html#scope-definitions)):
 ```yaml
 - CMD_URL_ADDPORT=false
 - CMD_PROTOCOL_USESSL=true
@@ -80,6 +81,6 @@ identity_providers:
 - CMD_OAUTH2_TOKEN_URL=https://<your-authelia-url>/api/oidc/token
 - CMD_OAUTH2_AUTHORIZATION_URL=https://<your-authelia-url>/api/oidc/authorization
 ```
-3. Run docker-compose up -d on HedgeDoc to apply your settings.
+6. Run docker-compose up -d on HedgeDoc to apply your settings.
 
-4. Sign in to your HedgeDoc using your Authelia login.
+7. Sign in to your HedgeDoc using your Authelia login.

--- a/docs/content/guides/auth/authelia.md
+++ b/docs/content/guides/auth/authelia.md
@@ -7,24 +7,40 @@ Also this guides assumes you run HedgeDoc via a [Docker container](../../setup/d
 
 ## Steps
 
-1. Set up the necessary OpenID Connect parameters in your Authelia `configuration.yml` as explained in the documentation at <https://www.authelia.com/docs/configuration/identity-providers/oidc.html>.
-2. Make sure to generate safe secrets (such as `LENGTH=64; tr -cd '[:alnum:]' < /dev/urandom | fold -w "${LENGTH}" | head -n 1 | tr -d '\n' ; echo`)
-3. A completed `identity_providers` section of the configuration may look like the following (the chosen Client ID `id` shouldn't actually be this guessable for safety reasons):
+1. Set up the necessary OpenID Connect parameters in your Authelia `configuration.yml` as explained in the [documentation](https://www.authelia.com/configuration/identity-providers/openid-connect/provider/).
+   Make sure to generate safe secrets (such as `LENGTH=64; tr -cd '[:alnum:]' < /dev/urandom | fold -w "${LENGTH}" | head -n 1 | tr -d '\n' ; echo`)
 
+2. A completed `identity_providers` section of the configuration may look like the following (the chosen Client ID shouldn't actually be this guessable for safety reasons):
 ```yaml
 identity_providers:
   oidc:
-    hmac_secret: <hmac secret here> # use docker secrets for this
-    issuer_private_key: <issuer private key secret here> # use docker secrets for this
+    ## Load the HMAC secret dynamically from a Docker secret file
+    hmac_secret: '{{ secret "/run/secrets/authelia_hmac_secret" }}'
+    
+    ## Load the OIDC Private Key dynamically into the new JWKS structure
+    jwks:
+      - key_id: 'primary'
+        algorithm: 'RS256'
+        use: 'sig'
+        # The templating engine reads the secret file, indents it by 10 spaces, 
+        # and formats it correctly for YAML using msquote and mindent.
+        key: {{ secret "/run/secrets/authelia_oidc_private_key.pem" | mindent 10 "|" | msquote }}
+        
     access_token_lifespan: 1h
     authorize_code_lifespan: 1m
     id_token_lifespan: 1h
     refresh_token_lifespan: 90m
     enable_client_debug_messages: false
+    
     clients:
-      - client_id: <random client id>
-        client_name: HedgeDoc
-        secret: <client secret here>
+      - client_id: '<random client id>'
+        client_name: 'HedgeDoc'
+        
+        ## In 4.38+, Authelia heavily recommends storing the Client Secret as a HASH, not plaintext.
+        ## You give HedgeDoc the plaintext password, but store the hashed version here.
+        ## Generate this hash using the 'authelia crypto hash generate' CLI command.
+        client_secret: '<hashed client secret>' 
+        
         public: false
         authorization_policy: two_factor
         scopes:
@@ -44,16 +60,18 @@ identity_providers:
           - fragment
         token_endpoint_auth_method: 'client_secret_post'
 ```
+(Note: As of Authelia v4.38.0+, issuer_private_key was deprecated and replaced by jwks. The configuration above uses Authelia's templating engine to securely load the private key and HMAC secret from external Docker secrets files, avoiding plaintext keys in your YAML).
 
-4. Restart Authelia to apply to new configuration and check for any errors in the log
-5. In the `docker-compose.yml` of HedgeDoc add the following environment variables (you can choose different attributes for e.g. the display name - all available attributes you can find in the [scope definitions](https://www.authelia.com/docs/configuration/identity-providers/oidc.html#scope-definitions)):
+1. Restart Authelia to apply to new configuration and check for any errors in the log.
 
+2. In the `docker-compose.yml` of HedgeDoc add the following environment variables (you can choose different attributes for e.g. the display name - all available attributes you can find in the [scope definitions](https://www.authelia.com/docs/configuration/identity-providers/oidc.html#scope-definitions)):
 ```yaml
 - CMD_URL_ADDPORT=false
 - CMD_PROTOCOL_USESSL=true
 - CMD_OAUTH2_PROVIDERNAME=Authelia
 - CMD_OAUTH2_CLIENT_ID=<client id here>
-- CMD_OAUTH2_CLIENT_SECRET=<client secret here>
+# NOTE: Use the plaintext client secret here, NOT the hashed one used in Authelia's configuration
+- CMD_OAUTH2_CLIENT_SECRET=<plaintext client secret here>
 - CMD_OAUTH2_SCOPE=openid email profile
 - CMD_OAUTH2_USER_PROFILE_USERNAME_ATTR=sub
 - CMD_OAUTH2_USER_PROFILE_DISPLAY_NAME_ATTR=name
@@ -62,6 +80,6 @@ identity_providers:
 - CMD_OAUTH2_TOKEN_URL=https://<your-authelia-url>/api/oidc/token
 - CMD_OAUTH2_AUTHORIZATION_URL=https://<your-authelia-url>/api/oidc/authorization
 ```
+3. Run docker-compose up -d on HedgeDoc to apply your settings.
 
-6. Run `docker-compose up -d` on HedgeDoc to apply your settings.
-7. Sign in to your HedgeDoc using your Authelia login
+4. Sign in to your HedgeDoc using your Authelia login.


### PR DESCRIPTION
### Component
Authelia Documentation

fixes: #5540 

### Description
What:
Update the Authelia configuration examples within the HedgeDoc OIDC authentication documentation.

Why:
Authelia v4.38.0 officially deprecated the issuer_private_key directive in favor of a JSON Web Key Set (jwks) structure. HedgeDoc administrators copying the existing documentation snippet into newer Authelia deployments experience fatal configuration errors and container crash loops during startup.

How:

* Replaced the deprecated issuer_private_key field with the new jwks array syntax in the YAML examples.

* Updated the configuration snippets to correctly map the RSA private key and HMAC secret using Authelia's updated secrets engine.

* Ensured that deprecated lifespans and session URL configurations match the current Authelia security and schema requirements.
* Spun up a local Docker Compose test environment and tested HedgeDoc 1.11.1 and Authelia v4.38.x (latest).

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [ x ] Updated documentation
- [ x ] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

