### PR TITLE
fix(external-links): open in new tab even on published/slide view

### DIFF
--- a/public/docs/release-notes.md
+++ b/public/docs/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## <i class="fa fa-tag"></i> UNRELEASED
+
+### Bugfixes
+
+- Fixed opening links in new tabs did not work for published and slideshow views. This was forgotten with the last fix in 1.12.0.
+
 ## <i class="fa fa-tag"></i> 1.12.0 <i class="fa fa-calendar-o"></i> 2026-08-21
 
 ### Important changes

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -574,8 +574,6 @@ export function postProcess (code) {
     currentLocation.hash = linkTag.hash
     linkTag.href = currentLocation.toString()
   })
-  rewriteExternalLinks(result)
-
   // update continue line numbers
   const linenumberdivs = result.find('.gutter.linenumber').toArray()
   for (let i = 0; i < linenumberdivs.length; i++) {

--- a/public/js/pretty.js
+++ b/public/js/pretty.js
@@ -10,6 +10,7 @@ import {
   parseMeta,
   postProcess,
   renderTOC,
+  rewriteExternalLinks,
   scrollToHash,
   smoothHashScroll,
   updateLastChange
@@ -55,6 +56,7 @@ if (md.meta.type && md.meta.type === 'slide') {
   rendered = preventXSS(rendered)
   const result = postProcess(rendered)
   markdown.html(result.html())
+  rewriteExternalLinks(markdown)
 }
 $(document.body).show()
 

--- a/public/js/reveal-markdown.js
+++ b/public/js/reveal-markdown.js
@@ -323,6 +323,7 @@ import { md } from './extra'
         rendered = preventXSS(rendered)
         const result = window.postProcess(rendered)
         section.innerHTML = result[0].outerHTML
+        window.rewriteExternalLinks(window.$(section))
         addAttributes(section, section, null, section.getAttribute('data-element-attributes') ||
         section.parentNode.getAttribute('data-element-attributes') ||
         DEFAULT_ELEMENT_ATTRIBUTES_SEPARATOR,


### PR DESCRIPTION
### Component/Part
renderer in published and slideshow mode

### Description
Links should open in a new tab.
This was previously fixed and implemented for the renderer in the editor but not the /s/:noteId and /p/:noteId URL routes. Since they serialize and deserialize the HTML once, the event listener is lost when initialized in before and needs to be triggered explicitly after the deserialization.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added changelog snippet
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #6735 
