### PR TITLE
Fix race condition between guest login and API calls

### DIFF
--- a/frontend/src/components/application-loader/initializers/login-or-register-guest.spec.ts
+++ b/frontend/src/components/application-loader/initializers/login-or-register-guest.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { AuthProviderType } from '@hedgedoc/commons'
+import { clearCsrfToken } from '../../../redux/csrf-token/methods'
+import { store } from '../../../redux'
+import { clearUser } from '../../../redux/user/methods'
+import { loginOrRegisterGuest } from './login-or-register-guest'
+import { Mock } from 'ts-mockery'
+
+const mockResponses = {
+  '/api/private/csrf/token': Mock.of<Response>({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ token: 'csrf-token' })
+  }),
+  '/api/private/auth/guest/register': Mock.of<Response>({
+    status: 201,
+    headers: Mock.of<Headers>({ get: () => 'application/json' }),
+    json: () => Promise.resolve({ uuid: 'guest-xyz' })
+  }),
+  '/api/private/me': Mock.of<Response>({
+    status: 200,
+    headers: Mock.of<Headers>({ get: () => 'application/json' }),
+    json: () =>
+      Promise.resolve({
+        username: null,
+        displayName: 'Guest XYZ',
+        photoUrl: null,
+        authProvider: AuthProviderType.GUEST,
+        email: null
+      })
+  })
+}
+
+describe('loginOrRegisterGuest', () => {
+  const originalFetch = global.fetch
+
+  beforeAll(() => {
+    global.fetch = jest.fn((url: RequestInfo | URL) => {
+      if (typeof url === 'string' && url in mockResponses) {
+        return Promise.resolve(mockResponses[url as keyof typeof mockResponses])
+      }
+      return Promise.reject(new Error('Unexpected request'))
+    }) as typeof global.fetch
+  })
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    clearCsrfToken()
+    clearUser()
+  })
+
+  afterAll(() => {
+    global.fetch = originalFetch
+  })
+
+  it('stores guest users into the application state and localStorage', async () => {
+    await loginOrRegisterGuest()
+
+    expect(window.localStorage.getItem('guestUuid')).toBe('guest-xyz')
+    expect(store.getState().user).toStrictEqual({
+      username: null,
+      displayName: 'Guest XYZ',
+      photoUrl: null,
+      authProvider: AuthProviderType.GUEST,
+      email: null
+    })
+    const fetchCalls = jest.mocked(global.fetch).mock.calls.map(([url]) => url)
+    expect(fetchCalls).toStrictEqual(['/api/private/csrf/token', '/api/private/auth/guest/register', '/api/private/me'])
+  })
+})

--- a/frontend/src/components/application-loader/initializers/login-or-register-guest.ts
+++ b/frontend/src/components/application-loader/initializers/login-or-register-guest.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2026 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -32,6 +32,7 @@ export const loginOrRegisterGuest = async (ignoreSavedUuid?: boolean): Promise<v
     try {
       const { uuid } = await registerGuest()
       window.localStorage.setItem('guestUuid', uuid)
+      await fetchAndSetUser()
     } catch (error: unknown) {
       if (error instanceof RateLimitError) {
         throw error
@@ -40,13 +41,14 @@ export const loginOrRegisterGuest = async (ignoreSavedUuid?: boolean): Promise<v
     }
     return
   }
-  logInGuest(guestUuid)
-    .then(fetchAndSetUser)
-    .catch((error: unknown) => {
-      if (error instanceof RateLimitError) {
-        throw error
-      }
-      logger.error('Error logging in guest user', error)
-      return loginOrRegisterGuest(true)
-    })
+  try {
+    await logInGuest(guestUuid)
+    await fetchAndSetUser()
+  } catch (error: unknown) {
+    if (error instanceof RateLimitError) {
+      throw error
+    }
+    logger.error('Error logging in guest user', error)
+    await loginOrRegisterGuest(true)
+  }
 }


### PR DESCRIPTION
### Component/Part
frontend -> application loader

### Description
When the app starts, it checks for an active session and looks up in the browser's localStorage whether a guestUUID was stored which could be used to initialize a new session as that guest user. However, the session initialization request (`loginOrRegisterGuest`) was not awaited and ran async parallel to other API requests which were failing due to no active session yet.

This PR fixes the problem by explicitly awaiting the guest session initialization in the application loader before performing any other API requests.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x

### Related Issue(s)
fixes #6468 
