### PR TITLE
fix(docker): copy dist/package.json into the backend image

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -65,6 +65,7 @@ COPY --chown=node --from=prod-dependencies /usr/src/app/node_modules ./node_modu
 
 COPY --chown=node backend/package.json backend/package.json
 COPY --chown=node --from=builder /usr/src/app/backend/dist/src backend/dist
+COPY --chown=node --from=builder /usr/src/app/backend/dist/package.json backend/dist/package.json
 COPY --chown=node backend/public backend/public
 
 COPY --chown=node database/package.json /usr/src/app/database/package.json


### PR DESCRIPTION
`build.sh` marks the compiled backend output as CommonJS by writing `dist/package.json` (the workspace is `"type": "module"`, but `tsconfig.build.json` compiles to CommonJS). The Dockerfile only copies `dist/src`'s contents into the final image, never that file - so `dist/main.js` gets misread as ESM via the parent `package.json`, and every container crashes on startup:

```
ReferenceError: exports is not defined in ES module scope
```

I have build & verified the fix locally: - now fails on normal config validation (`HD_BASE_URL: Required`) instead of the module-loading crash.
