### PR TITLE
Fix tests running with ESM-only DOMHandler and DOMElementType modules

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -124,7 +124,7 @@
       ]
     },
     "transformIgnorePatterns": [
-      "/node_modules/"
+      "/node_modules/(?!domhandler|domelementtype)/"
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",

--- a/commons/package.json
+++ b/commons/package.json
@@ -7,8 +7,8 @@
   "license": "AGPL-3.0",
   "scripts": {
     "build": "rm -rf dist && tsc --project tsconfig.json",
-    "test": "jest",
-    "test:ci": "jest --ci",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:ci": "NODE_OPTIONS=--experimental-vm-modules jest --ci",
     "prepublish": "yarn lint && yarn build && yarn test",
     "format": "../node_modules/.bin/oxfmt --check src",
     "format:fix": "../node_modules/.bin/oxfmt src",


### PR DESCRIPTION
### Component/Part
test runner configuration

### Description
This change ignores the DOMHandler and DOMElementType packages from the transpiler ignore list, so that they get transpiled again which is necessary for the tests to pass.
Furthermore this enabled the experimental-vm-modules option for the tests which is required in order to load ESM modules in Node.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
none
