### PR TITLE
fix(frontend): don't let guest registration failure block the whole app

### DIFF
--- a/frontend/src/components/application-loader/initializers/login-or-register-guest.ts
+++ b/frontend/src/components/application-loader/initializers/login-or-register-guest.ts
@@ -29,8 +29,15 @@ export const loginOrRegisterGuest = async (ignoreSavedUuid?: boolean): Promise<v
   }
   const guestUuid = ignoreSavedUuid ? null : window.localStorage.getItem('guestUuid')
   if (guestUuid === null) {
-    const { uuid } = await registerGuest()
-    window.localStorage.setItem('guestUuid', uuid)
+    try {
+      const { uuid } = await registerGuest()
+      window.localStorage.setItem('guestUuid', uuid)
+    } catch (error: unknown) {
+      if (error instanceof RateLimitError) {
+        throw error
+      }
+      logger.error('Error registering guest user', error)
+    }
     return
   }
   logInGuest(guestUuid)


### PR DESCRIPTION
The mandatory "Register or login guest user" startup task treats any uncaught failure as fatal - `application-loader.tsx` halts the whole task loop and renders only the error screen, permanently, for every visitor.

The returning-guest path (`logInGuest(...).catch(...)`) already handles this correctly. The first-time-visitor path didn't, so e.g. `HD_NOTE_PERMISSIONS_MAX_GUEST_LEVEL=deny` (a documented, schema-valid config value) makes the entire app unusable, including the login button.

Fix mirrors the existing pattern: log and continue on ordinary failures, only propagate `RateLimitError`.
