### PR TITLE
Add GitHub Gist and GitLab Snippet import

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -305,46 +305,57 @@
         "exceeded": "You've exceeded the maximum length of this note by {{exceeded}} characters. Consider shortening it."
       }
     },
-    "export": {
-      "common": {
+    "importExport": {
+      "service": {
+        "gist": {
+          "name": "GitHub Gist",
+          "shortName": "Gist",
+          "infoToken": "You need a personal access token with the Gists account permission. You can create one in your GitHub settings here:",
+          "tokenLink": "Create a fine-grained personal access token",
+          "makePublic": "Make Gist public?"
+        },
+        "gitlab": {
+          "name": "GitLab snippet",
+          "shortName": "Snippet",
+          "infoToken": "You need a personal access token with the api permission. You can create one in your GitLab user settings here:",
+          "tokenLink": "Create an access token",
+          "instanceUrl": "Instance URL",
+          "setVisibility": "Set snippet visibility",
+          "visibility": {
+            "private": "Private",
+            "internal": "Internal",
+            "public": "Public"
+          }
+        },
+        "styled-html": "Styled HTML",
+        "unstyled-html": "Unstyled HTML",
+        "markdown": "Markdown file",
+        "print": "Print"
+      },
+      "export": {
+        "button": "Export",
         "title": "Export to {{service}}",
         "createButton": "Create {{shortName}}",
-        "headingAuthentication": "Authentication",
-        "headingSettings": "Export settings",
-        "fieldToken": "Access token",
-        "fieldDescription": "Description",
         "notificationSuccessTitle": "{{shortName}} successfully created",
         "notificationSuccessMessage": "The note has been exported to {{service}}.",
         "notificationSuccessButton": "Open {{shortName}}",
-        "notificationErrorTitle": "Error while creating {{shortName}}: {{errorMessage}}"
+        "notificationErrorTitle": "Error while creating {{shortName}}: {{errorMessage}}",
+        "settings": "Export settings"
       },
-      "gist": {
-        "service": "GitHub Gist",
-        "shortName": "Gist",
-        "infoToken": "You need a personal access token with the Gists account permission. You can create one in your GitHub settings here:",
-        "fieldPublic": "Make Gist public?"
+      "import": {
+        "button": "Import",
+        "title": "Import from {{service}}",
+        "url": "URL",
+        "anonymousImport": "Leave this empty to import anonymously.",
+        "notificationSuccessTitle": "Import successful",
+        "notificationSuccessMessage": "The content from {{service}} has been appended to the note.",
+        "notificationError": "Error while importing from {{service}}: {{errorMessage}}"
       },
-      "gitlab": {
-        "service": "GitLab snippet",
-        "shortName": "Snippet",
-        "infoToken": "You need a personal access token with the api permission. You can create one in your GitLab user settings here:",
-        "infoTokenLink": "Preferences → Access tokens",
-        "fieldUrl": "GitLab URL",
-        "fieldVisibility": "Set snippet visibility",
-        "visibility": {
-          "private": "Private",
-          "internal": "Internal",
-          "public": "Public"
-        }
-      },
-      "styled-html": "Styled HTML",
-      "unstyled-html": "Unstyled HTML",
-      "markdown-file": "Markdown file",
-      "print": "Print"
-    },
-    "import": {
-      "clipboard": "Clipboard",
-      "file": "Markdown file"
+      "common": {
+        "authentication": "Authentication",
+        "accessToken": "Access token",
+        "description": "Description"
+      }
     },
     "autocompletions": {
       "link": "Link",

--- a/frontend/src/components/editor-page/sidebar/sidebar.tsx
+++ b/frontend/src/components/editor-page/sidebar/sidebar.tsx
@@ -6,7 +6,7 @@
 import { AliasesSidebarEntry } from './specific-sidebar-entries/aliases-sidebar-entry/aliases-sidebar-entry'
 import { DeleteNoteSidebarEntry } from './specific-sidebar-entries/delete-note-sidebar-entry/delete-note-sidebar-entry'
 import { ExportSidebarMenu } from './specific-sidebar-entries/export-sidebar-menu/export-sidebar-menu'
-import { ImportMenuSidebarMenu } from './specific-sidebar-entries/import-menu-sidebar-menu'
+import { ImportMenuSidebarMenu } from './specific-sidebar-entries/import-sidebar-menu/import-menu-sidebar-menu'
 import { MediaBrowserSidebarMenu } from './specific-sidebar-entries/media-browser-sidebar-menu/media-browser-sidebar-menu'
 import { NoteInfoSidebarMenu } from './specific-sidebar-entries/note-info-sidebar-menu/note-info-sidebar-menu'
 import { PermissionsSidebarEntry } from './specific-sidebar-entries/permissions-sidebar-entry/permissions-sidebar-entry'

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/build-append-content-formatter.spec.ts
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/build-append-content-formatter.spec.ts
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { buildAppendContentFormatter } from './build-append-content-formatter'
+
+describe('buildAppendContentFormatter', () => {
+  it('appends content with a separator to an existing note', () => {
+    const formatter = buildAppendContentFormatter('imported')
+
+    expect(formatter({ markdownContent: 'existing', currentSelection: { from: 0, to: 0 } })).toEqual([
+      [{ from: 8, to: 8, insert: '\nimported' }],
+      undefined
+    ])
+  })
+
+  it('does not add a separator to an empty note', () => {
+    const formatter = buildAppendContentFormatter('imported')
+
+    expect(formatter({ markdownContent: '', currentSelection: { from: 0, to: 0 } })).toEqual([
+      [{ from: 0, to: 0, insert: 'imported' }],
+      undefined
+    ])
+  })
+})

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/build-append-content-formatter.ts
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/build-append-content-formatter.ts
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import type { ContentFormatter } from '../../change-content-context/use-change-editor-content-callback'
+
+/**
+ * Builds an editor formatter that appends imported content to a note.
+ *
+ * @param content Content to append.
+ * @returns Formatter that inserts the content at the end of the current document.
+ */
+export const buildAppendContentFormatter = (content: string): ContentFormatter => {
+  return ({ markdownContent }) => {
+    const contentWithSeparator = (markdownContent.length === 0 ? '' : '\n') + content
+    return [
+      [
+        {
+          from: markdownContent.length,
+          to: markdownContent.length,
+          insert: contentWithSeparator
+        }
+      ],
+      undefined
+    ]
+  }
+}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-gist-sidebar-entry/export-gist-modal.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-gist-sidebar-entry/export-gist-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -32,18 +32,19 @@ export const ExportGistModal: React.FC<ModalVisibilityProps> = ({ show, onHide }
 
   const { dispatchUiNotification, showErrorNotificationBuilder } = useUiNotifications()
 
-  const textService = useTranslatedText('editor.export.gist.service')
-  const textShortName = useTranslatedText('editor.export.gist.shortName')
-  const textModalTitle = useTranslatedText('editor.export.common.title', { replace: { service: textService } })
-  const textCreateButton = useTranslatedText('editor.export.common.createButton', {
+  const textService = useTranslatedText('editor.importExport.service.gist.name')
+  const textShortName = useTranslatedText('editor.importExport.service.gist.shortName')
+  const textModalTitle = useTranslatedText('editor.importExport.export.title', { replace: { service: textService } })
+  const textCreateButton = useTranslatedText('editor.importExport.export.createButton', {
     replace: { shortName: textShortName }
   })
-  const textNotificationButton = useTranslatedText('editor.export.common.notificationSuccessButton', {
+  const textNotificationButton = useTranslatedText('editor.importExport.export.notificationSuccessButton', {
     replace: {
       shortName: textShortName
     }
   })
-  const textFieldPublic = useTranslatedText('editor.export.gist.fieldPublic')
+  const textFieldPublic = useTranslatedText('editor.importExport.service.gist.makePublic')
+  const textTokenLink = useTranslatedText('editor.importExport.service.gist.tokenLink')
 
   const [ghToken, setGhToken] = useState('')
   const [gistDescription, setGistDescription] = useState('')
@@ -59,8 +60,8 @@ export const ExportGistModal: React.FC<ModalVisibilityProps> = ({ show, onHide }
     createGist(ghToken, noteContent, gistDescription, noteFilename, gistPublic)
       .then((gistUrl) => {
         dispatchUiNotification(
-          'editor.export.common.notificationSuccessTitle',
-          'editor.export.common.notificationSuccessMessage',
+          'editor.importExport.export.notificationSuccessTitle',
+          'editor.importExport.export.notificationSuccessMessage',
           {
             durationInSecond: 30,
             icon: Github,
@@ -77,7 +78,7 @@ export const ExportGistModal: React.FC<ModalVisibilityProps> = ({ show, onHide }
       })
       .catch(
         showErrorNotificationBuilder(
-          'editor.export.common.notificationErrorTitle',
+          'editor.importExport.export.notificationErrorTitle',
           { replace: { shortName: textShortName } },
           true
         )
@@ -100,27 +101,24 @@ export const ExportGistModal: React.FC<ModalVisibilityProps> = ({ show, onHide }
     <CommonModal show={show} onHide={onHide} title={textModalTitle} showCloseButton={true} titleIcon={Github}>
       <Modal.Body>
         <h5 className={'mb-2'}>
-          <Trans i18nKey={'editor.export.common.headingAuthentication'} />
+          <Trans i18nKey={'editor.importExport.common.authentication'} />
         </h5>
         <FormGroup className={'my-2'}>
           <FormLabel>
-            <Trans i18nKey={'editor.export.common.fieldToken'} />
+            <Trans i18nKey={'editor.importExport.common.accessToken'} />
           </FormLabel>
           <FormControl value={ghToken} onChange={onGhTokenChange} type={'password'} isInvalid={!ghTokenFormatValid} />
           <FormText muted={true}>
-            <Trans i18nKey={'editor.export.gist.infoToken'} />{' '}
-            <ExternalLink
-              text={'https://github.com/settings/personal-access-tokens/new'}
-              href={'https://github.com/settings/personal-access-tokens/new'}
-            />
+            <Trans i18nKey={'editor.importExport.service.gist.infoToken'} />{' '}
+            <ExternalLink text={textTokenLink} href={'https://github.com/settings/personal-access-tokens/new'} />
           </FormText>
         </FormGroup>
         <h5 className={'mb-2 mt-4'}>
-          <Trans i18nKey={'editor.export.common.headingSettings'} />
+          <Trans i18nKey={'editor.importExport.export.settings'} />
         </h5>
         <FormGroup className={'my-2'}>
           <FormLabel>
-            <Trans i18nKey={'editor.export.common.fieldDescription'} />
+            <Trans i18nKey={'editor.importExport.common.description'} />
           </FormLabel>
           <FormControl value={gistDescription} onChange={onGistDescriptionChange} type={'text'} />
         </FormGroup>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-gist-sidebar-entry/export-gist-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-gist-sidebar-entry/export-gist-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -20,7 +20,7 @@ export const ExportGistSidebarEntry: React.FC = () => {
   return (
     <Fragment>
       <SidebarButton icon={IconGithub} onClick={setShowModal}>
-        <Trans i18nKey={'editor.export.gist.service'} />
+        <Trans i18nKey={'editor.importExport.service.gist.name'} />
       </SidebarButton>
       <ExportGistModal show={showModal} onHide={setHideModal} />
     </Fragment>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-gitlab-snippet-sidebar-entry/export-gitlab-snippet-modal.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-gitlab-snippet-sidebar-entry/export-gitlab-snippet-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -39,14 +39,14 @@ export const ExportGitlabSnippetModal: React.FC<ModalVisibilityProps> = ({ show,
   const [snippetVisibility, setSnippetVisibility] = useState<GitlabSnippetVisibility>(GitlabSnippetVisibility.PRIVATE)
   const [snippetDescription, setSnippetDescription] = useState<string>('')
 
-  const textService = useTranslatedText('editor.export.gitlab.service')
-  const textShortName = useTranslatedText('editor.export.gitlab.shortName')
-  const textModalTitle = useTranslatedText('editor.export.common.title', { replace: { service: textService } })
-  const textTokenLink = useTranslatedText('editor.export.gitlab.infoTokenLink')
-  const textCreateButton = useTranslatedText('editor.export.common.createButton', {
+  const textService = useTranslatedText('editor.importExport.service.gitlab.name')
+  const textShortName = useTranslatedText('editor.importExport.service.gitlab.shortName')
+  const textModalTitle = useTranslatedText('editor.importExport.export.title', { replace: { service: textService } })
+  const textTokenLink = useTranslatedText('editor.importExport.service.gitlab.tokenLink')
+  const textCreateButton = useTranslatedText('editor.importExport.export.createButton', {
     replace: { shortName: textShortName }
   })
-  const textNotificationButton = useTranslatedText('editor.export.common.notificationSuccessButton', {
+  const textNotificationButton = useTranslatedText('editor.importExport.export.notificationSuccessButton', {
     replace: {
       shortName: textShortName
     }
@@ -67,8 +67,8 @@ export const ExportGitlabSnippetModal: React.FC<ModalVisibilityProps> = ({ show,
     createSnippet(gitlabUrl, gitlabToken, noteContent, noteTitle, snippetDescription, noteFilename, snippetVisibility)
       .then((snippetUrl) => {
         dispatchUiNotification(
-          'editor.export.common.notificationSuccessTitle',
-          'editor.export.common.notificationSuccessMessage',
+          'editor.importExport.export.notificationSuccessTitle',
+          'editor.importExport.export.notificationSuccessMessage',
           {
             durationInSecond: 30,
             icon: Github,
@@ -85,7 +85,7 @@ export const ExportGitlabSnippetModal: React.FC<ModalVisibilityProps> = ({ show,
       })
       .catch(
         showErrorNotificationBuilder(
-          'editor.export.common.notificationErrorTitle',
+          'editor.importExport.export.notificationErrorTitle',
           { replace: { shortName: textShortName } },
           true
         )
@@ -110,17 +110,17 @@ export const ExportGitlabSnippetModal: React.FC<ModalVisibilityProps> = ({ show,
     <CommonModal show={show} onHide={onHide} title={textModalTitle} showCloseButton={true} titleIcon={IconGitlab}>
       <Modal.Body>
         <h5 className={'mb-2'}>
-          <Trans i18nKey={'editor.export.common.headingAuthentication'} />
+          <Trans i18nKey={'editor.importExport.common.authentication'} />
         </h5>
         <FormGroup className={'my-2'}>
           <FormLabel>
-            <Trans i18nKey={'editor.export.gitlab.fieldUrl'} />
+            <Trans i18nKey={'editor.importExport.service.gitlab.instanceUrl'} />
           </FormLabel>
           <FormControl value={gitlabUrl} onChange={changeGitlabUrl} type={'url'} placeholder={'https://gitlab.com'} />
         </FormGroup>
         <FormGroup className={'my-2'}>
           <FormLabel>
-            <Trans i18nKey={'editor.export.common.fieldToken'} />
+            <Trans i18nKey={'editor.importExport.common.accessToken'} />
           </FormLabel>
           <FormControl
             value={gitlabToken}
@@ -129,7 +129,7 @@ export const ExportGitlabSnippetModal: React.FC<ModalVisibilityProps> = ({ show,
             isInvalid={gitlabToken === ''}
           />
           <FormText muted={true}>
-            <Trans i18nKey={'editor.export.gitlab.infoToken'} />{' '}
+            <Trans i18nKey={'editor.importExport.service.gitlab.infoToken'} />{' '}
             <ExternalLink
               text={textTokenLink}
               href={`${gitlabUrl ?? 'https://gitlab.com'}/-/user_settings/personal_access_tokens?name=HedgeDoc+snippet+export&scopes=api`}
@@ -137,27 +137,27 @@ export const ExportGitlabSnippetModal: React.FC<ModalVisibilityProps> = ({ show,
           </FormText>
         </FormGroup>
         <h5 className={'mb-2 mt-4'}>
-          <Trans i18nKey={'editor.export.common.headingSettings'} />
+          <Trans i18nKey={'editor.importExport.export.settings'} />
         </h5>
         <FormGroup className={'my-2'}>
           <FormLabel>
-            <Trans i18nKey={'editor.export.common.fieldDescription'} />
+            <Trans i18nKey={'editor.importExport.common.description'} />
           </FormLabel>
           <FormControl value={snippetDescription} onChange={changeSnippetDescription} type={'text'} />
         </FormGroup>
         <FormGroup className={'mt-2'}>
           <FormLabel>
-            <Trans i18nKey={'editor.export.gitlab.fieldVisibility'} />
+            <Trans i18nKey={'editor.importExport.service.gitlab.setVisibility'} />
           </FormLabel>
           <FormControl as={'select'} value={snippetVisibility} onChange={changeSnippetVisibility}>
             <option value={GitlabSnippetVisibility.PRIVATE}>
-              <Trans i18nKey={'editor.export.gitlab.visibility.private'} />
+              <Trans i18nKey={'editor.importExport.service.gitlab.visibility.private'} />
             </option>
             <option value={GitlabSnippetVisibility.INTERNAL}>
-              <Trans i18nKey={'editor.export.gitlab.visibility.internal'} />
+              <Trans i18nKey={'editor.importExport.service.gitlab.visibility.internal'} />
             </option>
             <option value={GitlabSnippetVisibility.PUBLIC}>
-              <Trans i18nKey={'editor.export.gitlab.visibility.public'} />
+              <Trans i18nKey={'editor.importExport.service.gitlab.visibility.public'} />
             </option>
           </FormControl>
         </FormGroup>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-gitlab-snippet-sidebar-entry/export-gitlab-snippet-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-gitlab-snippet-sidebar-entry/export-gitlab-snippet-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -20,7 +20,7 @@ export const ExportGitlabSnippetSidebarEntry: React.FC = () => {
   return (
     <Fragment>
       <SidebarButton icon={IconGitlab} onClick={setShowModal}>
-        <Trans i18nKey={'editor.export.gitlab.service'} />
+        <Trans i18nKey={'editor.importExport.service.gitlab.name'} />
       </SidebarButton>
       <ExportGitlabSnippetModal show={showModal} onHide={setHideModal} />
     </Fragment>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-html-sidebar-entries/export-styled-html-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-html-sidebar-entries/export-styled-html-sidebar-entry.tsx
@@ -19,7 +19,7 @@ export const ExportStyledHtmlSidebarEntry: React.FC = () => {
 
   return (
     <SidebarButton onClick={onClick} icon={IconFileEarmarkRichtext}>
-      <Trans i18nKey={'editor.export.styled-html'} />
+      <Trans i18nKey={'editor.importExport.service.styled-html'} />
     </SidebarButton>
   )
 }

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-html-sidebar-entries/export-unstyled-html-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-html-sidebar-entries/export-unstyled-html-sidebar-entry.tsx
@@ -19,7 +19,7 @@ export const ExportUnstyledHtmlSidebarEntry: React.FC = () => {
 
   return (
     <SidebarButton onClick={onClick} icon={IconFileEarmarkCode}>
-      <Trans i18nKey={'editor.export.unstyled-html'} />
+      <Trans i18nKey={'editor.importExport.service.unstyled-html'} />
     </SidebarButton>
   )
 }

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-markdown-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-markdown-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -29,7 +29,7 @@ export const ExportMarkdownSidebarEntry: React.FC = () => {
 
   return (
     <SidebarButton {...cypressId('menu-export-markdown')} onClick={onClick} icon={IconFileText}>
-      <Trans i18nKey={'editor.export.markdown-file'} />
+      <Trans i18nKey={'editor.importExport.service.markdown'} />
     </SidebarButton>
   )
 }

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-print-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/entries/export-print-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -18,7 +18,7 @@ export const ExportPrintSidebarEntry: React.FC = () => {
 
   return (
     <SidebarButton {...cypressId('menu-export-print')} onClick={printIframe} icon={IconPrinterFill}>
-      <Trans i18nKey={'editor.export.print'} />
+      <Trans i18nKey={'editor.importExport.service.print'} />
     </SidebarButton>
   )
 }

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/export-sidebar-menu.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/export-sidebar-menu/export-sidebar-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -48,13 +48,12 @@ export const ExportSidebarMenu: React.FC<SpecificSidebarMenuProps> = ({
         icon={expand ? IconArrowLeft : IconCloudDownload}
         className={concatCssClasses(className, { [styles.main]: expand })}
         onClick={onClickHandler}>
-        <Trans i18nKey={'editor.documentBar.export'} />
+        <Trans i18nKey={'editor.importExport.export.button'} />
       </SidebarButton>
       <SidebarMenu expand={expand}>
         <ExportPrintSidebarEntry />
         <ExportMarkdownSidebarEntry />
         <ExportHtmlSidebarEntries />
-
         <ExportGistSidebarEntry />
         <ExportGitlabSnippetSidebarEntry />
       </SidebarMenu>

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gist/fetch-gist.spec.ts
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gist/fetch-gist.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { fetchGist } from './fetch-gist'
+
+describe('fetchGist', () => {
+  const mockResponse = (body: string, status = 200): Response => {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(JSON.parse(body) as unknown),
+      text: () => Promise.resolve(body)
+    } as Response
+  }
+
+  beforeEach(() => {
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('fetches the first file anonymously', async () => {
+    jest.mocked(global.fetch).mockResolvedValueOnce(
+      mockResponse(
+        JSON.stringify({
+          files: {
+            'first.md': { content: 'first' },
+            'second.md': { content: 'second' }
+          }
+        })
+      )
+    )
+
+    await expect(fetchGist('https://gist.github.com/user/abcdef', '')).resolves.toBe('first')
+    expect(global.fetch).toHaveBeenCalledWith('https://api.github.com/gists/abcdef', {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    })
+  })
+
+  it('uses the access token when provided', async () => {
+    jest
+      .mocked(global.fetch)
+      .mockResolvedValueOnce(mockResponse(JSON.stringify({ files: { 'note.md': { content: 'private' } } })))
+
+    await fetchGist('https://gist.github.com/user/abcdef', 'secret')
+
+    expect(global.fetch).toHaveBeenCalledWith('https://api.github.com/gists/abcdef', {
+      headers: expect.objectContaining({ Authorization: 'Bearer secret' })
+    })
+  })
+
+  it('retrieves complete content for a truncated first file', async () => {
+    jest
+      .mocked(global.fetch)
+      .mockResolvedValueOnce(
+        mockResponse(
+          JSON.stringify({
+            files: {
+              'note.md': { content: 'partial', truncated: true, raw_url: 'https://gist.githubusercontent.com/raw' }
+            }
+          })
+        )
+      )
+      .mockResolvedValueOnce(mockResponse('complete'))
+
+    await expect(fetchGist('https://gist.github.com/user/abcdef', '')).resolves.toBe('complete')
+    expect(global.fetch).toHaveBeenLastCalledWith('https://gist.githubusercontent.com/raw')
+  })
+
+  it('rejects non-Gist URLs', async () => {
+    await expect(fetchGist('https://example.com/user/abcdef', '')).rejects.toThrow(
+      'Enter a complete gist.github.com URL'
+    )
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gist/fetch-gist.ts
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gist/fetch-gist.ts
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+interface GistFile {
+  content?: string
+  raw_url?: string
+  truncated?: boolean
+}
+
+interface GistResponse {
+  files?: Record<string, GistFile | null>
+}
+
+/**
+ * Parses the given GitHub Gist URL to extract the gist ID from it.
+ *
+ * @param gistUrl The GitHub Gist URL to parse
+ * @returns The found Gist ID
+ * @throws Error if the URL is not valid or not a plausible Gist URL
+ */
+const parseGistId = (gistUrl: string): string => {
+  let url: URL
+  try {
+    url = new URL(gistUrl)
+  } catch {
+    throw new Error('The Gist URL is invalid')
+  }
+
+  const pathParts = url.pathname.split('/').filter(Boolean)
+  if (url.protocol !== 'https:' || url.hostname !== 'gist.github.com' || pathParts.length !== 2) {
+    throw new Error('Enter a complete gist.github.com URL')
+  }
+  return pathParts[1]
+}
+
+/**
+ * Fetches the first file from a GitHub Gist.
+ *
+ * @param gistUrl Public URL of the Gist.
+ * @param token Optional GitHub access token.
+ * @returns Content of the first file.
+ * @throws Error If the URL or GitHub response is invalid, or the request fails.
+ */
+export const fetchGist = async (gistUrl: string, token: string): Promise<string> => {
+  const gistId = parseGistId(gistUrl)
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28'
+  }
+  if (token !== '') {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  const response = await fetch(`https://api.github.com/gists/${encodeURIComponent(gistId)}`, { headers })
+  if (!response.ok) {
+    throw new Error(
+      response.status === 401
+        ? token === ''
+          ? 'An access token is required'
+          : 'The GitHub access token is invalid'
+        : 'The Gist could not be retrieved'
+    )
+  }
+
+  const gist = (await response.json()) as GistResponse
+  const firstFile = Object.values(gist.files ?? {}).find((file): file is GistFile => file !== null)
+  if (!firstFile) {
+    throw new Error('The Gist does not contain any files')
+  }
+
+  if (firstFile.truncated && firstFile.raw_url) {
+    const rawResponse = await fetch(firstFile.raw_url)
+    if (!rawResponse.ok) {
+      throw new Error('The complete Gist file could not be retrieved')
+    }
+    return rawResponse.text()
+  }
+  if (typeof firstFile.content !== 'string') {
+    throw new Error('The Gist response does not contain file content')
+  }
+  return firstFile.content
+}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gist/import-gist-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gist/import-gist-sidebar-entry.tsx
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useBooleanState } from '../../../../../../hooks/common/use-boolean-state'
+import { SidebarButton } from '../../../sidebar-button/sidebar-button'
+import React, { Fragment } from 'react'
+import { Github as IconGithub } from 'react-bootstrap-icons'
+import { Trans, useTranslation } from 'react-i18next'
+import { fetchGist } from './fetch-gist'
+import { ImportFromRemoteModal } from '../import-from-remote-modal'
+
+const buildGithubTokenProvisioningUrl = (): string =>
+  'https://github.com/settings/personal-access-tokens/new?name=HedgeDoc+snippet+import&description=Access+token+for+importing+HedgeDoc+notes+from+GitHub+Gist&gists=write'
+
+/**
+ * Renders the sidebar entry for importing a GitHub Gist.
+ */
+export const ImportGistSidebarEntry: React.FC = () => {
+  useTranslation()
+  const [showModal, setShowModal, setHideModal] = useBooleanState(false)
+
+  return (
+    <Fragment>
+      <SidebarButton icon={IconGithub} onClick={setShowModal}>
+        <Trans i18nKey={'editor.importExport.service.gist.name'} />
+      </SidebarButton>
+      <ImportFromRemoteModal
+        show={showModal}
+        onHide={setHideModal}
+        icon={IconGithub}
+        serviceI18nKey={'editor.importExport.service.gist.shortName'}
+        urlPlaceholder={'https://gist.github.com/user/gist-id'}
+        tokenProvisioningUrlI18nKey={'editor.importExport.service.gist.tokenLink'}
+        buildTokenProvisioningUrl={buildGithubTokenProvisioningUrl}
+        fetchContent={fetchGist}
+      />
+    </Fragment>
+  )
+}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gitlab-snippet/fetch-gitlab-snippet.spec.ts
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gitlab-snippet/fetch-gitlab-snippet.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { fetchGitlabSnippet } from './fetch-gitlab-snippet'
+
+describe('fetchGitlabSnippet', () => {
+  const mockResponse = (body: string, status = 200): Response => {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: () => Promise.resolve(body)
+    } as Response
+  }
+
+  beforeEach(() => {
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('fetches content through the API of a self-managed GitLab instance', async () => {
+    jest.mocked(global.fetch).mockResolvedValueOnce(mockResponse('first'))
+
+    await expect(fetchGitlabSnippet('https://gitlab.example.com/-/snippets/42', '')).resolves.toBe('first')
+    expect(global.fetch).toHaveBeenCalledWith('https://gitlab.example.com/api/v4/snippets/42/raw', { headers: {} })
+  })
+
+  it('uses the access token for raw content', async () => {
+    jest.mocked(global.fetch).mockResolvedValueOnce(mockResponse('private'))
+
+    await fetchGitlabSnippet('https://gitlab.com/-/snippets/42', 'secret')
+
+    expect(global.fetch).toHaveBeenCalledWith('https://gitlab.com/api/v4/snippets/42/raw', {
+      headers: { 'PRIVATE-TOKEN': 'secret' }
+    })
+  })
+
+  it('rejects URLs without a numeric snippet ID', async () => {
+    await expect(fetchGitlabSnippet('https://gitlab.com/-/snippets/not-an-id', '')).rejects.toThrow(
+      'Enter a complete GitLab snippet URL'
+    )
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gitlab-snippet/fetch-gitlab-snippet.ts
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gitlab-snippet/fetch-gitlab-snippet.ts
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+interface ParsedSnippetUrl {
+  instanceOrigin: string
+  snippetId: string
+}
+
+/**
+ * Parses the given GitLab snippet URL into GitLab instance origin and snippet id.
+ * For example: https://gitlab.fachschaften.org/-/snippets/123456 would become:
+ * origin: https://gitlab.fachschaften.org and snippet id: 123456
+ *
+ * @param snippetUrl The snippet URL to parse
+ * @returns The parsing result including origin and snippet id
+ * @throws Error if the URL is invalid or not a plausible GitLab snippet URL
+ */
+const parseSnippetUrl = (snippetUrl: string): ParsedSnippetUrl => {
+  let url: URL
+  try {
+    url = new URL(snippetUrl)
+  } catch {
+    throw new Error('The GitLab snippet URL is invalid')
+  }
+
+  const pathParts = url.pathname.split('/').filter(Boolean)
+  const snippetsIndex = pathParts.lastIndexOf('snippets')
+  const snippetId = pathParts[snippetsIndex + 1]
+  if (
+    !['http:', 'https:'].includes(url.protocol) ||
+    url.username !== '' ||
+    url.password !== '' ||
+    snippetsIndex === -1 ||
+    !/^\d+$/.test(snippetId ?? '')
+  ) {
+    throw new Error('Enter a complete GitLab snippet URL')
+  }
+  return { instanceOrigin: url.origin, snippetId }
+}
+
+/**
+ * Fetches the first file from a GitLab snippet.
+ *
+ * @param snippetUrl Public URL of the snippet.
+ * @param token Optional GitLab access token.
+ * @returns Content of the first file.
+ * @throws Error If the URL or GitLab response is invalid, or a request fails.
+ */
+export const fetchGitlabSnippet = async (snippetUrl: string, token: string): Promise<string> => {
+  const { instanceOrigin, snippetId } = parseSnippetUrl(snippetUrl)
+  const headers: Record<string, string> = {}
+  if (token !== '') {
+    headers['PRIVATE-TOKEN'] = token
+  }
+
+  const response = await fetch(`${instanceOrigin}/api/v4/snippets/${encodeURIComponent(snippetId)}/raw`, { headers })
+  if (!response.ok) {
+    throw new Error(
+      response.status === 401 ? 'The GitLab access token is invalid' : 'The snippet could not be retrieved'
+    )
+  }
+  return response.text()
+}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gitlab-snippet/import-gitlab-snippet-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/gitlab-snippet/import-gitlab-snippet-sidebar-entry.tsx
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useBooleanState } from '../../../../../../hooks/common/use-boolean-state'
+import { IconGitlab } from '../../../../../common/icons/additional/icon-gitlab'
+import { SidebarButton } from '../../../sidebar-button/sidebar-button'
+import React, { Fragment } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import { fetchGitlabSnippet } from './fetch-gitlab-snippet'
+import { ImportFromRemoteModal } from '../import-from-remote-modal'
+
+const buildGitlabTokenProvisioningUrl = (snippetUrl: string): string => {
+  let instanceOrigin = 'https://gitlab.com'
+  try {
+    const url = new URL(snippetUrl)
+    if (['http:', 'https:'].includes(url.protocol)) {
+      instanceOrigin = url.origin
+    }
+  } catch {
+    // Use GitLab.com until a valid instance URL has been entered.
+  }
+  return `${instanceOrigin}/-/user_settings/personal_access_tokens?name=HedgeDoc+snippet+import&scopes=read_api`
+}
+
+/**
+ * Renders the sidebar entry for importing a GitLab snippet.
+ */
+export const ImportGitlabSnippetSidebarEntry: React.FC = () => {
+  useTranslation()
+  const [showModal, setShowModal, setHideModal] = useBooleanState(false)
+
+  return (
+    <Fragment>
+      <SidebarButton icon={IconGitlab} onClick={setShowModal}>
+        <Trans i18nKey={'editor.importExport.service.gitlab.name'} />
+      </SidebarButton>
+      <ImportFromRemoteModal
+        show={showModal}
+        onHide={setHideModal}
+        icon={IconGitlab}
+        serviceI18nKey={'editor.importExport.service.gitlab.shortName'}
+        urlPlaceholder={'https://gitlab.com/-/snippets/123'}
+        tokenProvisioningUrlI18nKey={'editor.importExport.service.gitlab.tokenLink'}
+        buildTokenProvisioningUrl={buildGitlabTokenProvisioningUrl}
+        fetchContent={fetchGitlabSnippet}
+      />
+    </Fragment>
+  )
+}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/import-from-remote-modal.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/import-from-remote-modal.tsx
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useUiNotifications } from '../../../../notifications/ui-notification-boundary'
+import { CommonModal, type ModalVisibilityProps } from '../../../../common/modals/common-modal'
+import { ExternalLink } from '../../../../common/links/external-link'
+import { useChangeEditorContentCallback } from '../../../change-content-context/use-change-editor-content-callback'
+import { buildAppendContentFormatter } from '../build-append-content-formatter'
+import { useOnInputChange } from '../../../../../hooks/common/use-on-input-change'
+import React, { useCallback, useState } from 'react'
+import { Button, FormControl, FormGroup, FormLabel, FormText, Modal } from 'react-bootstrap'
+import type { Icon } from 'react-bootstrap-icons'
+import { Trans, useTranslation } from 'react-i18next'
+import { useTranslatedText } from '../../../../../hooks/common/use-translated-text'
+
+interface ImportFromRemoteModalProps extends ModalVisibilityProps {
+  icon: Icon
+  serviceI18nKey: string
+  urlPlaceholder: string
+  tokenProvisioningUrlI18nKey: string
+  buildTokenProvisioningUrl: (url: string) => string
+  fetchContent: (url: string, token: string) => Promise<string>
+}
+
+/**
+ * Renders a modal for importing content from a remote code snippet service.
+ */
+export const ImportFromRemoteModal: React.FC<ImportFromRemoteModalProps> = ({
+  show,
+  onHide,
+  icon,
+  serviceI18nKey,
+  urlPlaceholder,
+  tokenProvisioningUrlI18nKey,
+  buildTokenProvisioningUrl,
+  fetchContent
+}) => {
+  const { t } = useTranslation()
+  const changeEditorContent = useChangeEditorContentCallback()
+  const { dispatchUiNotification, showErrorNotificationBuilder } = useUiNotifications()
+
+  const [url, setUrl] = useState('')
+  const [token, setToken] = useState('')
+  const [importing, setImporting] = useState(false)
+
+  const changeUrl = useOnInputChange(setUrl)
+  const changeToken = useOnInputChange(setToken)
+
+  const service = useTranslatedText(serviceI18nKey)
+  const tokenProvisioningUrlText = useTranslatedText(tokenProvisioningUrlI18nKey)
+
+  const importSnippet = useCallback(() => {
+    setImporting(true)
+    fetchContent(url, token)
+      .then((content) => {
+        changeEditorContent?.(buildAppendContentFormatter(content))
+        dispatchUiNotification(
+          'editor.importExport.import.notificationSuccessTitle',
+          'editor.importExport.import.notificationSuccessMessage',
+          {
+            icon,
+            contentI18nOptions: { service }
+          }
+        )
+        setUrl('')
+        setToken('')
+        onHide?.()
+      })
+      .catch(showErrorNotificationBuilder('editor.importExport.import.notificationError', { service }, true))
+      .finally(() => setImporting(false))
+  }, [
+    changeEditorContent,
+    dispatchUiNotification,
+    fetchContent,
+    icon,
+    onHide,
+    service,
+    showErrorNotificationBuilder,
+    token,
+    url
+  ])
+
+  return (
+    <CommonModal
+      show={show}
+      onHide={onHide}
+      title={t('editor.importExport.import.title', { service })}
+      showCloseButton={true}
+      titleIcon={icon}>
+      <Modal.Body>
+        <FormGroup className={'my-2'}>
+          <FormLabel>
+            <Trans i18nKey={'editor.importExport.import.url'} />
+          </FormLabel>
+          <FormControl value={url} onChange={changeUrl} type={'url'} placeholder={urlPlaceholder} />
+        </FormGroup>
+        <FormGroup className={'my-2'}>
+          <FormLabel>
+            <Trans i18nKey={'editor.importExport.common.accessToken'} />
+          </FormLabel>
+          <FormControl value={token} onChange={changeToken} type={'password'} />
+          <FormText muted={true}>
+            <Trans i18nKey={'editor.importExport.import.anonymousImport'} />{' '}
+            <ExternalLink text={tokenProvisioningUrlText} href={buildTokenProvisioningUrl(url)} />
+          </FormText>
+        </FormGroup>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant={'success'} onClick={importSnippet} disabled={url === '' || importing || !changeEditorContent}>
+          <Trans i18nKey={'editor.importExport.import.button'} />
+        </Button>
+      </Modal.Footer>
+    </CommonModal>
+  )
+}

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/import-markdown-sidebar-entry.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/import-markdown-sidebar-entry.tsx
@@ -1,13 +1,14 @@
 /*
- * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { cypressId } from '../../../../utils/cypress-attribute'
-import { FileContentFormat, readFile } from '../../../../utils/read-file'
-import { UploadInput } from '../../../common/upload-input'
-import { useChangeEditorContentCallback } from '../../change-content-context/use-change-editor-content-callback'
-import { SidebarButton } from '../sidebar-button/sidebar-button'
+import { cypressId } from '../../../../../utils/cypress-attribute'
+import { FileContentFormat, readFile } from '../../../../../utils/read-file'
+import { UploadInput } from '../../../../common/upload-input'
+import { useChangeEditorContentCallback } from '../../../change-content-context/use-change-editor-content-callback'
+import { SidebarButton } from '../../sidebar-button/sidebar-button'
+import { buildAppendContentFormatter } from '../build-append-content-formatter'
 import React, { Fragment, useCallback, useRef } from 'react'
 import { FileText as IconFileText } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
@@ -22,19 +23,7 @@ export const ImportMarkdownSidebarEntry: React.FC = () => {
   const onImportMarkdown = useCallback(
     async (file: File): Promise<void> => {
       const content = await readFile(file, FileContentFormat.TEXT)
-      changeEditorContent?.(({ markdownContent }) => {
-        const newContent = (markdownContent.length === 0 ? '' : '\n') + content
-        return [
-          [
-            {
-              from: markdownContent.length,
-              to: markdownContent.length,
-              insert: newContent
-            }
-          ],
-          undefined
-        ]
-      })
+      changeEditorContent?.(buildAppendContentFormatter(content))
     },
     [changeEditorContent]
   )
@@ -51,7 +40,7 @@ export const ImportMarkdownSidebarEntry: React.FC = () => {
         icon={IconFileText}
         onClick={buttonClick}
         disabled={!changeEditorContent}>
-        <Trans i18nKey={'editor.import.file'} />
+        <Trans i18nKey={'editor.importExport.service.markdown'} />
       </SidebarButton>
       {changeEditorContent !== undefined && (
         <UploadInput

--- a/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/import-menu-sidebar-menu.tsx
+++ b/frontend/src/components/editor-page/sidebar/specific-sidebar-entries/import-sidebar-menu/import-menu-sidebar-menu.tsx
@@ -1,20 +1,21 @@
 /*
- * SPDX-FileCopyrightText: 2024 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { cypressId } from '../../../../utils/cypress-attribute'
-import { IconGitlab } from '../../../common/icons/additional/icon-gitlab'
-import { SidebarButton } from '../sidebar-button/sidebar-button'
-import { SidebarMenu } from '../sidebar-menu/sidebar-menu'
-import type { SpecificSidebarMenuProps } from '../types'
-import { DocumentSidebarMenuSelection } from '../types'
+import { cypressId } from '../../../../../utils/cypress-attribute'
+import { SidebarButton } from '../../sidebar-button/sidebar-button'
+import { SidebarMenu } from '../../sidebar-menu/sidebar-menu'
+import type { SpecificSidebarMenuProps } from '../../types'
+import { DocumentSidebarMenuSelection } from '../../types'
+import { ImportGistSidebarEntry } from './gist/import-gist-sidebar-entry'
+import { ImportGitlabSnippetSidebarEntry } from './gitlab-snippet/import-gitlab-snippet-sidebar-entry'
 import { ImportMarkdownSidebarEntry } from './import-markdown-sidebar-entry'
 import React, { Fragment, useCallback } from 'react'
-import { ArrowLeft as IconArrowLeft, CloudUpload as IconCloudUpload, Github as IconGithub } from 'react-bootstrap-icons'
+import { ArrowLeft as IconArrowLeft, CloudUpload as IconCloudUpload } from 'react-bootstrap-icons'
 import { Trans, useTranslation } from 'react-i18next'
-import styles from '../sidebar-button/sidebar-button.module.scss'
-import { concatCssClasses } from '../../../../utils/concat-css-classes'
+import styles from '../../sidebar-button/sidebar-button.module.scss'
+import { concatCssClasses } from '../../../../../utils/concat-css-classes'
 
 /**
  * Renders the import menu for the sidebar.
@@ -45,15 +46,11 @@ export const ImportMenuSidebarMenu: React.FC<SpecificSidebarMenuProps> = ({
         icon={expand ? IconArrowLeft : IconCloudUpload}
         className={concatCssClasses(className, { [styles.main]: expand })}
         onClick={onClickHandler}>
-        <Trans i18nKey={'editor.documentBar.import'} />
+        <Trans i18nKey={'editor.importExport.import.button'} />
       </SidebarButton>
       <SidebarMenu expand={expand}>
-        <SidebarButton icon={IconGithub} disabled={true}>
-          Gist
-        </SidebarButton>
-        <SidebarButton icon={IconGitlab} disabled={true}>
-          Gitlab Snippet
-        </SidebarButton>
+        <ImportGistSidebarEntry />
+        <ImportGitlabSnippetSidebarEntry />
         <ImportMarkdownSidebarEntry />
       </SidebarMenu>
     </Fragment>


### PR DESCRIPTION
### Component/Part
import/export

### Description
This PR adds the implementation for the missing GitHub Gist and GitLab snippet import.
It restructures the import and export section of the translations to reduce duplicates.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #6481

### Screenshots

<img width="780" height="598" alt="image" src="https://github.com/user-attachments/assets/ed1a461c-f93c-43d5-b2c2-e016ec9a4b1a" />
