### PR TITLE
chore: add minimumReleaseAge to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,7 @@
   "ignorePaths": [
     "docker/docker-compose.yml"
   ],
+  "minimumReleaseAge": "1 day",
   "packageRules": [
     {
       "groupName": "NestJS packages",


### PR DESCRIPTION
### Component/Part
renovate config

### Description

As pnpm enforces us to not use packages before 1 day has passed, renovate should not suggest updates till then.

See: https://docs.renovatebot.com/configuration-options/#minimumreleaseage


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/hedgedoc/blob/develop/CONTRIBUTING.md) and
  made sure that:
  - My commits are signed-off to accept the DCO.
  - This PR targets the correct branch: `master` for 1.x & docs, `develop` for 2.x
