### PR TITLE
fix(auth): two session races that break first-time OIDC login

### DIFF
--- a/backend/src/api/private/auth/auth.controller.ts
+++ b/backend/src/api/private/auth/auth.controller.ts
@@ -95,6 +95,8 @@ export class AuthController {
       request.session.pendingUser.authProviderIdentifier;
     // Cleanup
     request.session.pendingUser = null;
+    // See OidcController.loginWithOpenIdConnect().
+    await request.session.save();
   }
 
   @Delete('pending-user')

--- a/backend/src/api/private/auth/oidc/oidc.controller.ts
+++ b/backend/src/api/private/auth/oidc/oidc.controller.ts
@@ -45,10 +45,10 @@ export class OidcController {
   @Get(':oidcIdentifier')
   @Redirect()
   @OpenApi(201, 400, 401, 429)
-  loginWithOpenIdConnect(
+  async loginWithOpenIdConnect(
     @Req() request: RequestWithSession,
     @Param('oidcIdentifier') oidcIdentifier: string,
-  ): { url: string } {
+  ): Promise<{ url: string }> {
     const code = this.oidcService.generateCode();
     const state = this.oidcService.generateState();
     request.session.oidc = {
@@ -62,6 +62,9 @@ export class OidcController {
       authProviderIdentifier: oidcIdentifier,
     };
     const authorizationUrl = this.oidcService.getAuthorizationUrl(oidcIdentifier, code, state);
+    // Persist before redirecting - the async onSend save otherwise races
+    // @Redirect()'s response and can crash with ERR_HTTP_HEADERS_SENT.
+    await request.session.save();
     return { url: authorizationUrl };
   }
 
@@ -86,6 +89,8 @@ export class OidcController {
       const mayUpdate = this.identityService.mayUpdateIdentity(oidcIdentifier);
 
       if (identity === null) {
+        // See loginWithOpenIdConnect() above.
+        await request.session.save();
         return { url: '/new-user' };
       }
 
@@ -103,6 +108,7 @@ export class OidcController {
       request.session.loginAuthProviderType = AuthProviderType.OIDC;
       request.session.loginAuthProviderIdentifier = oidcIdentifier;
       request.session.pendingUser = null;
+      await request.session.save();
       return { url: '/' };
     } catch (error) {
       if (error instanceof HttpException) {

--- a/backend/src/api/private/auth/oidc/oidc.controller.ts
+++ b/backend/src/api/private/auth/oidc/oidc.controller.ts
@@ -42,6 +42,17 @@ export class OidcController {
     this.logger.setContext(OidcController.name);
   }
 
+  // These GET endpoints have side effects (session mutation), so reject
+  // anything that isn't a real navigation - avoids double-firing from
+  // client-side link prefetching. Only rejects on a positive mismatch.
+  private assertTopLevelNavigation(request: RequestWithSession): void {
+    const mode = request.headers['sec-fetch-mode'];
+    const dest = request.headers['sec-fetch-dest'];
+    if ((mode !== undefined && mode !== 'navigate') || (dest !== undefined && dest !== 'document')) {
+      throw new BadRequestException('This endpoint must be reached via a real browser navigation');
+    }
+  }
+
   @Get(':oidcIdentifier')
   @Redirect()
   @OpenApi(201, 400, 401, 429)
@@ -49,6 +60,7 @@ export class OidcController {
     @Req() request: RequestWithSession,
     @Param('oidcIdentifier') oidcIdentifier: string,
   ): Promise<{ url: string }> {
+    this.assertTopLevelNavigation(request);
     const code = this.oidcService.generateCode();
     const state = this.oidcService.generateState();
     request.session.oidc = {
@@ -76,6 +88,7 @@ export class OidcController {
     @Req() request: RequestWithSession,
   ): Promise<{ url: string }> {
     try {
+      this.assertTopLevelNavigation(request);
       const userInfo = await this.oidcService.extractUserInfoFromCallback(oidcIdentifier, request);
       const oidcUserIdentifier = request.session.pendingUser?.providerUserId;
       if (!oidcUserIdentifier) {


### PR DESCRIPTION
Two related bugs in the OIDC login flow, found setting up a HedgeDoc 2.x deployment behind OIDC. Both cause first-time signup to intermittently fail with "There was an error creating your user account."

1. `OidcController` handlers mutate `request.session` then return via `@Redirect()`. `@fastify/session` persists the session asynchronously in an `onSend` hook that can still be in flight when the redirect completes, then crashes with `ERR_HTTP_HEADERS_SENT` trying to write headers twice. Fixed by explicitly `await`ing `request.session.save()` before returning, matching the pattern `AuthController.logout()` already uses.

2. `GET /auth/oidc/:id` and its `/callback` have side effects (session mutation) on what's nominally a safe/idempotent GET. Next.js's App Router speculatively fetches same-origin links in the background before falling back to a real navigation on failure - so the handler runs twice per click, each write racing the other. Confirmed directly by watching the `session` table while reproducing against a real Keycloak instance. Fixed by rejecting requests that aren't a genuine top-level navigation, using the `Sec-Fetch-Mode`/`Sec-Fetch-Dest` headers browsers set for exactly this distinction.

I have only tested this in my OIDC-only setup, though.
