### PR TITLE
fix(frontend): set note title from server when title state from markdown is empty string- #6660

### DIFF
--- a/commons/src/title-extraction/generate-note-title.spec.ts
+++ b/commons/src/title-extraction/generate-note-title.spec.ts
@@ -54,4 +54,14 @@ describe('generate note title', () => {
     const actual = generateNoteTitle({ ...testFrontmatter }, () => 'first-heading')
     expect(actual).toEqual('first-heading')
   })
+
+  it('falls back to the previous title when the first heading is empty', () => {
+    const actual = generateNoteTitle({ ...testFrontmatter }, () => '', 'previous')
+    expect(actual).toEqual('previous')
+  })
+
+  it('returns an empty string if no title source is available', () => {
+    const actual = generateNoteTitle({ ...testFrontmatter }, () => undefined)
+    expect(actual).toEqual('')
+  })
 })

--- a/commons/src/title-extraction/generate-note-title.ts
+++ b/commons/src/title-extraction/generate-note-title.ts
@@ -10,17 +10,19 @@ import type { NoteFrontmatter } from '../note-frontmatter/note-frontmatter.js'
  *
  * @param frontmatter The frontmatter of the note
  * @param firstHeadingProvider A function that provides the first heading of the markdown content
+ * @param previousTitle The previous title to use as a fallback when the first heading is empty and no frontmatter title exists
  * @return The title from the frontmatter or, if no title is present in the frontmatter, the first heading.
  */
 export const generateNoteTitle = (
   frontmatter: NoteFrontmatter | undefined,
   firstHeadingProvider: () => string | undefined,
+  previousTitle?: string,
 ): string => {
   if (frontmatter?.title) {
     return frontmatter.title.trim()
   } else if (frontmatter?.opengraph.title) {
-    return (frontmatter?.opengraph.title ?? firstHeadingProvider() ?? '').trim()
+    return frontmatter?.opengraph.title.trim()
   } else {
-    return (firstHeadingProvider() ?? '').trim()
+    return (firstHeadingProvider() ?? '').trim() || previousTitle?.trim() || ''
   }
 }

--- a/frontend/src/redux/note-details/build-state-from-updated-markdown-content.spec.ts
+++ b/frontend/src/redux/note-details/build-state-from-updated-markdown-content.spec.ts
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { buildStateFromUpdatedMarkdownContent } from './build-state-from-updated-markdown-content'
+import { initialState } from './initial-state'
+
+describe('build state from updated markdown content', () => {
+  it('keeps the server title while the first heading is not extracted yet', () => {
+    const actual = buildStateFromUpdatedMarkdownContent(
+      { ...initialState, title: 'Server title', firstHeading: '' },
+      '# Markdown heading'
+    )
+
+    expect(actual.title).toBe('Server title')
+  })
+})

--- a/frontend/src/redux/note-details/build-state-from-updated-markdown-content.ts
+++ b/frontend/src/redux/note-details/build-state-from-updated-markdown-content.ts
@@ -61,7 +61,7 @@ const buildStateFromMarkdownContentAndLines = (
       },
       startOfContentLineOffset: 0,
       rawFrontmatter: '',
-      title: generateNoteTitle(initialState.frontmatter, () => state.firstHeading),
+      title: generateNoteTitle(initialState.frontmatter, () => state.firstHeading, state.title),
       frontmatter: initialState.frontmatter
     }
   }
@@ -102,7 +102,7 @@ const buildStateFromFrontmatter = (
 ) => {
   return {
     ...state,
-    title: generateNoteTitle(noteFrontmatter, () => state.firstHeading),
+    title: generateNoteTitle(noteFrontmatter, () => state.firstHeading, state.title),
     rawFrontmatter: frontmatterExtraction.rawText,
     frontmatter: noteFrontmatter,
     startOfContentLineOffset: frontmatterExtraction.lineOffset

--- a/frontend/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.ts
+++ b/frontend/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.ts
@@ -17,8 +17,7 @@ import type { NoteInterface } from '@hedgedoc/commons'
  */
 export const buildStateFromServerInterface = (dto: NoteInterface): NoteDetails => {
   const newState = convertNoteInterfaceToNoteDetails(dto)
-  const rebuiltState = buildStateFromUpdatedMarkdownContent(newState, newState.markdownContent.plain)
-  return rebuiltState.title === "" ? { ...rebuiltState, title: dto.metadata.title } : rebuiltState
+  return buildStateFromUpdatedMarkdownContent(newState, newState.markdownContent.plain)
 }
 
 /**

--- a/frontend/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.ts
+++ b/frontend/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.ts
@@ -17,7 +17,8 @@ import type { NoteInterface } from '@hedgedoc/commons'
  */
 export const buildStateFromServerInterface = (dto: NoteInterface): NoteDetails => {
   const newState = convertNoteInterfaceToNoteDetails(dto)
-  return buildStateFromUpdatedMarkdownContent(newState, newState.markdownContent.plain)
+  const rebuiltState = buildStateFromUpdatedMarkdownContent(newState, newState.markdownContent.plain)
+  return rebuiltState.title === "" ? { ...rebuiltState, title: dto.metadata.title } : rebuiltState
 }
 
 /**


### PR DESCRIPTION
Fixup of #6660 

Thanks to @jwhitlow45 for finding the bug and providing the foundation that we built upon.

---

### Component/Part
Frontend

### Description
This PR fixes an issue I observed where occasionally both the app bar and title bar of browser tabs were displaying as "Untitled" for a note that has an h1 tag.

This happens because `buildStateFromServerInterface` sets the title from the server response and then immediately calls `buildStateFromUpdatedMarkdownContent`. This recomputes the title from `state.firstHeading` which is `undefined` while the note is loading and results in the title being set to `''`. The only way for the correct title to be displayed after this occurs is for the `HeadlineExtracted` event to restore it. To avoid this the server-provided `dbo.metadata.title` is used when the recomputed title is empty.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `develop` for 2.x

### Related Issue(s)
I did not find any related issues.