### PR TITLE
fix(docs): quickstart backend/frontend are unreachable from the proxy, stale DB var names

### DIFF
--- a/docs/content/files/setup-docker/config.env
+++ b/docs/content/files/setup-docker/config.env
@@ -1,17 +1,18 @@
 # General settings
 HD_BASE_URL="https://md.example.com"
 HD_SESSION_SECRET="change_me_in_production"
+HD_BACKEND_BIND_IP="0.0.0.0"
 
 # Database settings
 HD_DATABASE_TYPE="postgres"
 HD_DATABASE_HOST="db"
 HD_DATABASE_PORT="5432"
 HD_DATABASE_NAME="hedgedoc"
-HD_DATABASE_USER="hedgedoc"
-HD_DATABASE_PASS="password"
+HD_DATABASE_USERNAME="hedgedoc"
+HD_DATABASE_PASSWORD="password"
 
 # Uploads
-HD_MEDIA_BACKEND="filesystem"
+HD_MEDIA_BACKEND_TYPE="filesystem"
 HD_MEDIA_BACKEND_FILESYSTEM_UPLOAD_PATH="uploads/"
 
 # Auth

--- a/docs/content/files/setup-docker/docker-compose.yml
+++ b/docs/content/files/setup-docker/docker-compose.yml
@@ -10,12 +10,13 @@ services:
     environment:
       HD_BASE_URL: "${HD_BASE_URL}"
       HD_INTERNAL_API_URL: http://backend:3000
+      HOSTNAME: "0.0.0.0"
 
   db:
     image: postgres:16
     environment:
-      POSTGRES_USER: "${HD_DATABASE_USER}"
-      POSTGRES_PASSWORD: "${HD_DATABASE_PASS}"
+      POSTGRES_USER: "${HD_DATABASE_USERNAME}"
+      POSTGRES_PASSWORD: "${HD_DATABASE_PASSWORD}"
       POSTGRES_DB: "${HD_DATABASE_NAME}"
     volumes:
       - hedgedoc_postgres:/var/lib/postgresql/data


### PR DESCRIPTION
Reproduced end to end: the three-file Docker quickstart doesn't work as published, because backend and frontend end up unreachable from the `proxy` container that's supposed to route to them.

- `HD_BACKEND_BIND_IP` defaults to `127.0.0.1` - refuses connections from other containers.
- Next's standalone server binds to whatever Docker's auto-injected `HOSTNAME` resolves to, not `0.0.0.0`, unless overridden.

Also `HD_DATABASE_USER`/`HD_DATABASE_PASS` and `HD_MEDIA_BACKEND` don't match the current schema (`HD_DATABASE_USERNAME`/`HD_DATABASE_PASSWORD`, `HD_MEDIA_BACKEND_TYPE`) - updated `docker-compose.yml`'s references to match.
