### PR TITLE
fix(database): widen session.oidc_id_token to text, varchar(255) is too small

### DIFF
--- a/backend/src/database/migrations/20250312211152_initial.js
+++ b/backend/src/database/migrations/20250312211152_initial.js
@@ -448,7 +448,7 @@ const up = async function (knex) {
       )
       .nullable();
     table.string(FieldNameSession.loginAuthProviderIdentifier).nullable();
-    table.string(FieldNameSession.oidcIdToken).nullable();
+    table.text(FieldNameSession.oidcIdToken).nullable();
     table.string(FieldNameSession.oidcSid).nullable();
     table.string(FieldNameSession.oidcLoginState).nullable();
     table.string(FieldNameSession.oidcLoginCode).nullable();


### PR DESCRIPTION
OIDC login fails on the session upsert:

```
value too long for type character varying(255)
```

`table.string(FieldNameSession.oidcIdToken)` defaults to `varchar(255)`. At least the OIDC ID tokens my IdP issues (JWTs with `profile`/`email` claims) routinely exceed that. `.text()` instead, matching `pendingUserData` in the same table.

2.x has no stable release and no migration path from 1.x yet, so this edits the initial migration directly rather than adding a new one.
