### PR TITLE
Show pretty error messages on the login page

### DIFF
--- a/backend/src/api/private/auth/oidc/oidc.controller.spec.ts
+++ b/backend/src/api/private/auth/oidc/oidc.controller.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { beforeEach, afterEach, describe, expect, it, jest } from '@jest/globals';
+import { UnauthorizedException } from '@nestjs/common';
+import { errors as oidcErrors } from 'openid-client';
+import { Mock } from 'ts-mockery';
+
+import type { IdentityService } from '../../../../auth/identity.service';
+import type { OidcService } from '../../../../auth/oidc/oidc.service';
+import type { ConsoleLoggerService } from '../../../../logger/console-logger.service';
+import type { UsersService } from '../../../../users/users.service';
+import type { RequestWithSession } from '../../../utils/request.type';
+import { OidcController } from './oidc.controller';
+
+describe('OidcController', () => {
+  let controller: OidcController;
+  let oidcService: OidcService;
+  let saveSession: jest.Mock<() => Promise<void>>;
+
+  saveSession = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  const mockRequest = Mock.of<RequestWithSession>({
+    headers: {
+      'sec-fetch-dest': 'document',
+      'sec-fetch-mode': 'navigate',
+    },
+    session: {
+      csrfToken: null,
+      loginAuthProviderIdentifier: null,
+      loginAuthProviderType: null,
+      oidc: {
+        idToken: null,
+        loginCode: 'code',
+        loginState: 'state',
+        sid: null,
+      },
+      pendingUser: {
+        authProviderIdentifier: 'test',
+      },
+      save: saveSession,
+      userId: null,
+    },
+  });
+
+  const expectSessionIsCleared = () => {
+    expect(mockRequest.session.pendingUser).toBeNull();
+    expect(mockRequest.session.oidc.loginCode).toBeNull();
+    expect(mockRequest.session.oidc.loginState).toBeNull();
+    expect(saveSession).toHaveBeenCalledTimes(1);
+  };
+
+  beforeEach(() => {
+    const logger = Mock.of<ConsoleLoggerService>({
+      error: jest.fn(),
+      log: jest.fn(),
+      setContext: jest.fn(),
+    });
+    const usersService = Mock.of<UsersService>({});
+    const identityService = Mock.of<IdentityService>({});
+    oidcService = Mock.of<OidcService>({
+      extractUserInfoFromCallback: jest.fn(),
+    });
+    controller = new OidcController(logger, usersService, identityService, oidcService);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('redirects provider errors with their description', async () => {
+    jest.spyOn(oidcService, 'extractUserInfoFromCallback').mockRejectedValue(
+      new oidcErrors.OPError({
+        error: 'access_denied',
+        error_description: 'The user cancelled the login',
+      }),
+    );
+
+    await expect(controller.callback('test', mockRequest)).resolves.toEqual({
+      url: '/login?error=provider&providerError=access_denied&providerDescription=The+user+cancelled+the+login',
+    });
+    expectSessionIsCleared();
+  });
+
+  it('redirects RP validation errors', async () => {
+    jest
+      .spyOn(oidcService, 'extractUserInfoFromCallback')
+      .mockRejectedValue(new oidcErrors.RPError({ message: 'state mismatch' }));
+
+    await expect(controller.callback('test', mockRequest)).resolves.toEqual({
+      url: '/login?error=invalid-response',
+    });
+    expectSessionIsCleared();
+  });
+
+  it('redirects expected callback errors', async () => {
+    jest
+      .spyOn(oidcService, 'extractUserInfoFromCallback')
+      .mockRejectedValue(new UnauthorizedException('Missing user identifier'));
+
+    await expect(controller.callback('test', mockRequest)).resolves.toEqual({
+      url: '/login?error=invalid-response',
+    });
+    expectSessionIsCleared();
+  });
+
+  it('redirects unexpected callback errors', async () => {
+    jest
+      .spyOn(oidcService, 'extractUserInfoFromCallback')
+      .mockRejectedValue(new Error('Database unavailable'));
+
+    await expect(controller.callback('test', mockRequest)).resolves.toEqual({
+      url: '/login?error=internal',
+    });
+    expectSessionIsCleared();
+  });
+});

--- a/backend/src/api/private/auth/oidc/oidc.controller.ts
+++ b/backend/src/api/private/auth/oidc/oidc.controller.ts
@@ -1,9 +1,9 @@
 /*
- * SPDX-FileCopyrightText: 2025 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { AuthProviderType } from '@hedgedoc/commons';
+import { AuthProviderType, AuthErrorCodes } from '@hedgedoc/commons';
 import { FieldNameIdentity } from '@hedgedoc/database';
 import {
   BadRequestException,
@@ -11,7 +11,6 @@ import {
   Controller,
   Get,
   HttpCode,
-  InternalServerErrorException,
   Param,
   Post,
   Redirect,
@@ -20,6 +19,7 @@ import {
 } from '@nestjs/common';
 import { HttpException } from '@nestjs/common/exceptions/http.exception';
 import { ApiTags } from '@nestjs/swagger';
+import { errors as oidcErrors } from 'openid-client';
 
 import { IdentityService } from '../../../../auth/identity.service';
 import { OidcService } from '../../../../auth/oidc/oidc.service';
@@ -90,8 +90,8 @@ export class OidcController {
     @Param('oidcIdentifier') oidcIdentifier: string,
     @Req() request: RequestWithSession,
   ): Promise<{ url: string }> {
+    this.assertTopLevelNavigation(request);
     try {
-      this.assertTopLevelNavigation(request);
       const userInfo = await this.oidcService.extractUserInfoFromCallback(oidcIdentifier, request);
       const oidcUserIdentifier = request.session.pendingUser?.providerUserId;
       if (!oidcUserIdentifier) {
@@ -127,11 +127,31 @@ export class OidcController {
       await request.session.save();
       return { url: '/' };
     } catch (error) {
-      if (error instanceof HttpException) {
-        throw error;
+      const errorParams = new URLSearchParams();
+      if (error instanceof oidcErrors.OPError) {
+        errorParams.set('error', AuthErrorCodes.PROVIDER);
+        if (error.error) {
+          errorParams.set('providerError', error.error);
+        }
+        if (error.error_description) {
+          errorParams.set('providerDescription', error.error_description);
+        }
+      } else if (error instanceof oidcErrors.RPError || error instanceof HttpException) {
+        errorParams.set('error', AuthErrorCodes.INVALID_RESPONSE);
+      } else {
+        errorParams.set('error', AuthErrorCodes.INTERNAL);
       }
-      this.logger.log('Error during OIDC callback: ' + String(error), 'callback');
-      throw new InternalServerErrorException();
+
+      this.logger.error(
+        'Error during OIDC callback: ' + String(error),
+        error instanceof Error ? error.stack : undefined,
+        'callback',
+      );
+      request.session.pendingUser = null;
+      request.session.oidc.loginCode = null;
+      request.session.oidc.loginState = null;
+      await request.session.save();
+      return { url: `/login?${errorParams.toString()}` };
     }
   }
 

--- a/commons/src/dtos/auth/auth-error-codes.enum.ts
+++ b/commons/src/dtos/auth/auth-error-codes.enum.ts
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+export enum AuthErrorCodes {
+  INTERNAL = 'internal',
+  PROVIDER = 'provider',
+  INVALID_RESPONSE = 'invalid-response',
+}

--- a/commons/src/dtos/auth/index.ts
+++ b/commons/src/dtos/auth/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -13,6 +13,7 @@ export * from './logout-response.dto.js'
 export * from './backchannel-logout.dto.js'
 export * from './pending-user-confirmation.dto.js'
 export * from './auth-provider-type.enum.js'
+export * from './auth-error-codes.enum.js'
 export * from './register.dto.js'
 export * from './update-password.dto.js'
 export * from './username-check.dto.js'

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -615,6 +615,12 @@
     "title": "Announcement"
   },
   "errors": {
+    "oidcLogin": {
+      "title": "Login failed",
+      "provider": "The identity provider could not complete the login.",
+      "invalidResponse": "The authentication response could not be verified. Please start the login again.",
+      "internal": "An unexpected error occurred while logging in. Please try again."
+    },
     "notFound": {
       "title": "Page not found",
       "description": "The requested page either does not exist or you don't have permission to access it."

--- a/frontend/src/app/(editor)/login/page.tsx
+++ b/frontend/src/app/(editor)/login/page.tsx
@@ -15,6 +15,7 @@ import { OneClickLoginCard } from '../../../components/login-page/one-click/one-
 import { GuestCard } from '../../../components/login-page/guest/guest-card'
 import { useIsLoggedIn } from '../../../hooks/common/use-is-logged-in'
 import { LoginLayout } from '../../../components/layout/login-layout'
+import { OidcLoginErrorCard } from '../../../components/login-page/oidc/oidc-login-error-card'
 
 /**
  * Renders the login page with different login methods.
@@ -28,6 +29,7 @@ const LoginPage: NextPage = () => {
 
   return (
     <LoginLayout>
+      <OidcLoginErrorCard />
       <GuestCard />
       <LocalLoginCard />
       <LdapLoginCards />

--- a/frontend/src/components/login-page/oidc/oidc-login-error-card.tsx
+++ b/frontend/src/components/login-page/oidc/oidc-login-error-card.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react'
+import { Card } from 'react-bootstrap'
+import { Trans, useTranslation } from 'react-i18next'
+import { AuthErrorCodes } from '@hedgedoc/commons'
+import { useSingleStringUrlParameter } from '../../../hooks/common/use-single-string-url-parameter'
+
+const validAuthErrorCodes = Object.values(AuthErrorCodes)
+const i18nKeyMap = {
+  [AuthErrorCodes.PROVIDER]: 'errors.oidcLogin.provider',
+  [AuthErrorCodes.INVALID_RESPONSE]: 'errors.oidcLogin.invalidResponse',
+  [AuthErrorCodes.INTERNAL]: 'errors.oidcLogin.internal'
+} as const
+
+/**
+ * Renders an error-themed card for the login page depending on the URL parameter `error`.
+ */
+export const OidcLoginErrorCard: React.FC = () => {
+  useTranslation()
+
+  const errorType = useSingleStringUrlParameter('error', null)
+  const providerError = useSingleStringUrlParameter('providerError', null)
+  const providerDescription = useSingleStringUrlParameter('providerDescription', null)
+
+  if (!errorType || !validAuthErrorCodes.includes(errorType as AuthErrorCodes)) {
+    return null
+  }
+
+  const descriptionI18nKey = i18nKeyMap[errorType as AuthErrorCodes]
+  const providerDetailMessage = errorType === AuthErrorCodes.PROVIDER ? (providerDescription ?? providerError) : null
+
+  return (
+    <Card border='danger' className='bg-danger-subtle'>
+      <Card.Body>
+        <Card.Title className='text-danger'>
+          <Trans i18nKey='errors.oidcLogin.title' />
+        </Card.Title>
+        <p className='mb-0'>
+          <Trans i18nKey={descriptionI18nKey} />
+        </p>
+        {providerDetailMessage !== null && <p className='mb-0 mt-2 text-break small'>{providerDetailMessage}</p>}
+      </Card.Body>
+    </Card>
+  )
+}


### PR DESCRIPTION
### Component/Part
OIDC login

### Description
Previously, OIDC login failures were handled by the backend which just threw an HTTP 500 Internal Server Error as plain JSON. This is not very user-friendly.

Now the backend redirects to the login page back with an additional ?error parameter. The login page renders a new login failure card when this parameter is present and one of the valid error reasons.

Can be tested by opening for example:
http://localhost:8080/login?error=provider&providerDescription=The+user+has+rejected+the+permission+prompt.

### Screenshot
<img width="1263" height="441" alt="image" src="https://github.com/user-attachments/assets/15bd34e7-e2f8-47a1-bee6-9c421eca991f" />


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #5522
