### PR TITLE
Persist the CSRF secret when updating a session

### DIFF
--- a/backend/src/sessions/knex-session-store.spec.ts
+++ b/backend/src/sessions/knex-session-store.spec.ts
@@ -133,6 +133,28 @@ describe('KnexSessionStore', () => {
   });
 
   describe('set', () => {
+    it('keeps the CSRF token when it updates an existing session', (done) => {
+      mockInsert(tracker, TableSession, insertColumns);
+      const session = {
+        cookie: { originalMaxAge: null },
+        csrfToken: 'my-csrf',
+        userId: null,
+        loginAuthProviderType: null,
+        loginAuthProviderIdentifier: null,
+        oidc: { idToken: null, sid: null, loginCode: null, loginState: null },
+        pendingUser: null,
+      } as FastifySession;
+      store.set('session-1', session, (error) => {
+        expect(error).toBeUndefined();
+        const sql = tracker.history.insert[0].sql;
+        expect(sql).toContain('on conflict ("id") do update set');
+        expect(sql).toContain(
+          `"${FieldNameSession.csrfToken}" = excluded."${FieldNameSession.csrfToken}"`,
+        );
+        done();
+      });
+    });
+
     it('inserts a session where all optional fields are null', (done) => {
       mockInsert(tracker, TableSession, insertColumns);
       const session = {

--- a/backend/src/sessions/knex-session-store.ts
+++ b/backend/src/sessions/knex-session-store.ts
@@ -120,6 +120,7 @@ export class KnexSessionStore implements SessionStore {
       .onConflict(FieldNameSession.id)
       .merge([
         FieldNameSession.userId,
+        FieldNameSession.csrfToken,
         FieldNameSession.pendingUserData,
         FieldNameSession.loginAuthProviderType,
         FieldNameSession.loginAuthProviderIdentifier,


### PR DESCRIPTION
Fixes #6831.

`KnexSessionStore.set()` upserts the session with `onConflict(id).merge([...])`, and `csrfToken` was missing from the merge list, so a CSRF secret generated for a session that already existed was never persisted. This adds it, with a unit test.

## Change

- `backend/src/sessions/knex-session-store.ts`: add `FieldNameSession.csrfToken` to the merge list. Every other persisted field was already there, except `id`, which is the conflict key, and `createdAt`, which is excluded on purpose.
- `backend/src/sessions/knex-session-store.spec.ts`: a test asserting that the generated upsert updates `csrf_token` on conflict.

## Verification

All on `develop` at `f199a28`.

**The test fails without the change**, and the generated SQL shows why:

```
on conflict ("id") do update set "user_id" = excluded."user_id", "pending_user_data" = excluded."pending_user_data", … "updated_at" = excluded."updated_at"
```

With the change, the suite passes: 6 of 6.

**Built backend, before and after**, same reproduction as in the issue (sqlite, one OIDC provider configured):

```
                                        without   with
GET    /api/private/auth/oidc/<id>        302     302
GET    /api/private/csrf/token            200     200
DELETE /api/private/auth/pending-user     403     204
```

**Suites:** backend unit tests 45 suites, 578 tests passed (577 before the change, plus the new one); backend e2e on sqlite 15 suites, 405 tests passed, the same as before the change; `oxlint` 0 warnings and 0 errors; `oxfmt --check` clean.
