### PR TITLE
fix(frontend): cache config/motd fetches instead of refetching every request

### DIFF
--- a/frontend/src/api/config/index.ts
+++ b/frontend/src/api/config/index.ts
@@ -17,6 +17,8 @@ export const getConfig = async (baseUrl?: string): Promise<FrontendConfigInterfa
   if (isBuildTime) {
     return undefined
   }
-  const response = await new GetApiRequestBuilder<FrontendConfigInterface>('config', baseUrl).sendRequest()
+  const response = await new GetApiRequestBuilder<FrontendConfigInterface>('config', baseUrl)
+    .withCustomOptions({ next: { revalidate: 60 } })
+    .sendRequest()
   return response.asParsedJsonObject()
 }

--- a/frontend/src/components/global-dialogs/motd-modal/fetch-motd.ts
+++ b/frontend/src/components/global-dialogs/motd-modal/fetch-motd.ts
@@ -24,7 +24,8 @@ export const fetchMotd = async (baseUrl: string): Promise<MotdApiResponse | unde
   }
   const motdUrl = `${baseUrl}public/motd.md`
   const response = await fetch(motdUrl, {
-    ...defaultConfig
+    ...defaultConfig,
+    next: { revalidate: 60 }
   })
 
   if (response.status !== 200) {


### PR DESCRIPTION
I've been getting red lights on my Zabbix for my new 2.x test instance. :sweat_smile: 

RootLayout calls `getConfig()` and `fetchMotd()` unconditionally on every request it renders, including 404s, since it's the root layout for the whole `(editor)` segment. Neither is cached, and `getConfig()` throws on any non-2xx response.

That means a burst of unrelated traffic (e.g. scanner bots hitting random nonexistent paths, which any public site gets constantly) is enough backend API volume to trip the backend's own rate limiter, which then 500s the entire frontend for everyone until the window clears. Confirmed in production, correlated with external uptime monitoring flagging the site down during these bursts.

Both calls are only ever made from `RootLayout` (editor and render segments), so caching them shouldn't leave stale data anywhere else. Adds Next's fetch revalidation (60s) to both: the cache is shared across all requests to the instance, so at most one real backend call per minute per endpoint happens regardless of incoming request volume.

Fixes https://github.com/hedgedoc/hedgedoc/issues/6745