### PR TITLE
fix(oidc): reset oidc session state on callback errors

### DIFF
--- a/backend/src/api/private/auth/oidc/oidc.controller.spec.ts
+++ b/backend/src/api/private/auth/oidc/oidc.controller.spec.ts
@@ -115,4 +115,36 @@ describe('OidcController', () => {
     });
     expectSessionIsCleared();
   });
+
+  it('redirects callback errors when no oidc session data exists yet', async () => {
+    const noOidcRequest = Mock.of<RequestWithSession>({
+      headers: {
+        'sec-fetch-dest': 'document',
+        'sec-fetch-mode': 'navigate',
+      },
+      session: {
+        csrfToken: null,
+        loginAuthProviderIdentifier: null,
+        loginAuthProviderType: null,
+        pendingUser: null,
+        save: saveSession,
+        userId: null,
+      } as unknown as RequestWithSession['session'],
+    });
+    jest
+      .spyOn(oidcService, 'extractUserInfoFromCallback')
+      .mockRejectedValue(new oidcErrors.RPError({ message: 'state mismatch' }));
+
+    await expect(controller.callback('test', noOidcRequest)).resolves.toEqual({
+      url: '/login?error=invalid-response',
+    });
+    expect(noOidcRequest.session.pendingUser).toBeNull();
+    expect(noOidcRequest.session.oidc).toEqual({
+      idToken: null,
+      sid: null,
+      loginCode: null,
+      loginState: null,
+    });
+    expect(saveSession).toHaveBeenCalledTimes(1);
+  });
 });

--- a/backend/src/api/private/auth/oidc/oidc.controller.ts
+++ b/backend/src/api/private/auth/oidc/oidc.controller.ts
@@ -148,8 +148,17 @@ export class OidcController {
         'callback',
       );
       request.session.pendingUser = null;
-      request.session.oidc.loginCode = null;
-      request.session.oidc.loginState = null;
+      // The callback may fail before extractUserInfoFromCallback assigns
+      // session.oidc (e.g. state mismatch on a session that never ran
+      // loginWithOpenIdConnect), so reset the whole object like
+      // AuthController.deletePendingUserData does instead of touching a
+      // possibly-undefined property.
+      request.session.oidc = {
+        idToken: null,
+        sid: null,
+        loginCode: null,
+        loginState: null,
+      };
       await request.session.save();
       return { url: `/login?${errorParams.toString()}` };
     }


### PR DESCRIPTION
### Component/Part
backend (auth/oidc)

### Description
the OIDC callback error handler clears the login state with property assignments: `request.session.oidc.loginCode = null`. when the callback fails before `extractUserInfoFromCallback` assigns `session.oidc`, e.g. a state mismatch on a session that never ran `loginWithOpenIdConnect` (fresh session, expired session, direct callback hit), `session.oidc` is undefined and the assignment throws `TypeError: Cannot set properties of undefined (setting 'loginCode')`, turning the pretty login error redirect into a 500

this resets the whole `oidc` object instead, mirroring `AuthController`'s `deletePendingUserData`, which is safe whether or not the property was set before

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `develop` for 2.x

### Related Issue(s)
none opened, the anchor is commit 1cda22a ("fix(oidc-login): show pretty error messages on the login page", merged 2026-08-27), the crash defeats that feature on this failure path